### PR TITLE
Fix: autoloader in sdp ingestion skill

### DIFF
--- a/databricks-skills/spark-declarative-pipelines/1-ingestion-patterns.md
+++ b/databricks-skills/spark-declarative-pipelines/1-ingestion-patterns.md
@@ -33,12 +33,12 @@ CREATE OR REPLACE STREAMING TABLE bronze_customers AS
 SELECT
   *,
   current_timestamp() AS _ingested_at
-FROM read_files(
+FROM stream(read_files(
   '/mnt/raw/customers/',
   format => 'json',
   schemaHints => 'customer_id STRING, email STRING',
   mode => 'PERMISSIVE'  -- Handles schema changes gracefully
-);
+));
 ```
 
 ### File Formats


### PR DESCRIPTION
Fix an issue in the sdp ingestion skill.

There is a syntax error in the autoloader within the sdp ingestion skill.

You need to add the stream() wrapper to create a streaming table.

Doc: https://docs.databricks.com/aws/en/ingestion/cloud-object-storage/auto-loader/patterns#auto-loader-syntax-for-lakeflow-spark-declarative-pipelines

Error: https://e2-demo-field-eng.cloud.databricks.com/pipelines/376b4f4d-7f89-4153-bf21-3e30b4bba2f4/updates/86bb40b8-b720-4bf1-9e4b-c3ea44c750f5?o=1444828305810485

Fix: https://e2-demo-field-eng.cloud.databricks.com/pipelines/376b4f4d-7f89-4153-bf21-3e30b4bba2f4/updates/142770ac-be94-4d7e-aa6b-07d450dd50dd?o=1444828305810485