### PR TITLE
Add MLflow skills integration to installer

### DIFF
--- a/databricks-skills/README.md
+++ b/databricks-skills/README.md
@@ -7,10 +7,22 @@ Skills that teach Claude Code how to work effectively with Databricks - providin
 Run in your project root:
 
 ```bash
+# Install all skills (Databricks + MLflow)
 curl -sSL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/databricks-skills/install_skills.sh | bash
+
+# Install specific skills
+curl -sSL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/databricks-skills/install_skills.sh | bash -s -- asset-bundles agent-evaluation
+
+# Pin MLflow skills to a specific version
+curl -sSL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/databricks-skills/install_skills.sh | bash -s -- --mlflow-version v1.0.0
+
+# List available skills
+curl -sSL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/databricks-skills/install_skills.sh | bash -s -- --list
 ```
 
-This creates `.claude/skills/` and copies all skills. Claude Code loads them automatically.
+This creates `.claude/skills/` and downloads all skills. Claude Code loads them automatically.
+- **Databricks skills** are downloaded from this repository
+- **MLflow skills** are fetched dynamically from [github.com/mlflow/skills](https://github.com/mlflow/skills)
 
 **Manual install:**
 ```bash
@@ -23,9 +35,18 @@ cp -r ai-dev-kit/databricks-skills/agent-bricks .claude/skills/
 ### 🤖 AI & Agents
 - **agent-bricks** - Knowledge Assistants, Genie Spaces, Multi-Agent Supervisors
 - **databricks-genie** - Genie Spaces: create, curate, and query via Conversation API
-- **mlflow-evaluation** - Model evaluation, scoring, trace analysis
 - **model-serving** - Deploy MLflow models and AI agents to endpoints
 - **unstructured-pdf-generation** - Generate synthetic PDFs for RAG
+
+### 📊 MLflow (from [mlflow/skills](https://github.com/mlflow/skills))
+- **agent-evaluation** - End-to-end agent evaluation workflow
+- **analyze-mlflow-chat-session** - Debug multi-turn conversations
+- **analyze-mlflow-trace** - Debug traces, spans, and assessments
+- **instrumenting-with-mlflow-tracing** - Add MLflow tracing to Python/TypeScript
+- **mlflow-onboarding** - MLflow setup guide for new users
+- **querying-mlflow-metrics** - Aggregated metrics and time-series analysis
+- **retrieving-mlflow-traces** - Trace search and filtering
+- **searching-mlflow-docs** - Search MLflow documentation
 
 ### 📊 Analytics & Dashboards
 - **aibi-dashboards** - AI/BI dashboards (with SQL validation workflow)
@@ -97,3 +118,4 @@ description: "What this teaches"
 - [databricks-tools-core](../databricks-tools-core/) - Python library
 - [databricks-mcp-server](../databricks-mcp-server/) - MCP server
 - [Databricks Docs](https://docs.databricks.com/) - Official documentation
+- [MLflow Skills](https://github.com/mlflow/skills) - Upstream MLflow skills repository


### PR DESCRIPTION
Integrates 8 MLflow skills from github.com/mlflow/skills into the unified installer. MLflow skills are fetched dynamically at install time (not vendored), with the MLflow repo as the source of truth.

Changes to install_skills.sh:
- Add MLFLOW_SKILLS list (8 skills from mlflow/skills repo)
- Add --mlflow-version <ref> flag to pin version/branch/tag
- Add download_mlflow_skill() for fetching from MLflow repo
- Add is_mlflow_skill() and get_mlflow_skill_extra_files() helpers
- Refactor download_skill() to route based on skill source
- Update --list and --help to show grouped display (Databricks vs MLflow)
- Remove mlflow-evaluation from DATABRICKS_SKILLS (now agent-evaluation)

Changes to README.md:
- Document new installation options and flags
- Add MLflow skills section with descriptions
- Note that MLflow skills are fetched from upstream repo
- Remove maintainer section (no longer need manual sync)

Usage:
  ./install_skills.sh                          # All 24 skills
  ./install_skills.sh agent-evaluation         # Single MLflow skill
  ./install_skills.sh asset-bundles agent-evaluation  # Mix sources
  ./install_skills.sh --mlflow-version v1.0.0  # Pin MLflow version
  ./install_skills.sh --list                   # Grouped skill list

MLflow skills: agent-evaluation, analyze-mlflow-chat-session, analyze-mlflow-trace, instrumenting-with-mlflow-tracing, mlflow-onboarding, querying-mlflow-metrics, retrieving-mlflow-traces, searching-mlflow-docs