### PR TITLE
Add UC Volume file operations

### DIFF
--- a/databricks-mcp-server/databricks_mcp_server/server.py
+++ b/databricks-mcp-server/databricks_mcp_server/server.py
@@ -10,4 +10,4 @@ from fastmcp import FastMCP
 mcp = FastMCP("Databricks MCP Server")
 
 # Import and register all tools
-from .tools import sql, compute, file, pipelines, jobs, agent_bricks, aibi_dashboards, serving
+from .tools import sql, compute, file, pipelines, jobs, agent_bricks, aibi_dashboards, serving, volume_files

--- a/databricks-mcp-server/databricks_mcp_server/tools/volume_files.py
+++ b/databricks-mcp-server/databricks_mcp_server/tools/volume_files.py
@@ -1,0 +1,182 @@
+"""Volume file tools - Manage files in Unity Catalog Volumes."""
+from typing import Dict, Any, List
+
+from databricks_tools_core.file import (
+    list_volume_files as _list_volume_files,
+    upload_to_volume as _upload_to_volume,
+    download_from_volume as _download_from_volume,
+    delete_volume_file as _delete_volume_file,
+    delete_volume_directory as _delete_volume_directory,
+    create_volume_directory as _create_volume_directory,
+    get_volume_file_metadata as _get_volume_file_metadata,
+)
+
+from ..server import mcp
+
+
+@mcp.tool
+def list_volume_files(volume_path: str) -> List[Dict[str, Any]]:
+    """
+    List files and directories in a Unity Catalog volume path.
+
+    Args:
+        volume_path: Path in volume (e.g., "/Volumes/catalog/schema/volume/folder")
+
+    Returns:
+        List of file/directory info with name, path, is_directory, file_size, last_modified
+    """
+    results = _list_volume_files(volume_path)
+    return [
+        {
+            "name": r.name,
+            "path": r.path,
+            "is_directory": r.is_directory,
+            "file_size": r.file_size,
+            "last_modified": r.last_modified,
+        }
+        for r in results
+    ]
+
+
+@mcp.tool
+def upload_to_volume(
+    local_path: str,
+    volume_path: str,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """
+    Upload a local file to a Unity Catalog volume.
+
+    Args:
+        local_path: Path to local file to upload
+        volume_path: Target path in volume (e.g., "/Volumes/catalog/schema/volume/data.csv")
+        overwrite: Whether to overwrite existing file (default: True)
+
+    Returns:
+        Dictionary with local_path, volume_path, success, and error (if failed)
+    """
+    result = _upload_to_volume(
+        local_path=local_path,
+        volume_path=volume_path,
+        overwrite=overwrite,
+    )
+    return {
+        "local_path": result.local_path,
+        "volume_path": result.volume_path,
+        "success": result.success,
+        "error": result.error,
+    }
+
+
+@mcp.tool
+def download_from_volume(
+    volume_path: str,
+    local_path: str,
+    overwrite: bool = True,
+) -> Dict[str, Any]:
+    """
+    Download a file from a Unity Catalog volume to local path.
+
+    Args:
+        volume_path: Path in volume (e.g., "/Volumes/catalog/schema/volume/data.csv")
+        local_path: Target local file path
+        overwrite: Whether to overwrite existing local file (default: True)
+
+    Returns:
+        Dictionary with volume_path, local_path, success, and error (if failed)
+    """
+    result = _download_from_volume(
+        volume_path=volume_path,
+        local_path=local_path,
+        overwrite=overwrite,
+    )
+    return {
+        "volume_path": result.volume_path,
+        "local_path": result.local_path,
+        "success": result.success,
+        "error": result.error,
+    }
+
+
+@mcp.tool
+def delete_volume_file(volume_path: str) -> Dict[str, Any]:
+    """
+    Delete a file from a Unity Catalog volume.
+
+    Args:
+        volume_path: Path to file in volume (e.g., "/Volumes/catalog/schema/volume/file.csv")
+
+    Returns:
+        Dictionary with volume_path and success status
+    """
+    try:
+        _delete_volume_file(volume_path)
+        return {"volume_path": volume_path, "success": True}
+    except Exception as e:
+        return {"volume_path": volume_path, "success": False, "error": str(e)}
+
+
+@mcp.tool
+def delete_volume_directory(volume_path: str) -> Dict[str, Any]:
+    """
+    Delete an empty directory from a Unity Catalog volume.
+
+    Note: Directory must be empty. Delete all contents first.
+
+    Args:
+        volume_path: Path to directory in volume
+
+    Returns:
+        Dictionary with volume_path and success status
+    """
+    try:
+        _delete_volume_directory(volume_path)
+        return {"volume_path": volume_path, "success": True}
+    except Exception as e:
+        return {"volume_path": volume_path, "success": False, "error": str(e)}
+
+
+@mcp.tool
+def create_volume_directory(volume_path: str) -> Dict[str, Any]:
+    """
+    Create a directory in a Unity Catalog volume.
+
+    Creates parent directories as needed (like mkdir -p).
+    Idempotent - succeeds if directory already exists.
+
+    Args:
+        volume_path: Path for new directory (e.g., "/Volumes/catalog/schema/volume/new_folder")
+
+    Returns:
+        Dictionary with volume_path and success status
+    """
+    try:
+        _create_volume_directory(volume_path)
+        return {"volume_path": volume_path, "success": True}
+    except Exception as e:
+        return {"volume_path": volume_path, "success": False, "error": str(e)}
+
+
+@mcp.tool
+def get_volume_file_info(volume_path: str) -> Dict[str, Any]:
+    """
+    Get metadata for a file in a Unity Catalog volume.
+
+    Args:
+        volume_path: Path to file in volume
+
+    Returns:
+        Dictionary with name, path, is_directory, file_size, last_modified
+    """
+    try:
+        info = _get_volume_file_metadata(volume_path)
+        return {
+            "name": info.name,
+            "path": info.path,
+            "is_directory": info.is_directory,
+            "file_size": info.file_size,
+            "last_modified": info.last_modified,
+            "success": True,
+        }
+    except Exception as e:
+        return {"volume_path": volume_path, "success": False, "error": str(e)}

--- a/databricks-skills/databricks-unity-catalog/6-volumes.md
+++ b/databricks-skills/databricks-unity-catalog/6-volumes.md
@@ -1,0 +1,465 @@
+# Unity Catalog Volumes
+
+Comprehensive reference for working with Unity Catalog Volumes: file operations, permissions, and best practices.
+
+## Overview
+
+Volumes are a Unity Catalog capability for accessing, storing, and governing files. Unlike tables (structured data), volumes store unstructured or semi-structured files.
+
+| Volume Type | Description | Storage |
+|-------------|-------------|---------|
+| **Managed** | Databricks manages the storage location | Default metastore location |
+| **External** | You manage the storage location | Your cloud storage (S3, ADLS, GCS) |
+
+**Common Use Cases:**
+- ML training data (images, audio, video, PDFs)
+- Data exploration and staging
+- Library files (.whl, .jar)
+- Config files and scripts
+- ETL landing zones
+
+---
+
+## Volume Path Format
+
+All volume operations use the path format:
+
+```
+/Volumes/<catalog>/<schema>/<volume>/<path_to_file>
+```
+
+**Examples:**
+```
+/Volumes/main/default/my_volume/data.csv
+/Volumes/analytics/raw/landing_zone/2024/01/orders.parquet
+/Volumes/ml/training/images/cats/cat_001.jpg
+```
+
+---
+
+## MCP Tools
+
+### List Files in Volume
+
+```python
+# List files and directories
+list_volume_files(
+    volume_path="/Volumes/main/default/my_volume/data/"
+)
+# Returns: [{"name": "file.csv", "path": "...", "is_directory": false, "file_size": 1024, "last_modified": "..."}]
+```
+
+### Upload File to Volume
+
+```python
+# Upload a local file
+upload_to_volume(
+    local_path="/tmp/data.csv",
+    volume_path="/Volumes/main/default/my_volume/data.csv",
+    overwrite=True
+)
+# Returns: {"local_path": "...", "volume_path": "...", "success": true}
+```
+
+### Download File from Volume
+
+```python
+# Download to local path
+download_from_volume(
+    volume_path="/Volumes/main/default/my_volume/data.csv",
+    local_path="/tmp/downloaded.csv",
+    overwrite=True
+)
+# Returns: {"volume_path": "...", "local_path": "...", "success": true}
+```
+
+### Create Directory
+
+```python
+# Create directory (creates parents like mkdir -p)
+create_volume_directory(
+    volume_path="/Volumes/main/default/my_volume/data/2024/01"
+)
+# Returns: {"volume_path": "...", "success": true}
+```
+
+### Delete File
+
+```python
+# Delete a file
+delete_volume_file(
+    volume_path="/Volumes/main/default/my_volume/old_data.csv"
+)
+# Returns: {"volume_path": "...", "success": true}
+```
+
+### Get File Info
+
+```python
+# Get file metadata
+get_volume_file_info(
+    volume_path="/Volumes/main/default/my_volume/data.csv"
+)
+# Returns: {"name": "data.csv", "file_size": 1024, "last_modified": "...", "success": true}
+```
+
+---
+
+## Python SDK Examples
+
+### Volume CRUD Operations
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.catalog import VolumeType
+
+w = WorkspaceClient()
+
+# List volumes in a schema
+for volume in w.volumes.list(catalog_name="main", schema_name="default"):
+    print(f"{volume.full_name}: {volume.volume_type}")
+
+# Get volume details
+volume = w.volumes.read(name="main.default.my_volume")
+print(f"Storage: {volume.storage_location}")
+
+# Create managed volume
+managed = w.volumes.create(
+    catalog_name="main",
+    schema_name="default",
+    name="my_managed_volume",
+    volume_type=VolumeType.MANAGED,
+    comment="Managed volume for ML data"
+)
+
+# Create external volume
+external = w.volumes.create(
+    catalog_name="main",
+    schema_name="default",
+    name="my_external_volume",
+    volume_type=VolumeType.EXTERNAL,
+    storage_location="s3://my-bucket/volumes/data",
+    comment="External volume on S3"
+)
+
+# Update volume
+w.volumes.update(
+    name="main.default.my_volume",
+    comment="Updated description"
+)
+
+# Delete volume
+w.volumes.delete(name="main.default.my_volume")
+```
+
+### File Operations
+
+```python
+from databricks.sdk import WorkspaceClient
+import io
+
+w = WorkspaceClient()
+
+# Upload file from memory
+data = b"col1,col2\n1,2\n3,4"
+w.files.upload(
+    file_path="/Volumes/main/default/my_volume/data.csv",
+    contents=io.BytesIO(data),
+    overwrite=True
+)
+
+# Upload file from disk (recommended for large files)
+w.files.upload_from(
+    file_path="/Volumes/main/default/my_volume/large_file.parquet",
+    source_path="/local/path/large_file.parquet",
+    overwrite=True,
+    use_parallel=True  # Parallel upload for large files
+)
+
+# List directory contents
+for entry in w.files.list_directory_contents("/Volumes/main/default/my_volume/"):
+    file_type = "dir" if entry.is_directory else "file"
+    print(f"{entry.name}: {file_type} ({entry.file_size} bytes)")
+
+# Download file to memory
+response = w.files.download("/Volumes/main/default/my_volume/data.csv")
+content = response.contents.read()
+
+# Download file to disk (recommended for large files)
+w.files.download_to(
+    file_path="/Volumes/main/default/my_volume/large_file.parquet",
+    destination="/local/path/downloaded.parquet",
+    use_parallel=True  # Parallel download for large files
+)
+
+# Create directory
+w.files.create_directory("/Volumes/main/default/my_volume/new_folder/")
+
+# Delete file
+w.files.delete("/Volumes/main/default/my_volume/old_data.csv")
+
+# Delete empty directory
+w.files.delete_directory("/Volumes/main/default/my_volume/empty_folder/")
+
+# Get file metadata
+metadata = w.files.get_metadata("/Volumes/main/default/my_volume/data.csv")
+print(f"Size: {metadata.content_length}, Modified: {metadata.last_modified}")
+```
+
+---
+
+## SQL Operations
+
+### Query Volume Metadata
+
+```sql
+-- List all volumes in a catalog
+SELECT
+    volume_catalog,
+    volume_schema,
+    volume_name,
+    volume_type,
+    storage_location,
+    comment,
+    created,
+    created_by
+FROM system.information_schema.volumes
+WHERE volume_catalog = 'analytics'
+ORDER BY volume_schema, volume_name;
+
+-- Find volumes by type
+SELECT volume_name, storage_location
+FROM system.information_schema.volumes
+WHERE volume_type = 'EXTERNAL';
+```
+
+### Read Files from Volumes
+
+```sql
+-- Read CSV file
+SELECT * FROM read_files('/Volumes/main/default/my_volume/data.csv');
+
+-- Read with options
+SELECT * FROM read_files(
+    '/Volumes/main/default/my_volume/data/',
+    format => 'csv',
+    header => true,
+    inferSchema => true
+);
+
+-- Read Parquet files
+SELECT * FROM read_files(
+    '/Volumes/main/default/my_volume/parquet_data/',
+    format => 'parquet'
+);
+
+-- Read JSON files
+SELECT * FROM read_files(
+    '/Volumes/main/default/my_volume/events/*.json',
+    format => 'json'
+);
+
+-- Create table from volume files
+CREATE TABLE analytics.bronze.raw_orders AS
+SELECT * FROM read_files('/Volumes/analytics/raw/landing/orders/');
+```
+
+### Write Files to Volumes
+
+```sql
+-- Copy data to volume as Parquet
+COPY INTO '/Volumes/main/default/my_volume/export/'
+FROM (SELECT * FROM analytics.gold.customers)
+FILEFORMAT = PARQUET;
+
+-- Export as CSV
+COPY INTO '/Volumes/main/default/my_volume/export/'
+FROM (SELECT * FROM analytics.gold.report)
+FILEFORMAT = CSV
+HEADER = true;
+```
+
+---
+
+## Permissions
+
+### Required Permissions
+
+| Operation | Required Privilege |
+|-----------|-------------------|
+| List files | `READ VOLUME` |
+| Read files | `READ VOLUME` |
+| Write files | `WRITE VOLUME` |
+| Create volume | `CREATE VOLUME` on schema |
+| Delete volume | Owner or `MANAGE` |
+
+**Note:** Also requires `USE CATALOG` on parent catalog and `USE SCHEMA` on parent schema.
+
+### Grant Permissions
+
+```sql
+-- Grant read access to a volume
+GRANT READ VOLUME ON VOLUME main.default.my_volume TO `data_readers`;
+
+-- Grant write access
+GRANT WRITE VOLUME ON VOLUME main.default.my_volume TO `data_writers`;
+
+-- Grant ability to create volumes in a schema
+GRANT CREATE VOLUME ON SCHEMA main.default TO `data_engineers`;
+
+-- Revoke access
+REVOKE WRITE VOLUME ON VOLUME main.default.my_volume FROM `data_writers`;
+```
+
+### Python SDK Permissions
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.catalog import SecurableType, PermissionsChange, Privilege
+
+w = WorkspaceClient()
+
+# Grant permissions
+w.grants.update(
+    securable_type=SecurableType.VOLUME,
+    full_name="main.default.my_volume",
+    changes=[
+        PermissionsChange(
+            add=[Privilege.READ_VOLUME],
+            principal="data_readers"
+        )
+    ]
+)
+
+# Get current permissions
+grants = w.grants.get(
+    securable_type=SecurableType.VOLUME,
+    full_name="main.default.my_volume"
+)
+for grant in grants.privilege_assignments:
+    print(f"{grant.principal}: {grant.privileges}")
+```
+
+---
+
+## Best Practices
+
+### Organization
+
+1. **Use meaningful paths** - Organize by date, source, or type
+   ```
+   /Volumes/catalog/schema/volume/year=2024/month=01/file.parquet
+   /Volumes/catalog/schema/volume/source=salesforce/accounts.csv
+   ```
+
+2. **Separate raw and processed** - Use different volumes for landing vs. curated
+   ```
+   /Volumes/analytics/raw/landing_zone/    # Raw uploads
+   /Volumes/analytics/curated/processed/   # Cleaned data
+   ```
+
+3. **Archive old data** - Move infrequently accessed files to archive volumes
+
+### Performance
+
+1. **Use parallel uploads** for large files (SDK v0.72.0+)
+   ```python
+   w.files.upload_from(..., use_parallel=True)
+   ```
+
+2. **Batch small files** - Combine many small files into larger archives
+
+3. **Use Parquet** for analytics - Columnar format is more efficient
+
+4. **Partition by date** - Enables efficient pruning in queries
+
+### Security
+
+1. **Use managed volumes** when Databricks should control storage
+
+2. **Use external volumes** when you need:
+   - Existing data in cloud storage
+   - Cross-workspace access
+   - Custom retention policies
+
+3. **Apply least privilege** - Grant only required permissions
+
+4. **Audit access** - Monitor volume access in audit logs
+   ```sql
+   SELECT *
+   FROM system.access.audit
+   WHERE action_name LIKE '%Volume%'
+     AND event_date >= current_date() - 7;
+   ```
+
+---
+
+## Troubleshooting
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `PERMISSION_DENIED` | Missing volume permissions | Grant `READ VOLUME` or `WRITE VOLUME` |
+| `NOT_FOUND` | Volume or path doesn't exist | Check path spelling, ensure volume exists |
+| `ALREADY_EXISTS` | File exists, overwrite=False | Set `overwrite=True` or delete first |
+| `RESOURCE_DOES_NOT_EXIST` | Parent directory doesn't exist | Create parent directories first |
+| `INVALID_PARAMETER_VALUE` | Invalid path format | Use `/Volumes/catalog/schema/volume/path` format |
+
+### Debug Checklist
+
+1. **Verify volume exists:**
+   ```sql
+   SELECT * FROM system.information_schema.volumes
+   WHERE volume_name = 'my_volume';
+   ```
+
+2. **Check permissions:**
+   ```python
+   grants = w.grants.get(
+       securable_type=SecurableType.VOLUME,
+       full_name="catalog.schema.volume"
+   )
+   ```
+
+3. **Verify path format:**
+   - Must start with `/Volumes/`
+   - Three-level namespace: `catalog/schema/volume`
+   - No double slashes (`//`)
+
+4. **Check file exists:**
+   ```python
+   try:
+       w.files.get_metadata("/Volumes/catalog/schema/volume/file.csv")
+   except Exception as e:
+       print(f"File not found: {e}")
+   ```
+
+### External Volume Issues
+
+1. **Storage credential required** - External volumes need a storage credential
+   ```python
+   # Create storage credential first
+   w.storage_credentials.create(
+       name="my_s3_cred",
+       aws_iam_role={"role_arn": "arn:aws:iam::..."}
+   )
+   
+   # Create external location
+   w.external_locations.create(
+       name="my_s3_location",
+       url="s3://my-bucket/path",
+       credential_name="my_s3_cred"
+   )
+   
+   # Then create external volume
+   w.volumes.create(
+       ...
+       volume_type=VolumeType.EXTERNAL,
+       storage_location="s3://my-bucket/path/volume"
+   )
+   ```
+
+2. **Network access** - Ensure workspace can reach cloud storage
+
+3. **IAM permissions** - Verify IAM role has bucket access

--- a/databricks-skills/databricks-unity-catalog/SKILL.md
+++ b/databricks-skills/databricks-unity-catalog/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: databricks-unity-catalog
-description: "Unity Catalog system tables for lineage, audit logs, billing, compute, jobs, and query history. Use when querying system.access.audit, system.access.table_lineage, system.billing.usage, system.compute.clusters, system.lakeflow.jobs, system.lakeflow.job_run_timeline, or system.query.history."
+description: "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/)."
 ---
 
-# Unity Catalog System Tables
+# Unity Catalog
 
-Guidance for querying Unity Catalog system tables for observability, lineage, and auditing.
+Guidance for Unity Catalog system tables, volumes, and governance.
 
 ## When to Use This Skill
 
 Use this skill when:
+- Working with **volumes** (upload, download, list files in `/Volumes/`)
 - Querying **lineage** (table dependencies, column-level lineage)
 - Analyzing **audit logs** (who accessed what, permission changes)
 - Monitoring **billing and usage** (DBU consumption, cost analysis)
@@ -22,8 +23,31 @@ Use this skill when:
 | Topic | File | Description |
 |-------|------|-------------|
 | System Tables | [5-system-tables.md](5-system-tables.md) | Lineage, audit, billing, compute, jobs, query history |
+| Volumes | [6-volumes.md](6-volumes.md) | Volume file operations, permissions, best practices |
 
 ## Quick Start
+
+### Volume File Operations (MCP Tools)
+
+```python
+# List files in a volume
+list_volume_files(volume_path="/Volumes/catalog/schema/volume/folder/")
+
+# Upload file to volume
+upload_to_volume(
+    local_path="/tmp/data.csv",
+    volume_path="/Volumes/catalog/schema/volume/data.csv"
+)
+
+# Download file from volume
+download_from_volume(
+    volume_path="/Volumes/catalog/schema/volume/data.csv",
+    local_path="/tmp/downloaded.csv"
+)
+
+# Create directory
+create_volume_directory(volume_path="/Volumes/catalog/schema/volume/new_folder")
+```
 
 ### Enable System Tables Access
 

--- a/databricks-tools-core/databricks_tools_core/file/__init__.py
+++ b/databricks-tools-core/databricks_tools_core/file/__init__.py
@@ -1,7 +1,7 @@
 """
-File - Workspace File Operations
+File - Workspace and Volume File Operations
 
-Functions for uploading files and folders to Databricks Workspace.
+Functions for uploading files and folders to Databricks Workspace and Unity Catalog Volumes.
 """
 
 from .workspace import (
@@ -11,9 +11,34 @@ from .workspace import (
     upload_file,
 )
 
+from .volume_files import (
+    VolumeFileInfo,
+    VolumeUploadResult,
+    VolumeDownloadResult,
+    list_volume_files,
+    upload_to_volume,
+    download_from_volume,
+    delete_volume_file,
+    delete_volume_directory,
+    create_volume_directory,
+    get_volume_file_metadata,
+)
+
 __all__ = [
+    # Workspace file operations
     "UploadResult",
     "FolderUploadResult",
     "upload_folder",
     "upload_file",
+    # Volume file operations
+    "VolumeFileInfo",
+    "VolumeUploadResult",
+    "VolumeDownloadResult",
+    "list_volume_files",
+    "upload_to_volume",
+    "download_from_volume",
+    "delete_volume_file",
+    "delete_volume_directory",
+    "create_volume_directory",
+    "get_volume_file_metadata",
 ]

--- a/databricks-tools-core/databricks_tools_core/file/volume_files.py
+++ b/databricks-tools-core/databricks_tools_core/file/volume_files.py
@@ -1,0 +1,291 @@
+"""
+Volume Files - Unity Catalog Volume File Operations
+
+Functions for working with files in Unity Catalog Volumes.
+Uses Databricks Files API via SDK (w.files).
+
+Volume paths use the format: /Volumes/<catalog>/<schema>/<volume>/<path>
+"""
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from databricks.sdk.service.files import DirectoryEntry
+
+from ..auth import get_workspace_client
+
+
+@dataclass
+class VolumeFileInfo:
+    """Information about a file or directory in a volume."""
+    name: str
+    path: str
+    is_directory: bool
+    file_size: Optional[int] = None
+    last_modified: Optional[str] = None
+
+
+@dataclass
+class VolumeUploadResult:
+    """Result from uploading a file to a volume."""
+    local_path: str
+    volume_path: str
+    success: bool
+    error: Optional[str] = None
+
+
+@dataclass
+class VolumeDownloadResult:
+    """Result from downloading a file from a volume."""
+    volume_path: str
+    local_path: str
+    success: bool
+    error: Optional[str] = None
+
+
+def list_volume_files(volume_path: str) -> List[VolumeFileInfo]:
+    """
+    List files and directories in a volume path.
+
+    Args:
+        volume_path: Path in volume (e.g., "/Volumes/catalog/schema/volume/folder")
+
+    Returns:
+        List of VolumeFileInfo objects
+
+    Raises:
+        Exception: If path doesn't exist or access denied
+
+    Example:
+        >>> files = list_volume_files("/Volumes/main/default/my_volume/data")
+        >>> for f in files:
+        ...     print(f"{f.name}: {'dir' if f.is_directory else 'file'}")
+    """
+    w = get_workspace_client()
+
+    # Ensure path ends with / for directory listing
+    if not volume_path.endswith('/'):
+        volume_path = volume_path + '/'
+
+    results = []
+    for entry in w.files.list_directory_contents(volume_path):
+        results.append(VolumeFileInfo(
+            name=entry.name,
+            path=entry.path,
+            is_directory=entry.is_directory,
+            file_size=entry.file_size,
+            last_modified=entry.last_modified.isoformat() if entry.last_modified else None
+        ))
+
+    return results
+
+
+def upload_to_volume(
+    local_path: str,
+    volume_path: str,
+    overwrite: bool = True
+) -> VolumeUploadResult:
+    """
+    Upload a local file to a Unity Catalog volume.
+
+    Args:
+        local_path: Path to local file
+        volume_path: Target path in volume (e.g., "/Volumes/catalog/schema/volume/file.csv")
+        overwrite: Whether to overwrite existing file (default: True)
+
+    Returns:
+        VolumeUploadResult with success status
+
+    Example:
+        >>> result = upload_to_volume(
+        ...     local_path="/tmp/data.csv",
+        ...     volume_path="/Volumes/main/default/my_volume/data.csv"
+        ... )
+        >>> if result.success:
+        ...     print("Upload complete")
+    """
+    if not os.path.exists(local_path):
+        return VolumeUploadResult(
+            local_path=local_path,
+            volume_path=volume_path,
+            success=False,
+            error=f"Local file not found: {local_path}"
+        )
+
+    if not os.path.isfile(local_path):
+        return VolumeUploadResult(
+            local_path=local_path,
+            volume_path=volume_path,
+            success=False,
+            error=f"Path is not a file: {local_path}"
+        )
+
+    try:
+        w = get_workspace_client()
+
+        # Use upload_from for direct file-to-volume upload
+        w.files.upload_from(
+            file_path=volume_path,
+            source_path=local_path,
+            overwrite=overwrite
+        )
+
+        return VolumeUploadResult(
+            local_path=local_path,
+            volume_path=volume_path,
+            success=True
+        )
+
+    except Exception as e:
+        return VolumeUploadResult(
+            local_path=local_path,
+            volume_path=volume_path,
+            success=False,
+            error=str(e)
+        )
+
+
+def download_from_volume(
+    volume_path: str,
+    local_path: str,
+    overwrite: bool = True
+) -> VolumeDownloadResult:
+    """
+    Download a file from a Unity Catalog volume to local path.
+
+    Args:
+        volume_path: Path in volume (e.g., "/Volumes/catalog/schema/volume/file.csv")
+        local_path: Target local file path
+        overwrite: Whether to overwrite existing local file (default: True)
+
+    Returns:
+        VolumeDownloadResult with success status
+
+    Example:
+        >>> result = download_from_volume(
+        ...     volume_path="/Volumes/main/default/my_volume/data.csv",
+        ...     local_path="/tmp/downloaded.csv"
+        ... )
+        >>> if result.success:
+        ...     print("Download complete")
+    """
+    # Check if local file exists and overwrite is False
+    if os.path.exists(local_path) and not overwrite:
+        return VolumeDownloadResult(
+            volume_path=volume_path,
+            local_path=local_path,
+            success=False,
+            error=f"Local file already exists: {local_path}"
+        )
+
+    try:
+        w = get_workspace_client()
+
+        # Create parent directory if needed
+        parent_dir = str(Path(local_path).parent)
+        if parent_dir and not os.path.exists(parent_dir):
+            os.makedirs(parent_dir)
+
+        # Use download_to for direct volume-to-file download
+        w.files.download_to(
+            file_path=volume_path,
+            destination=local_path,
+            overwrite=overwrite
+        )
+
+        return VolumeDownloadResult(
+            volume_path=volume_path,
+            local_path=local_path,
+            success=True
+        )
+
+    except Exception as e:
+        return VolumeDownloadResult(
+            volume_path=volume_path,
+            local_path=local_path,
+            success=False,
+            error=str(e)
+        )
+
+
+def delete_volume_file(volume_path: str) -> None:
+    """
+    Delete a file from a Unity Catalog volume.
+
+    Args:
+        volume_path: Path to file in volume (e.g., "/Volumes/catalog/schema/volume/file.csv")
+
+    Raises:
+        Exception: If file doesn't exist or access denied
+
+    Example:
+        >>> delete_volume_file("/Volumes/main/default/my_volume/old_data.csv")
+    """
+    w = get_workspace_client()
+    w.files.delete(volume_path)
+
+
+def delete_volume_directory(volume_path: str) -> None:
+    """
+    Delete an empty directory from a Unity Catalog volume.
+
+    Note: Directory must be empty. Delete all contents first.
+
+    Args:
+        volume_path: Path to directory in volume
+
+    Raises:
+        Exception: If directory not empty, doesn't exist, or access denied
+
+    Example:
+        >>> delete_volume_directory("/Volumes/main/default/my_volume/old_folder/")
+    """
+    w = get_workspace_client()
+    w.files.delete_directory(volume_path)
+
+
+def create_volume_directory(volume_path: str) -> None:
+    """
+    Create a directory in a Unity Catalog volume.
+
+    Creates parent directories as needed (like mkdir -p).
+    Idempotent - succeeds if directory already exists.
+
+    Args:
+        volume_path: Path for new directory (e.g., "/Volumes/catalog/schema/volume/new_folder")
+
+    Example:
+        >>> create_volume_directory("/Volumes/main/default/my_volume/data/2024/01")
+    """
+    w = get_workspace_client()
+    w.files.create_directory(volume_path)
+
+
+def get_volume_file_metadata(volume_path: str) -> VolumeFileInfo:
+    """
+    Get metadata for a file in a Unity Catalog volume.
+
+    Args:
+        volume_path: Path to file in volume
+
+    Returns:
+        VolumeFileInfo with file metadata
+
+    Raises:
+        Exception: If file doesn't exist or access denied
+
+    Example:
+        >>> info = get_volume_file_metadata("/Volumes/main/default/my_volume/data.csv")
+        >>> print(f"Size: {info.file_size} bytes")
+    """
+    w = get_workspace_client()
+    metadata = w.files.get_metadata(volume_path)
+
+    return VolumeFileInfo(
+        name=Path(volume_path).name,
+        path=volume_path,
+        is_directory=False,
+        file_size=metadata.content_length,
+        last_modified=metadata.last_modified.isoformat() if metadata.last_modified else None
+    )


### PR DESCRIPTION
## Summary

- Adds comprehensive file operations for Unity Catalog Volumes including list, upload, download, delete, create directory, and get metadata functionality
- Exposes volume operations as MCP tools for agent-based workflows
- Adds detailed skill documentation for working with UC Volumes

## Changes

### Core Library (`databricks-tools-core`)
- New `volume_files.py` module with functions:
  - `list_volume_files()` - List files/directories in a volume path
  - `upload_to_volume()` - Upload local files to a volume
  - `download_from_volume()` - Download files from a volume
  - `delete_volume_file()` / `delete_volume_directory()` - Delete operations
  - `create_volume_directory()` - Create directories
  - `get_volume_file_metadata()` - Get file metadata
- Dataclasses for typed results: `VolumeFileInfo`, `VolumeUploadResult`, `VolumeDownloadResult`

### MCP Server (`databricks-mcp-server`)
- New `volume_files.py` tools module exposing all volume operations as MCP tools
- Tools return dictionary responses for easy consumption by agents

### Skills (`databricks-skills`)
- New `6-volumes.md` documentation covering:
  - Volume types (managed vs external)
  - Path format reference
  - MCP tool usage examples
  - Python SDK examples for CRUD operations
  - Permissions and best practices
- Updated Unity Catalog skill to reference volumes documentation