### PR TITLE
Find by name tools and Genie space support for MAS

### DIFF
--- a/databricks-skills/agent-bricks/1-knowledge-assistants.md
+++ b/databricks-skills/agent-bricks/1-knowledge-assistants.md
@@ -120,6 +120,47 @@ To update the indexed documents:
 
 5. **Test the KA** in the Databricks UI
 
+## Using KA in Multi-Agent Supervisors
+
+Knowledge Assistants can be used as agents in a Multi-Agent Supervisor (MAS). Each KA has an associated model serving endpoint.
+
+### Finding the Endpoint Name
+
+Use `get_ka` to retrieve the KA details. The response includes:
+- `tile_id`: The unique identifier for the KA
+- `name`: The KA name (sanitized)
+- `endpoint_status`: Current status (ONLINE, PROVISIONING, etc.)
+
+The endpoint name follows this pattern: `ka-{tile_id}-endpoint`
+
+### Finding a KA by Name
+
+If you know the KA name but not the tile_id, use `find_ka_by_name`:
+
+```python
+find_ka_by_name(name="HR_Policy_Assistant")
+# Returns: {"found": True, "tile_id": "01abc...", "name": "HR_Policy_Assistant", "endpoint_name": "ka-01abc...-endpoint"}
+```
+
+### Example: Adding KA to MAS
+
+```python
+# First, find the KA
+ka_result = find_ka_by_name(name="HR_Policy_Assistant")
+
+# Then use it in a MAS
+create_or_update_mas(
+    name="Support MAS",
+    agents=[
+        {
+            "name": "hr_agent",
+            "endpoint_name": ka_result["endpoint_name"],
+            "description": "Answers HR policy questions from the employee handbook"
+        }
+    ]
+)
+```
+
 ## Troubleshooting
 
 ### Endpoint stays in PROVISIONING

--- a/databricks-skills/agent-bricks/2-genie-spaces.md
+++ b/databricks-skills/agent-bricks/2-genie-spaces.md
@@ -201,6 +201,17 @@ Write sample questions that:
 
 5. **Test** in the Databricks UI
 
+## Finding Existing Genie Spaces
+
+To find an existing Genie space by name, use `find_genie_by_name`:
+
+```python
+find_genie_by_name(display_name="Sales Analytics")
+# Returns: {"found": True, "space_id": "abc123...", "display_name": "Sales Analytics", ...}
+```
+
+**IMPORTANT**: There is NO system table for Genie spaces. Do NOT try to query `system.ai.genie_spaces` or similar tables - they don't exist. Always use the `find_genie_by_name` tool to look up existing spaces.
+
 ## Updating a Genie Space
 
 To update an existing space:

--- a/databricks-skills/agent-bricks/3-multi-agent-supervisors.md
+++ b/databricks-skills/agent-bricks/3-multi-agent-supervisors.md
@@ -21,15 +21,20 @@ Use a Multi-Agent Supervisor when:
 
 ## Prerequisites
 
-Before creating a MAS, you need:
+Before creating a MAS, you need agents of one or both types:
 
-**Model Serving Endpoints**: Each agent must be deployed as a model serving endpoint in Databricks.
-
-These could be:
+**Model Serving Endpoints** (`endpoint_name`):
+- Knowledge Assistant (KA) endpoints (e.g., `ka-abc123-endpoint`)
 - Custom agents built with LangChain, LlamaIndex, etc.
 - Fine-tuned models
 - RAG applications
-- External API integrations
+
+**Genie Spaces** (`genie_space_id`):
+- Existing Genie spaces for SQL-based data exploration
+- Great for analytics, metrics, and data-driven questions
+- No separate endpoint deployment required - reference the space directly
+- To find a Genie space by name, use `find_genie_by_name(display_name="My Genie")`
+- **Note**: There is NO system table for Genie spaces - do not try to query `system.ai.genie_spaces`
 
 ## Creating a Multi-Agent Supervisor
 
