### PR TITLE
Allow to install skills globally, support ".agents" directory, and Cursor

### DIFF
--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -53,7 +53,7 @@ MLFLOW_REPO_REF="main"
 DATABRICKS_SKILLS="agent-bricks aibi-dashboards asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-docs databricks-genie databricks-jobs databricks-python-sdk databricks-unity-catalog lakebase-provisioned mlflow-evaluation model-serving spark-declarative-pipelines spark-structured-streaming synthetic-data-generation unstructured-pdf-generation vector-search"
 
 # MLflow skills (fetched from mlflow/skills repo)
-MLFLOW_SKILLS="mlflow-evaluation"
+MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
 
 # All available skills
 ALL_SKILLS="$DATABRICKS_SKILLS $MLFLOW_SKILLS"


### PR DESCRIPTION
This PR adds a few command-line flags to `install_skills.sh`:

- `--global` - to install skills to the user's directory: `~/.claude/skills` by default, `~/.agents/skills` when used together with `--agents`, or `~/.cursor/skills` when used with `--cursor`
- `--agents` - to install into the `.agents/skills` directory understandable by multiple tools (Codex, Copilot, ...)
- `--cursor` - to install into the `.cursor/skills` directory