@@ -40,24 +45,26 @@ Use the `create_or_update_mas` tool:
   ```json
   [
     {
-      "name": "billing_agent",
-      "endpoint_name": "billing-assistant-endpoint",
-      "description": "Handles billing, payments, invoices, and subscription questions"
+      "name": "policy_agent",
+      "ka_tile_id": "f32c5f73-466b-4798-b3a0-5396b5ece2a5",
+      "description": "Answers questions about company policies and procedures from indexed documents"
     },
     {
-      "name": "technical_agent",
-      "endpoint_name": "tech-support-endpoint",
-      "description": "Handles technical issues, bugs, and product features"
+      "name": "usage_analytics",
+      "genie_space_id": "01abc123-def4-5678-90ab-cdef12345678",
+      "description": "Answers data questions about usage metrics, trends, and statistics"
     },
     {
-      "name": "hr_agent",
-      "endpoint_name": "hr-assistant-endpoint",
-      "description": "Handles HR policies, benefits, and employee questions"
+      "name": "custom_agent",
+      "endpoint_name": "my-custom-endpoint",
+      "description": "Handles specialized queries via custom model endpoint"
     }
   ]
   ```
 - `description`: "Routes customer queries to specialized support agents"
 - `instructions`: "Analyze the user's question and route to the most appropriate agent. If unclear, ask for clarification."
+
+This example shows mixing Knowledge Assistants (policy_agent), Genie spaces (usage_analytics), and custom endpoints (custom_agent).
 
 ## Agent Configuration
 
@@ -66,8 +73,15 @@ Each agent in the `agents` list needs:
 | Field | Required | Description |
 |-------|----------|-------------|
 | `name` | Yes | Internal identifier for the agent |
-| `endpoint_name` | Yes | Model serving endpoint name |
-| `description` | Yes | What this agent handles (used for routing) |
+| `description` | Yes | What this agent handles (critical for routing) |
+| `ka_tile_id` | One of these | Knowledge Assistant tile ID (for document Q&A agents) |
+| `genie_space_id` | One of these | Genie space ID (for SQL-based data agents) |
+| `endpoint_name` | One of these | Model serving endpoint name (for custom agents) |
+
+**Note**: Provide exactly one of: `ka_tile_id`, `genie_space_id`, or `endpoint_name`.
+
+To find a KA tile_id, use `find_ka_by_name(name="Your KA Name")`.
+To find a Genie space_id, use `find_genie_by_name(display_name="Your Genie Name")`.
 
 ### Writing Good Descriptions
 

--- a/databricks-skills/agent-bricks/SKILL.md
+++ b/databricks-skills/agent-bricks/SKILL.md
@@ -31,8 +31,9 @@ Before creating Agent Bricks, ensure you have the required data:
 - Create tables using the `spark-declarative-pipelines` skill
 
 ### For Multi-Agent Supervisors
-- **Model Serving Endpoints**: Deployed agent endpoints to orchestrate
-- These could be custom agents, fine-tuned models, or other deployed services
+- **Model Serving Endpoints**: Deployed agent endpoints (KA endpoints, custom agents, fine-tuned models)
+- **Genie Spaces**: Existing Genie spaces can be used directly as agents for SQL-based queries
+- Mix and match endpoint-based and Genie-based agents in the same MAS
 
 ## MCP Tools
 
@@ -48,6 +49,11 @@ Before creating Agent Bricks, ensure you have the required data:
 
 **get_ka** - Get Knowledge Assistant details
 - `tile_id`: The KA tile ID
+
+**find_ka_by_name** - Find a Knowledge Assistant by name
+- `name`: The exact name of the KA to find
+- Returns: `tile_id`, `name`, `endpoint_name`, `endpoint_status`
+- Use this to look up an existing KA when you know the name but not the tile_id
 
 **delete_ka** - Delete a Knowledge Assistant
 - `tile_id`: The KA tile ID to delete
@@ -82,25 +88,41 @@ Before creating Agent Bricks, ensure you have the required data:
 
 - `space_id`: The Genie space ID
 
+**find_genie_by_name** - Find a Genie Space by display name
+
+- `display_name`: The exact display name of the Genie space
+- Returns: `space_id`, `display_name`, `description`, `warehouse_id`
+- Use this to look up an existing Genie space when you know the name but not the ID
+
 **delete_genie** - Delete a Genie Space
 
 - `space_id`: The Genie space ID to delete
+
+**IMPORTANT**: There is NO system table for Genie spaces (e.g., `system.ai.genie_spaces` does not exist). To find a Genie space by name, use the `find_genie_by_name` tool.
 
 ### Multi-Agent Supervisor Tools
 
 **create_or_update_mas** - Create or update a Multi-Agent Supervisor
 - `name`: Name for the MAS
-- `agents`: List of agent configurations:
-  - `name`: Agent name
-  - `endpoint_name`: Model serving endpoint name
-  - `description`: What this agent handles (used for routing)
+- `agents`: List of agent configurations, each with:
+  - `name`: Agent identifier (required)
+  - `description`: What this agent handles - critical for routing (required)
+  - `ka_tile_id`: Knowledge Assistant tile ID (use for document Q&A agents - recommended for KAs)
+  - `genie_space_id`: Genie space ID (use for SQL-based data agents)
+  - `endpoint_name`: Model serving endpoint name (use for custom agents)
+  - Note: Provide exactly one of: `ka_tile_id`, `genie_space_id`, or `endpoint_name`
 - `description`: (optional) What the MAS does
-- `instructions`: (optional) Routing instructions
+- `instructions`: (optional) Routing instructions for the supervisor
 - `tile_id`: (optional) Existing tile_id to update
 - `examples`: (optional) List of example questions with `question` and `guideline` fields
 
 **get_mas** - Get Multi-Agent Supervisor details
 - `tile_id`: The MAS tile ID
+
+**find_mas_by_name** - Find a Multi-Agent Supervisor by name
+- `name`: The exact name of the MAS to find
+- Returns: `tile_id`, `name`, `endpoint_status`, `agents_count`
+- Use this to look up an existing MAS when you know the name but not the tile_id
 
 **delete_mas** - Delete a Multi-Agent Supervisor
 - `tile_id`: The MAS tile ID to delete

--- a/databricks-tools-core/databricks_tools_core/agent_bricks/manager.py
+++ b/databricks-tools-core/databricks_tools_core/agent_bricks/manager.py
@@ -265,7 +265,7 @@ class AgentBricksManager:
             if page_token:
                 params["page_token"] = page_token
             resp = self._get("/api/2.0/data-rooms", params=params)
-            for space in resp.get("spaces", []):
+            for space in resp.get("data_rooms", []):
                 if space.get("display_name") == display_name:
                     return GenieIds(space_id=space["space_id"], display_name=display_name)
             page_token = resp.get("next_page_token")


### PR DESCRIPTION
## Summary

- Add `find_ka_by_name`, `find_genie_by_name`, and `find_mas_by_name` MCP tools for looking up Agent Bricks by name instead of ID
- Extend `create_or_update_mas` to support Genie spaces and Knowledge Assistants as agent types alongside custom endpoints
- Fix `genie_find_by_name` API response key (`data_rooms` instead of `spaces`)

## Changes

### New MCP Tools
- **find_ka_by_name**: Look up a Knowledge Assistant by name, returns tile_id and endpoint_name
- **find_genie_by_name**: Look up a Genie Space by display name, returns space_id and details
- **find_mas_by_name**: Look up a Multi-Agent Supervisor by name, returns tile_id and status

### Enhanced MAS Agent Configuration
Multi-Agent Supervisors now support three agent types:
- `ka_tile_id` - Reference Knowledge Assistants directly (auto-derives endpoint name)
- `genie_space_id` - Reference Genie Spaces for SQL-based data agents
- `endpoint_name` - Custom model serving endpoints (existing behavior)

Includes validation to ensure exactly one agent type is specified per agent.

### Bug Fix
- Fixed `genie_find_by_name` to use correct API response key `data_rooms`

### Documentation
- Updated skill documentation with new tools and agent type options
- Added warnings about non-existent Genie system tables