### PR TITLE
docs: add README.md files for 17 databricks-skills

### DIFF
--- a/databricks-skills/agent-bricks/README.md
+++ b/databricks-skills/agent-bricks/README.md
@@ -1,0 +1,49 @@
+# Agent Bricks
+
+Create and manage Databricks Agent Bricks: Knowledge Assistants (KA) for document Q&A, Genie Spaces for SQL exploration, and Multi-Agent Supervisors (MAS) for multi-agent orchestration.
+
+## Overview
+
+This skill covers building conversational AI applications on Databricks using three pre-built Agent Brick types. It activates when you need to create document-based Q&A systems, natural language SQL interfaces, or orchestrate multiple specialized agents into a unified experience. Agent Bricks dramatically reduce the effort needed to go from raw data to a production-ready conversational AI.
+
+## What's Included
+
+```
+agent-bricks/
+├── SKILL.md                        # Main skill reference: tools, workflows, and best practices
+├── 1-knowledge-assistants.md       # Deep dive into KA creation, provisioning, and examples
+└── 3-multi-agent-supervisors.md    # Deep dive into MAS routing, agent config, and hierarchical patterns
+```
+
+## Key Topics
+
+- Knowledge Assistants (KA) for RAG-based document Q&A over Unity Catalog Volumes
+- Genie Spaces for natural language to SQL exploration (delegated to the `databricks-genie` skill)
+- Multi-Agent Supervisors (MAS) for routing queries across multiple specialized agents
+- MCP tools for creating, updating, finding, and deleting each brick type
+- Provisioning lifecycle and endpoint status monitoring
+- Automatic example ingestion from companion JSON files
+- Agent description best practices for accurate MAS query routing
+- Hierarchical multi-level MAS architectures
+
+## When to Use
+
+- You need to build a document Q&A chatbot from PDFs or text files stored in Volumes
+- You want a natural language interface over structured data in Unity Catalog tables
+- You are combining multiple specialized agents (billing, HR, technical support) behind a single conversational endpoint
+- You need to find an existing KA or MAS by name to retrieve its tile ID or endpoint name
+- You are orchestrating KA endpoints, Genie Spaces, and custom model-serving endpoints together in one MAS
+
+## Related Skills
+
+- [Databricks Genie](../databricks-genie/) -- Comprehensive Genie Space creation, curation, and Conversation API guidance
+- [Unstructured PDF Generation](../unstructured-pdf-generation/) -- Generate synthetic PDFs to feed into Knowledge Assistants
+- [Synthetic Data Generation](../synthetic-data-generation/) -- Create raw data for Genie Space tables
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- Build bronze/silver/gold tables consumed by Genie Spaces
+- [Model Serving](../model-serving/) -- Deploy custom agent endpoints used as MAS agents
+- [Vector Search](../vector-search/) -- Build vector indexes for RAG applications paired with KAs
+
+## Resources
+
+- [Databricks Agent Framework Documentation](https://docs.databricks.com/generative-ai/agent-framework/)
+- [Databricks Model Serving Documentation](https://docs.databricks.com/machine-learning/model-serving/)

--- a/databricks-skills/aibi-dashboards/README.md
+++ b/databricks-skills/aibi-dashboards/README.md
@@ -1,0 +1,47 @@
+# AI/BI Dashboards
+
+Create AI/BI dashboards on Databricks with validated SQL queries and structured JSON deployment.
+
+## Overview
+
+This skill guides the creation of Databricks AI/BI dashboards (formerly Lakeview dashboards) through a strict validation workflow: test every SQL query before deployment, build compliant dashboard JSON, and deploy via MCP tools. It activates when users need to build interactive dashboards with counters, charts, tables, and filters on top of Unity Catalog data. The skill enforces best practices around widget versioning, layout grids, field name matching, and cardinality limits to prevent common "invalid widget" errors.
+
+## What's Included
+
+```
+aibi-dashboards/
+└── SKILL.md
+```
+
+## Key Topics
+
+- Mandatory query validation workflow (test all SQL via `execute_sql` before deploying)
+- Dataset architecture with one dataset per domain and fully-qualified table names
+- Widget field expression matching rules (query field `name` must equal encoding `fieldName`)
+- Widget specifications for counters (v2), tables (v2), bar/line/pie charts (v3), and text headers
+- 6-column grid layout system with no-gap positioning
+- Global filters vs. page-level filters using `PAGE_TYPE_GLOBAL_FILTERS` and `PAGE_TYPE_CANVAS`
+- Filter widget types: `filter-multi-select`, `filter-single-select`, `filter-date-range-picker`
+- Cardinality and readability guidelines for chart dimensions
+- Spark SQL date patterns (avoiding INTERVAL syntax)
+- Troubleshooting common errors: field mismatches, invalid widget definitions, empty widgets, layout gaps
+
+## When to Use
+
+- Building a new AI/BI dashboard on Databricks
+- Creating KPI counters, bar charts, line charts, pie charts, or data tables
+- Adding global or page-level filters to dashboards
+- Debugging "invalid widget definition" or "no selected fields to visualize" errors
+- Deploying dashboard JSON via `create_or_update_dashboard` MCP tool
+- Working with Lakeview dashboard specifications
+
+## Related Skills
+
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- for querying the underlying data and system tables
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- for building the data pipelines that feed dashboards
+- [Databricks Jobs](../databricks-jobs/) -- for scheduling dashboard data refreshes
+
+## Resources
+
+- [AI/BI Dashboards Documentation](https://docs.databricks.com/en/dashboards/index.html)
+- [Lakeview Dashboard API](https://docs.databricks.com/api/workspace/lakeview)

--- a/databricks-skills/asset-bundles/README.md
+++ b/databricks-skills/asset-bundles/README.md
@@ -1,0 +1,55 @@
+# Asset Bundles
+
+Create and configure Databricks Asset Bundles (DABs) with best practices for multi-environment deployments.
+
+## Overview
+
+This skill provides comprehensive guidance for creating, configuring, and deploying Databricks Asset Bundles. It activates when you are setting up new DAB projects, adding resources like dashboards, pipelines, jobs, or alerts, or configuring multi-environment deployment targets. The skill ensures correct path resolution, permission settings, and variable parameterization across dev, staging, and production environments.
+
+## What's Included
+
+```
+asset-bundles/
+├── SKILL.md              # Main skill: bundle structure, resource types, commands, and troubleshooting
+├── SDP_guidance.md       # Spark Declarative Pipeline configuration patterns for DABs
+└── alerts_guidance.md    # SQL Alert v2 API schema and configuration (critical API differences)
+```
+
+## Key Topics
+
+- Bundle project structure (`databricks.yml`, `resources/*.yml`, `src/`)
+- Multi-environment target configuration (dev/staging/prod)
+- Variable parameterization for catalog, schema, and warehouse
+- Dashboard resources with `dataset_catalog` and `dataset_schema` parameters
+- Pipeline resource configuration (serverless, streaming, batch)
+- SQL Alert v2 API schema (evaluation, schedule, notification)
+- Job resources with scheduling and permissions
+- Volume resources with grants
+- Apps resources and `app.yaml` configuration
+- Path resolution rules (`../src/` vs `./src/`)
+- Bundle validation, deployment, and monitoring commands
+
+## When to Use
+
+- Creating a new Databricks Asset Bundle project from scratch
+- Adding dashboard, pipeline, job, alert, volume, or app resources to a bundle
+- Configuring multi-environment deployments with variable substitution
+- Setting up permissions for bundle resources
+- Deploying or running bundle resources via the Databricks CLI
+- Debugging path resolution, permission, or schema validation errors
+
+## Related Skills
+
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- pipeline definitions referenced by DABs
+- [Databricks Apps (APX)](../databricks-app-apx/) -- app deployment via DABs
+- [Databricks Apps (Python)](../databricks-app-python/) -- Python app deployment via DABs
+- [Databricks Config](../databricks-config/) -- profile and authentication setup for CLI/SDK
+- [Databricks Jobs](../databricks-jobs/) -- job orchestration managed through bundles
+
+## Resources
+
+- [Databricks Asset Bundles Documentation](https://docs.databricks.com/dev-tools/bundles/)
+- [Bundle Resources Reference](https://docs.databricks.com/dev-tools/bundles/resources)
+- [Bundle Configuration Reference](https://docs.databricks.com/dev-tools/bundles/settings)
+- [Supported Resource Types](https://docs.databricks.com/aws/en/dev-tools/bundles/resources#resource-types)
+- [DAB Examples Repository](https://github.com/databricks/bundle-examples)

--- a/databricks-skills/databricks-app-apx/README.md
+++ b/databricks-skills/databricks-app-apx/README.md
@@ -1,0 +1,49 @@
+# Databricks Apps (APX Framework)
+
+Build full-stack Databricks applications using APX framework (FastAPI + React).
+
+## Overview
+
+This skill guides you through building full-stack Databricks applications using the APX framework, which combines a FastAPI backend with a React frontend powered by TanStack Router and auto-generated OpenAPI clients. It activates when users request a "Databricks app" or mention the APX framework, and walks through a structured workflow from initialization through backend modeling, frontend development, testing, deployment, and documentation.
+
+## What's Included
+
+```
+databricks-app-apx/
+├── SKILL.md               # Main skill: workflow phases, trigger conditions, and success criteria
+├── backend-patterns.md    # Pydantic model templates and CRUD route patterns
+├── best-practices.md      # Critical rules, anti-patterns, debugging checklists
+└── frontend-patterns.md   # List/detail page templates, navigation, formatters
+```
+
+## Key Topics
+
+- APX framework initialization and MCP server setup
+- Three-model Pydantic pattern (EntityIn, EntityOut, EntityListOut)
+- FastAPI route conventions with `response_model` and `operation_id`
+- Auto-generated OpenAPI client and React hooks
+- React Suspense boundaries with skeleton fallbacks
+- TanStack Router file-based routing
+- shadcn/ui component integration
+- Type safety across Python and TypeScript
+- Deployment to Databricks via DABs
+- Application log monitoring
+
+## When to Use
+
+- User requests a "Databricks app" or "Databricks application"
+- Building a full-stack app for Databricks without specifying a framework
+- User explicitly mentions the APX framework
+- Do NOT use if the user specifies Streamlit, Dash, Node.js, Shiny, Gradio, Flask, or other frameworks
+
+## Related Skills
+
+- [Databricks Apps (Python)](../databricks-app-python/) -- for Streamlit, Dash, Gradio, or Flask apps
+- [Asset Bundles](../asset-bundles/) -- deploying APX apps via DABs
+- [Databricks Python SDK](../databricks-python-sdk/) -- backend SDK integration
+- [Lakebase Provisioned](../lakebase-provisioned/) -- adding persistent PostgreSQL state to apps
+
+## Resources
+
+- [Databricks Apps Documentation](https://docs.databricks.com/dev-tools/databricks-apps/)
+- [APX GitHub Repository](https://github.com/databricks-solutions/apx)

--- a/databricks-skills/databricks-config/README.md
+++ b/databricks-skills/databricks-config/README.md
@@ -1,0 +1,44 @@
+# Databricks Config
+
+Configure Databricks profile and authenticate for Databricks Connect, Databricks CLI, and Databricks SDK.
+
+## Overview
+
+This skill walks through configuring a Databricks profile in `~/.databrickscfg` and authenticating via `databricks auth login`. It activates when users need to set up or update their local Databricks connection profile, choose between cluster-based or serverless compute, and verify their configuration. The skill ensures proper security practices including token redaction in output.
+
+## What's Included
+
+```
+databricks-config/
+└── SKILL.md    # Profile configuration workflow, compute options, and example configurations
+```
+
+## Key Topics
+
+- Profile configuration in `~/.databrickscfg`
+- OAuth authentication via `databricks auth login`
+- Workspace host URL parsing and profile name extraction
+- Compute option selection (Cluster ID vs Serverless)
+- Serverless compute configuration (`serverless_compute_id = auto`)
+- Token security and redaction practices
+
+## When to Use
+
+- Setting up a new Databricks profile for the first time
+- Switching between workspace environments or compute targets
+- Configuring authentication for Databricks Connect, CLI, or SDK
+- Troubleshooting connection or authentication issues
+- User invokes `/databricks-config` with an optional profile name or workspace URL
+
+## Related Skills
+
+- [Databricks Python SDK](../databricks-python-sdk/) -- uses profiles configured by this skill
+- [Asset Bundles](../asset-bundles/) -- references workspace profiles for deployment targets
+- [Databricks Apps (APX)](../databricks-app-apx/) -- apps that connect via configured profiles
+- [Databricks Apps (Python)](../databricks-app-python/) -- Python apps using configured profiles
+
+## Resources
+
+- [Databricks CLI Authentication](https://docs.databricks.com/dev-tools/cli/authentication.html)
+- [Databricks Configuration Profiles](https://docs.databricks.com/dev-tools/auth/index.html#configuration-profiles)
+- [Databricks Connect Setup](https://docs.databricks.com/dev-tools/databricks-connect.html)

--- a/databricks-skills/databricks-docs/README.md
+++ b/databricks-skills/databricks-docs/README.md
@@ -1,0 +1,42 @@
+# Databricks Documentation Reference
+
+Databricks documentation reference. Use as a lookup resource alongside other skills and MCP tools for comprehensive guidance.
+
+## Overview
+
+This skill provides access to the complete Databricks documentation index via the `llms.txt` endpoint. It activates when you need to look up Databricks concepts, APIs, or features that are not covered by a more specific skill. Rather than performing actions itself, it serves as a reference layer that informs how you use MCP tools and other action-oriented skills.
+
+## What's Included
+
+```
+databricks-docs/
+  SKILL.md
+  README.md
+```
+
+## Key Topics
+
+- Fetching and navigating the Databricks `llms.txt` documentation index
+- Looking up authoritative guidance on Databricks APIs and concepts
+- Complementing action skills with reference documentation
+- Documentation categories: Data Engineering, SQL & Analytics, AI/ML, Governance, and Developer Tools
+
+## When to Use
+
+- You need reference information on a Databricks feature not covered by another skill
+- You want to confirm API details or behavior before using an MCP tool
+- A user asks about an unfamiliar Databricks concept or capability
+- You need to supplement workflow skills (e.g., `spark-declarative-pipelines`, `databricks-python-sdk`) with deeper documentation
+
+## Related Skills
+
+- [Databricks Python SDK](../databricks-python-sdk/) -- SDK patterns for programmatic Databricks access
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- DLT / Lakeflow pipeline workflows
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- Governance and catalog management
+- [Model Serving](../model-serving/) -- Serving endpoints and model deployment
+- [MLflow Evaluation](../mlflow-evaluation/) -- MLflow 3 GenAI evaluation workflows
+
+## Resources
+
+- [Databricks LLMs.txt Documentation Index](https://docs.databricks.com/llms.txt)
+- [Databricks Documentation Home](https://docs.databricks.com/)

--- a/databricks-skills/databricks-genie/README.md
+++ b/databricks-skills/databricks-genie/README.md
@@ -1,0 +1,49 @@
+# Databricks Genie
+
+Create and query Databricks Genie Spaces for natural language SQL exploration.
+
+## Overview
+
+This skill teaches how to build Genie Spaces that let users ask natural language questions against structured data in Unity Catalog and receive SQL-generated answers. It activates when creating new Genie Spaces, adding sample questions, or programmatically querying a space via the Conversation API. Genie Spaces bridge the gap between business users and complex SQL, enabling self-service analytics through conversation.
+
+## What's Included
+
+```
+databricks-genie/
+├── SKILL.md          # Main skill reference: tools, quick start, and common issues
+├── conversation.md   # Genie Conversation API: ask_genie, follow-ups, response handling
+└── spaces.md         # Creating and managing Genie Spaces: table inspection, curation, best practices
+```
+
+## Key Topics
+
+- Creating Genie Spaces with `create_or_update_genie`
+- Table schema inspection workflow before space creation
+- Sample question design referencing actual column names
+- Conversation API for programmatic querying (`ask_genie`, `ask_genie_followup`)
+- Follow-up questions with conversation context
+- Auto-detection and selection of SQL warehouses
+- Table selection guidance (silver/gold layers recommended)
+- Space curation with instructions and certified queries
+- Choosing between `ask_genie` and direct SQL (`execute_sql`)
+
+## When to Use
+
+- You are creating a new Genie Space for data exploration
+- You need to connect Unity Catalog tables to a conversational interface
+- You want to ask questions to an existing Genie Space programmatically
+- You are testing a newly created Genie Space with sample queries
+- You need to add or refine sample questions to improve query generation
+- A user explicitly says "ask Genie" or "use my Genie Space"
+
+## Related Skills
+
+- [Agent Bricks](../agent-bricks/) -- Use Genie Spaces as agents inside Multi-Agent Supervisors
+- [Synthetic Data Generation](../synthetic-data-generation/) -- Generate raw parquet data to populate tables for Genie
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- Build bronze/silver/gold tables consumed by Genie Spaces
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- Manage the catalogs, schemas, and tables Genie queries
+
+## Resources
+
+- [Databricks Genie Documentation](https://docs.databricks.com/genie/)
+- [Genie Conversation API](https://docs.databricks.com/api/workspace/genie)

--- a/databricks-skills/databricks-jobs/README.md
+++ b/databricks-skills/databricks-jobs/README.md
@@ -1,0 +1,56 @@
+# Databricks Lakeflow Jobs
+
+Orchestrate data workflows with multi-task DAGs, flexible triggers, and comprehensive monitoring on Databricks.
+
+## Overview
+
+This skill covers creating, configuring, running, and monitoring Databricks Jobs using the Python SDK, CLI, or Asset Bundles. It activates whenever users need to create jobs, set up schedules or event-driven triggers, configure notifications, or manage job runs. The skill provides complete reference material for all task types (notebook, Python, SQL, dbt, pipeline, and more), trigger mechanisms (cron, periodic, file arrival, table update, continuous), and monitoring capabilities (email/webhook notifications, health rules, retries, timeouts).
+
+## What's Included
+
+```
+databricks-jobs/
+├── SKILL.md
+├── task-types.md
+├── triggers-schedules.md
+├── notifications-monitoring.md
+└── examples.md
+```
+
+## Key Topics
+
+- Multi-task DAG workflows with `depends_on` and conditional `run_if` logic
+- Task types: notebook, Spark Python, Python wheel, SQL, dbt, pipeline, Spark JAR, run-job, for-each
+- Trigger types: cron schedule, periodic interval, file arrival, table update, continuous
+- Compute configuration: job clusters, autoscaling, existing clusters, serverless
+- Job parameters and `dbutils.widgets.get()` access in notebooks
+- Email and webhook notifications for job lifecycle events
+- Health rules, timeout configuration, and retry policies
+- Run queue settings
+- Permissions model (CAN_VIEW, CAN_MANAGE_RUN, CAN_MANAGE)
+- Python SDK, CLI, and Asset Bundle (DABs) workflows
+- Complete examples: ETL pipelines, scheduled refreshes, event-driven pipelines, ML training, multi-environment deployments, streaming jobs, cross-job orchestration
+
+## When to Use
+
+- Creating a new Databricks job or workflow
+- Setting up cron-based or event-driven job schedules
+- Configuring file arrival or table update triggers
+- Building multi-task DAG pipelines with task dependencies
+- Adding email or webhook notifications and health monitoring
+- Running or managing jobs via Python SDK or CLI
+- Deploying jobs through Databricks Asset Bundles
+- Troubleshooting job failures, schedule issues, or permission errors
+
+## Related Skills
+
+- [Asset Bundles](../asset-bundles/) -- for deploying jobs via Databricks Asset Bundles
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- for configuring pipelines triggered by jobs
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- for system tables tracking job execution history
+
+## Resources
+
+- [Jobs API Reference](https://docs.databricks.com/api/workspace/jobs)
+- [Jobs Documentation](https://docs.databricks.com/en/jobs/index.html)
+- [DABs Job Task Types](https://docs.databricks.com/en/dev-tools/bundles/job-task-types.html)
+- [Bundle Examples Repository](https://github.com/databricks/bundle-examples)

--- a/databricks-skills/databricks-python-sdk/README.md
+++ b/databricks-skills/databricks-python-sdk/README.md
@@ -1,0 +1,66 @@
+# Databricks Python SDK
+
+Databricks development guidance including Python SDK, Databricks Connect, CLI, and REST API.
+
+## Overview
+
+This skill provides comprehensive reference material for working with the Databricks Python SDK (`databricks-sdk`), Databricks Connect, the Databricks CLI, and direct REST API access. It activates when writing code that interacts with Databricks services such as clusters, jobs, SQL warehouses, Unity Catalog, model serving, vector search, and more. The skill includes a complete API documentation index with method signatures and annotated example scripts for common operations.
+
+## What's Included
+
+```
+databricks-python-sdk/
+├── SKILL.md                              # Main skill: setup, authentication, core API reference, patterns
+├── doc-index.md                          # Complete SDK method signatures mapped to documentation URLs
+└── examples/
+    ├── 1-authentication.py               # Authentication patterns and credential setup
+    ├── 2-clusters-and-jobs.py            # Cluster management and job orchestration
+    ├── 3-sql-and-warehouses.py           # SQL statement execution and warehouse management
+    ├── 4-unity-catalog.py                # Catalogs, schemas, tables, and volumes
+    └── 5-serving-and-vector-search.py    # Model serving endpoints and vector search indexes
+```
+
+## Key Topics
+
+- Authentication (PAT, OAuth, Azure Service Principal, named profiles)
+- Databricks Connect for running Spark code locally
+- WorkspaceClient and AccountClient initialization
+- Clusters API (create, start, stop, resize, permissions)
+- Jobs API (create, run, monitor, repair)
+- SQL statement execution and warehouse management
+- Unity Catalog (catalogs, schemas, tables, volumes, files)
+- Model serving endpoints and OpenAI-compatible clients
+- Vector search indexes and queries
+- Pipelines (Delta Live Tables) management
+- Secrets management
+- DBUtils access
+- Direct REST API calls via `api_client.do()`
+- Async usage patterns (`asyncio.to_thread` for FastAPI)
+- Long-running operation wait patterns and pagination
+- Error handling with typed exceptions
+
+## When to Use
+
+- Writing Python code that uses `databricks-sdk` or `databricks-connect`
+- Managing Databricks resources programmatically (clusters, jobs, warehouses)
+- Querying Unity Catalog metadata or executing SQL statements
+- Integrating Databricks APIs into applications (FastAPI, scripts, notebooks)
+- Setting up authentication or configuring Databricks CLI
+- Looking up SDK method signatures or documentation URLs
+
+## Related Skills
+
+- [Databricks Config](../databricks-config/) -- profile and authentication setup
+- [Asset Bundles](../asset-bundles/) -- deploying resources via DABs
+- [Databricks Jobs](../databricks-jobs/) -- job orchestration patterns
+- [Unity Catalog](../databricks-unity-catalog/) -- catalog governance
+- [Model Serving](../model-serving/) -- serving endpoint management
+- [Vector Search](../vector-search/) -- vector index operations
+- [Lakebase Provisioned](../lakebase-provisioned/) -- managed PostgreSQL via SDK
+
+## Resources
+
+- [Databricks Python SDK Documentation](https://databricks-sdk-py.readthedocs.io/en/latest/)
+- [Databricks SDK GitHub Repository](https://github.com/databricks/databricks-sdk-py)
+- [Authentication Guide](https://databricks-sdk-py.readthedocs.io/en/latest/authentication.html)
+- [DBUtils Documentation](https://databricks-sdk-py.readthedocs.io/en/latest/dbutils.html)

--- a/databricks-skills/databricks-unity-catalog/README.md
+++ b/databricks-skills/databricks-unity-catalog/README.md
@@ -1,0 +1,51 @@
+# Databricks Unity Catalog
+
+Unity Catalog system tables and volumes -- query audit logs, lineage, billing, and manage volume file operations.
+
+## Overview
+
+This skill provides guidance for working with Unity Catalog system tables and volumes. It activates when users query system tables (audit, lineage, billing, compute, jobs, query history), perform volume file operations (upload, download, list files), or need to understand governance and access controls. The skill covers the `system` catalog schemas, SQL grant patterns, and MCP tool integration for both system table queries and volume management.
+
+## What's Included
+
+```
+databricks-unity-catalog/
+├── SKILL.md
+├── 5-system-tables.md
+└── 6-volumes.md
+```
+
+## Key Topics
+
+- System table schemas: `system.access` (audit, lineage), `system.billing` (usage, cost), `system.compute` (clusters, warehouses), `system.lakeflow` (jobs, pipelines), `system.query` (query history), `system.storage` (storage metrics)
+- Enabling system schemas and granting access with SQL
+- Table and column-level lineage queries
+- Audit log analysis: permission changes, data access tracking
+- Billing and DBU consumption monitoring by workspace and SKU
+- Volume types: managed vs. external
+- Volume file operations: list, upload, download, create directories
+- Volume path format: `/Volumes/<catalog>/<schema>/<volume>/<path>`
+- Best practices: date filtering on large system tables, minimal access grants, scheduled monitoring reports
+
+## When to Use
+
+- Querying system tables for audit, lineage, billing, or compute metrics
+- Uploading, downloading, or listing files in Unity Catalog Volumes
+- Analyzing who accessed specific tables or changed permissions
+- Monitoring DBU consumption and cost across workspaces
+- Tracking table dependencies and column-level lineage
+- Reviewing job execution history and query performance
+- Setting up governance and access controls for system data
+
+## Related Skills
+
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- for pipelines that write to Unity Catalog tables
+- [Databricks Jobs](../databricks-jobs/) -- for job execution data visible in system tables
+- [Synthetic Data Generation](../synthetic-data-generation/) -- for generating data stored in Unity Catalog Volumes
+- [AI/BI Dashboards](../aibi-dashboards/) -- for building dashboards on top of Unity Catalog data
+
+## Resources
+
+- [Unity Catalog System Tables](https://docs.databricks.com/administration-guide/system-tables/)
+- [Audit Log Reference](https://docs.databricks.com/administration-guide/account-settings/audit-logs.html)
+- [Unity Catalog Volumes](https://docs.databricks.com/en/connect/unity-catalog/volumes.html)

--- a/databricks-skills/lakebase-provisioned/README.md
+++ b/databricks-skills/lakebase-provisioned/README.md
@@ -1,0 +1,53 @@
+# Lakebase Provisioned
+
+Patterns and best practices for using Lakebase Provisioned (Databricks managed PostgreSQL) for OLTP workloads.
+
+## Overview
+
+This skill covers Lakebase Provisioned, Databricks' managed PostgreSQL database service designed for online transaction processing (OLTP) workloads. It activates when building applications that need a relational database for persistent state, implementing reverse ETL from Delta Lake, or integrating PostgreSQL with Databricks Apps and LangChain agents. The skill provides connection patterns ranging from simple scripts to production-grade setups with automatic OAuth token refresh.
+
+## What's Included
+
+```
+lakebase-provisioned/
+├── SKILL.md                 # Main skill: quick start, common patterns, CLI reference, troubleshooting
+├── connection-patterns.md   # Detailed connection methods (psycopg, SQLAlchemy, pooling, DNS workaround)
+└── reverse-etl.md           # Syncing data from Delta Lake tables to Lakebase PostgreSQL
+```
+
+## Key Topics
+
+- Creating and managing Lakebase Provisioned instances
+- OAuth token generation and automatic refresh (1-hour expiry)
+- Direct psycopg3 connections for scripts and notebooks
+- SQLAlchemy async engine with connection pooling and token injection
+- DNS resolution workaround for macOS
+- Databricks Apps integration with environment variables
+- Unity Catalog registration for governance
+- MLflow model resource declarations
+- Reverse ETL: synced tables with FULL and INCREMENTAL modes
+- Scheduling syncs via Databricks Jobs
+- CLI commands for instance lifecycle management
+
+## When to Use
+
+- Building applications that need a PostgreSQL database for transactional workloads
+- Adding persistent state to Databricks Apps
+- Implementing reverse ETL from Delta Lake to an operational database
+- Storing chat or agent memory for LangChain applications
+- Setting up connection pooling with OAuth token refresh for production apps
+
+## Related Skills
+
+- [Databricks Apps (APX)](../databricks-app-apx/) -- full-stack apps that can use Lakebase for persistence
+- [Databricks Apps (Python)](../databricks-app-python/) -- Python apps with Lakebase backend
+- [Databricks Python SDK](../databricks-python-sdk/) -- SDK used for instance management and token generation
+- [Asset Bundles](../asset-bundles/) -- deploying apps with Lakebase resources
+- [Databricks Jobs](../databricks-jobs/) -- scheduling reverse ETL sync jobs
+
+## Resources
+
+- [Lakebase Documentation](https://docs.databricks.com/aws/en/database)
+- [Databricks Python SDK - Database API](https://databricks-sdk-py.readthedocs.io/en/latest/)
+- [psycopg 3 Documentation](https://www.psycopg.org/psycopg3/docs/)
+- [SQLAlchemy Async Engine](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html)

--- a/databricks-skills/mlflow-evaluation/README.md
+++ b/databricks-skills/mlflow-evaluation/README.md
@@ -1,0 +1,63 @@
+# MLflow Evaluation
+
+MLflow 3 GenAI evaluation for agent development. Use when writing evaluation code, creating scorers, building datasets from traces, using built-in scorers, analyzing traces, optimizing agent context, or debugging evaluation failures.
+
+## Overview
+
+This skill covers the full MLflow 3 GenAI evaluation workflow, from trace analysis through dataset building, scorer creation, and evaluation execution. It activates when you need to evaluate agent quality using `mlflow.genai.evaluate()`, build custom or built-in scorers, construct evaluation datasets from production traces, or optimize agent performance. The reference files provide critical API interfaces, common gotchas, and working code patterns for every stage of the evaluation lifecycle.
+
+## What's Included
+
+```
+mlflow-evaluation/
+  SKILL.md
+  README.md
+  references/
+    CRITICAL-interfaces.md
+    GOTCHAS.md
+    patterns-context-optimization.md
+    patterns-datasets.md
+    patterns-evaluation.md
+    patterns-scorers.md
+    patterns-trace-analysis.md
+    user-journeys.md
+```
+
+## Key Topics
+
+- Core `mlflow.genai.evaluate()` API and data schema (inputs, outputs, expectations)
+- Built-in scorers: Guidelines, Correctness, Safety, RelevanceToQuery, RetrievalGroundedness, ExpectationsGuidelines
+- Custom scorer development with `@scorer` decorator, class-based scorers, and `make_judge`
+- Evaluation dataset creation from in-memory data, production traces, tagged traces, and Unity Catalog tables
+- Trace analysis: span hierarchy, latency profiling, bottleneck detection, error patterns, tool/LLM call analysis
+- Context optimization strategies: tool result management, message history compression, prompt engineering
+- Production monitoring with registered scorers and sampling configuration
+- Regression detection and version comparison workflows
+- Common mistakes and gotchas (15+ failure modes documented)
+
+## When to Use
+
+- Writing `mlflow.genai.evaluate()` code to assess agent quality
+- Creating `@scorer` functions or class-based scorers for custom metrics
+- Building evaluation datasets from production traces or ground truth
+- Using built-in scorers (Guidelines, Correctness, Safety, RetrievalGroundedness)
+- Analyzing MLflow traces for latency, errors, or architecture patterns
+- Optimizing agent context windows, prompts, or token usage
+- Debugging evaluation failures or unexpected scorer behavior
+- Comparing agent versions to detect regressions
+- Setting up CI/CD quality gates for agent deployments
+
+## Related Skills
+
+- [Databricks Docs](../databricks-docs/) -- General Databricks documentation reference
+- [Model Serving](../model-serving/) -- Deploying models and agents to serving endpoints
+- [Agent Bricks](../agent-bricks/) -- Building agents that can be evaluated with this skill
+- [Databricks Python SDK](../databricks-python-sdk/) -- SDK patterns used alongside MLflow APIs
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- Unity Catalog tables for managed evaluation datasets
+
+## Resources
+
+- [MLflow GenAI Evaluation Documentation](https://docs.databricks.com/en/mlflow/llm-evaluate.html)
+- [MLflow Scorers Documentation](https://docs.databricks.com/en/mlflow/llm-evaluate-scorers.html)
+- [MLflow Tracing Documentation](https://docs.databricks.com/en/mlflow/mlflow-tracing.html)
+- [MLflow Python Package (PyPI)](https://pypi.org/project/mlflow/)

--- a/databricks-skills/model-serving/README.md
+++ b/databricks-skills/model-serving/README.md
@@ -1,0 +1,60 @@
+# Databricks Model Serving
+
+Deploy MLflow models and AI agents to scalable REST API endpoints.
+
+## Overview
+
+This skill provides end-to-end guidance for deploying classical ML models, custom PyFunc models, and GenAI agents (ResponsesAgent/LangGraph) to Databricks Model Serving endpoints. It activates when you need to log, register, deploy, or query any model type on Databricks. The nine reference files walk through every stage from training to production, including tool integration, async deployment, and package management.
+
+## What's Included
+
+```
+model-serving/
+├── SKILL.md                    # Main skill reference: decision matrix, MCP tools, quick starts
+├── 1-classical-ml.md           # sklearn, xgboost, autolog, and deployment via SDK/UI
+├── 2-custom-pyfunc.md          # Custom PythonModel with preprocessing, signatures, and artifacts
+├── 3-genai-agents.md           # ResponsesAgent and LangGraph agent patterns
+├── 4-tools-integration.md      # UC Functions, Vector Search, and custom @tool integration
+├── 5-development-testing.md    # MCP-based upload, install, test, and iterate workflow
+├── 6-logging-registration.md   # mlflow.pyfunc.log_model, resources, Unity Catalog registration
+├── 7-deployment.md             # Async job-based deployment for agents, SDK deployment for ML
+├── 8-querying-endpoints.md     # MCP tools, Python SDK, REST API, and OpenAI-compatible queries
+└── 9-package-requirements.md   # DBR versions, pip installs, tested package combinations
+```
+
+## Key Topics
+
+- Classical ML deployment with MLflow autolog (sklearn, xgboost, LightGBM, PyTorch)
+- Custom PyFunc models with preprocessing, signatures, and external dependencies
+- GenAI agents using MLflow 3 ResponsesAgent and LangGraph
+- Tool integration: Unity Catalog Functions, Vector Search retriever, custom tools
+- MCP-based development and testing workflow (upload, install, run, iterate)
+- Model logging and Unity Catalog registration with resource declarations
+- Async job-based deployment to avoid MCP timeouts
+- Querying endpoints via MCP tools, Python SDK, REST API, and OpenAI-compatible clients
+- Package requirements and DBR version compatibility (DBR 16.1+ recommended)
+- ResponsesAgent output format (helper methods vs. raw dicts)
+
+## When to Use
+
+- You are deploying an ML model (sklearn, xgboost, custom PyFunc) to a serving endpoint
+- You are building and deploying a GenAI agent with ResponsesAgent or LangGraph
+- You need to integrate Unity Catalog Functions or Vector Search into an agent
+- You are logging and registering a model to Unity Catalog
+- You need to query a deployed model or agent endpoint
+- You are checking endpoint status or troubleshooting deployment issues
+- You need to determine the correct package versions for agent development
+
+## Related Skills
+
+- [Agent Bricks](../agent-bricks/) -- Pre-built agent tiles that deploy to model-serving endpoints
+- [Vector Search](../vector-search/) -- Create vector indexes used as retriever tools in agents
+- [Databricks Genie](../databricks-genie/) -- Genie Spaces can serve as agents in multi-agent setups
+- [MLflow Evaluation](../mlflow-evaluation/) -- Evaluate model and agent quality before deployment
+- [Databricks Jobs](../databricks-jobs/) -- Job-based async deployment used for agent endpoints
+
+## Resources
+
+- [Model Serving Documentation](https://docs.databricks.com/machine-learning/model-serving/)
+- [MLflow 3 ResponsesAgent](https://mlflow.org/docs/latest/llms/responses-agent-intro/)
+- [Agent Framework](https://docs.databricks.com/generative-ai/agent-framework/)

--- a/databricks-skills/spark-declarative-pipelines/README.md
+++ b/databricks-skills/spark-declarative-pipelines/README.md
@@ -1,0 +1,67 @@
+# Spark Declarative Pipelines
+
+Creates, configures, and updates Databricks Lakeflow Spark Declarative Pipelines (SDP/LDP) using serverless compute.
+
+## Overview
+
+This skill covers the end-to-end lifecycle of Spark Declarative Pipelines (formerly Delta Live Tables), including streaming tables, materialized views, CDC, SCD Type 2, and Auto Loader ingestion patterns. It activates when users build data pipelines, work with Delta Live Tables, ingest streaming data, implement change data capture, or mention SDP, LDP, DLT, Lakeflow, streaming tables, or bronze/silver/gold medallion architectures. The skill supports both Asset Bundle initialization (`databricks pipelines init`) and manual MCP-driven workflows using SQL or the modern `pyspark.pipelines` Python API.
+
+## What's Included
+
+```
+spark-declarative-pipelines/
+├── SKILL.md
+├── 1-ingestion-patterns.md
+├── 2-streaming-patterns.md
+├── 3-scd-patterns.md
+├── 4-performance-tuning.md
+├── 5-python-api.md
+├── 6-dlt-migration.md
+├── 7-advanced-configuration.md
+└── 8-project-initialization.md
+```
+
+## Key Topics
+
+- Auto Loader ingestion with `read_files()` for JSON, CSV, Parquet, and Avro from cloud storage
+- Streaming sources: Kafka, Event Hub, Kinesis
+- Deduplication, windowed aggregations, and stateful streaming operations
+- Change Data Capture (CDC) with AUTO CDC and SCD Type 1/Type 2 patterns
+- Querying SCD Type 2 history tables with `__START_AT` / `__END_AT` temporal columns
+- Liquid Clustering (`CLUSTER BY`) replacing legacy `PARTITION BY` and `Z-ORDER`
+- Modern Python API (`pyspark.pipelines` as `dp`) vs. legacy DLT API (`import dlt`)
+- DLT-to-SDP migration decision matrix and step-by-step guide
+- Advanced configuration via `extra_settings` (development mode, continuous pipelines, Photon, Python dependencies)
+- Project initialization with `databricks pipelines init` and Asset Bundles
+- Medallion architecture (bronze/silver/gold) with flat or subdirectory layouts
+- Serverless compute requirements, constraints, and when to fall back to classic clusters
+
+## When to Use
+
+- Creating a new data pipeline on Databricks
+- Ingesting files from cloud storage using Auto Loader
+- Building streaming tables or materialized views
+- Implementing change data capture (CDC) or slowly changing dimensions (SCD Type 2)
+- Migrating existing Delta Live Tables (DLT) pipelines to the modern SDP framework
+- Setting up a medallion architecture (bronze/silver/gold layers)
+- Configuring pipeline performance with Liquid Clustering
+- Initializing a new pipeline project with Asset Bundles
+- Debugging pipeline errors (empty tables, streaming read failures, column not found)
+
+## Related Skills
+
+- [Databricks Jobs](../databricks-jobs/) -- for orchestrating and scheduling pipeline runs
+- [Asset Bundles](../asset-bundles/) -- for multi-environment deployment of pipeline projects
+- [Synthetic Data Generation](../synthetic-data-generation/) -- for generating test data to feed into pipelines
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- for catalog/schema/volume management and governance
+
+## Resources
+
+- [Lakeflow Spark Declarative Pipelines Overview](https://docs.databricks.com/aws/en/ldp/)
+- [SQL Language Reference](https://docs.databricks.com/aws/en/ldp/developer/sql-dev)
+- [Python Language Reference](https://docs.databricks.com/aws/en/ldp/developer/python-ref)
+- [Loading Data (Auto Loader, Kafka, Kinesis)](https://docs.databricks.com/aws/en/ldp/load)
+- [Change Data Capture (CDC)](https://docs.databricks.com/aws/en/ldp/cdc)
+- [Developing Pipelines](https://docs.databricks.com/aws/en/ldp/develop)
+- [Liquid Clustering](https://docs.databricks.com/aws/en/delta/clustering)
+- [read_files -- Usage in Streaming Tables](https://docs.databricks.com/aws/en/sql/language-manual/functions/read_files#usage-in-streaming-tables)

--- a/databricks-skills/synthetic-data-generation/README.md
+++ b/databricks-skills/synthetic-data-generation/README.md
@@ -1,0 +1,50 @@
+# Synthetic Data Generation
+
+Generate realistic synthetic data using Faker and Spark, with non-linear distributions, integrity constraints, and save to Databricks.
+
+## Overview
+
+This skill guides the generation of realistic, story-driven synthetic data for Databricks using Python with Faker, NumPy, and Spark. It activates when users need test data, demo datasets, or synthetic tables with believable distributions and referential integrity. The generated data is saved as raw Parquet files to Unity Catalog Volumes, ready for downstream processing through Spark Declarative Pipelines (bronze/silver/gold layers).
+
+## What's Included
+
+```
+synthetic-data-generation/
+└── SKILL.md
+```
+
+## Key Topics
+
+- Workflow: write Python scripts locally, execute on Databricks via MCP tools, iterate on failures
+- Context reuse pattern for faster execution (`cluster_id` and `context_id` persistence)
+- Storage destination: Unity Catalog Volumes with `ai_dev_kit` catalog default
+- Raw transactional data only (no pre-aggregated fields) to feed downstream SDP pipelines
+- Referential integrity: generate master tables first, then child tables with valid foreign keys
+- Non-linear distributions: log-normal for prices, exponential for durations, weighted categoricals
+- Time-based patterns: weekday/weekend effects, holiday calendars, seasonality, event spikes
+- Row coherence: correlated attributes (tier affects priority, priority affects resolution time, resolution affects CSAT)
+- Data volume guidelines: 10K-50K minimum rows so patterns survive GROUP BY aggregation
+- Dynamic date ranges: last 6 months from current date
+- Script structure with configuration variables at top and validation at bottom
+- Pandas for generation, Spark for saving to Volumes
+
+## When to Use
+
+- Creating test or demo datasets for Databricks
+- Generating synthetic data with realistic distributions
+- Building data that preserves referential integrity across multiple tables
+- Preparing raw data for a medallion architecture pipeline
+- Needing reproducible datasets with configurable seeds and volumes
+- Prototyping dashboards or analytics with believable data
+
+## Related Skills
+
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- for building bronze/silver/gold pipelines on top of generated data
+- [AI/BI Dashboards](../aibi-dashboards/) -- for visualizing the generated data in dashboards
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- for managing catalogs, schemas, and volumes where data is stored
+
+## Resources
+
+- [Unity Catalog Volumes](https://docs.databricks.com/en/connect/unity-catalog/volumes.html)
+- [Faker Library Documentation](https://faker.readthedocs.io/)
+- [Databricks Execution Context API](https://docs.databricks.com/api/workspace/commandexecution)

--- a/databricks-skills/unstructured-pdf-generation/README.md
+++ b/databricks-skills/unstructured-pdf-generation/README.md
@@ -1,0 +1,44 @@
+# Unstructured PDF Generation
+
+Generate synthetic PDF documents for RAG and unstructured data use cases.
+
+## Overview
+
+This skill uses the `generate_pdf_documents` MCP tool to create realistic, LLM-generated PDF documents with companion JSON evaluation files, then uploads them to Unity Catalog Volumes. It activates when you need test PDFs, demo documents, or evaluation datasets for retrieval systems. The generated JSON files include question/guideline pairs that enable automated RAG pipeline evaluation out of the box.
+
+## What's Included
+
+```
+unstructured-pdf-generation/
+└── SKILL.md    # Complete reference: parameters, patterns, output format, and integration guide
+```
+
+## Key Topics
+
+- Generating synthetic PDFs with LLM-produced content based on a description
+- Companion JSON files with question/guideline pairs for RAG evaluation
+- Automatic upload to Unity Catalog Volumes
+- Configurable document size (SMALL, MEDIUM, LARGE)
+- Common patterns: HR policies, technical docs, financial reports, training materials
+- Integration with RAG evaluation pipelines
+- LLM provider configuration (Databricks Foundation Models or Azure OpenAI)
+
+## When to Use
+
+- You need test or demo PDF documents for a Knowledge Assistant
+- You are building a RAG pipeline and need evaluation datasets with ground-truth questions
+- You want to populate a Unity Catalog Volume with realistic synthetic documents
+- You are prototyping a document Q&A system and need content quickly
+- You need to generate documents at scale (5 to 50+) with specific domain focus
+
+## Related Skills
+
+- [Agent Bricks](../agent-bricks/) -- Create Knowledge Assistants that ingest the generated PDFs
+- [Vector Search](../vector-search/) -- Index generated documents for semantic search and RAG
+- [Synthetic Data Generation](../synthetic-data-generation/) -- Generate structured tabular data (complement to unstructured PDFs)
+- [MLflow Evaluation](../mlflow-evaluation/) -- Evaluate RAG systems using the generated question/guideline pairs
+
+## Resources
+
+- [Databricks Volumes Documentation](https://docs.databricks.com/volumes/)
+- [Databricks RAG Applications](https://docs.databricks.com/generative-ai/retrieval-augmented-generation.html)

--- a/databricks-skills/vector-search/README.md
+++ b/databricks-skills/vector-search/README.md
@@ -1,0 +1,50 @@
+# Databricks Vector Search
+
+Patterns for Databricks Vector Search: create endpoints and indexes, query with filters, manage embeddings.
+
+## Overview
+
+This skill covers creating, managing, and querying vector search indexes for RAG and semantic search applications on Databricks. It activates when building retrieval-augmented generation pipelines, implementing similarity matching, or choosing between endpoint and index types. The skill details both standard and storage-optimized endpoints, all three index types (Delta Sync managed, Delta Sync self-managed, Direct Access), and filtering, hybrid search, and CLI operations.
+
+## What's Included
+
+```
+vector-search/
+├── SKILL.md          # Main skill reference: endpoints, indexes, queries, filtering, and CLI
+└── index-types.md    # Detailed comparison of index types with creation patterns and decision tree
+```
+
+## Key Topics
+
+- Standard vs. Storage-Optimized endpoints (latency, capacity, cost trade-offs)
+- Delta Sync indexes with managed embeddings (easiest setup)
+- Delta Sync indexes with self-managed (pre-computed) embeddings
+- Direct Access indexes for real-time CRUD operations
+- Querying with `query_text`, `query_vector`, and hybrid search
+- Filtering: dictionary-style (`filters_json`) and SQL-like (`filter_string`)
+- Built-in Databricks embedding models (`databricks-gte-large-en`, `databricks-bge-large-en`)
+- Triggered vs. continuous pipeline sync
+- Index scanning and manual sync operations
+- Databricks CLI quick reference for endpoint and index management
+
+## When to Use
+
+- You are building a RAG application and need a vector index
+- You need to choose between Standard and Storage-Optimized endpoints
+- You are creating a Delta Sync or Direct Access index from a Delta table
+- You need to query a vector index with text, vectors, or hybrid search
+- You want to apply metadata filters to narrow search results
+- You are integrating Vector Search as a retriever tool in an agent
+
+## Related Skills
+
+- [Model Serving](../model-serving/) -- Deploy agents that use VectorSearchRetrieverTool
+- [Agent Bricks](../agent-bricks/) -- Knowledge Assistants use RAG over indexed documents
+- [Unstructured PDF Generation](../unstructured-pdf-generation/) -- Generate documents to index in Vector Search
+- [Databricks Unity Catalog](../databricks-unity-catalog/) -- Manage the catalogs and tables that back Delta Sync indexes
+- [Spark Declarative Pipelines](../spark-declarative-pipelines/) -- Build Delta tables used as Vector Search sources
+
+## Resources
+
+- [Databricks Vector Search Documentation](https://docs.databricks.com/generative-ai/vector-search.html)
+- [Vector Search Python SDK Reference](https://docs.databricks.com/dev-tools/sdk-python/vector-search.html)


### PR DESCRIPTION
## Summary

Adds human-facing README.md documentation to all 17 skill directories in `databricks-skills/` that were missing one. The only skill that already had a README (`databricks-app-python`) was left untouched.

These READMEs complement the existing SKILL.md files (which are designed for Claude Code to consume) by providing **human-readable documentation** for discoverability — helping contributors and users quickly understand what each skill does and whether it's relevant to their task.

## What's included

Each README follows a **consistent template** with these sections:

| Section | Purpose |
|---------|---------|
| **Title + One-liner** | Skill name and description sourced from SKILL.md |
| **Overview** | 2-3 sentences on scope and when the skill activates |
| **What's Included** | Accurate directory tree of all files in the skill |
| **Key Topics** | Bulleted list of main concepts and patterns covered |
| **When to Use** | Trigger conditions and scenarios |
| **Related Skills** | Relative links (`../skill-name/`) to related skills |
| **Resources** | Links to official Databricks documentation |

## Skills covered (17 new READMEs)

**AI & Agents:**
- `agent-bricks/` — Agent Brick types (Knowledge Assistants, Genie Spaces, Multi-Agent Supervisors)
- `databricks-genie/` — Genie Space creation, Conversation API
- `model-serving/` — ML model and GenAI agent deployment (9 reference files)
- `unstructured-pdf-generation/` — Synthetic PDF generation for RAG pipelines
- `vector-search/` — Vector index types, querying, and embedding models

**Data Engineering & Analytics:**
- `aibi-dashboards/` — AI/BI Dashboard creation with validation workflow
- `spark-declarative-pipelines/` — SDP/DLT pipelines, streaming, CDC, SCD Type 2 (8 reference files)
- `databricks-jobs/` — Lakeflow Jobs orchestration, triggers, monitoring
- `synthetic-data-generation/` — Faker/Spark-based test data generation
- `databricks-unity-catalog/` — Catalog governance, system tables, volumes

**Development & Deployment:**
- `asset-bundles/` — Databricks Asset Bundles for multi-environment deployment
- `databricks-app-apx/` — APX framework (FastAPI + React) full-stack apps
- `databricks-python-sdk/` — Python SDK, Databricks Connect, CLI, REST API
- `databricks-config/` — Profile configuration and OAuth authentication
- `lakebase-provisioned/` — Managed PostgreSQL for OLTP workloads

**Reference & Evaluation:**
- `databricks-docs/` — Documentation index reference skill
- `mlflow-evaluation/` — MLflow evaluation lifecycle (8 reference files)

## Design decisions

- **Lighter-weight** than the existing `databricks-app-python/README.md` — no Contributing, Testing, or Example sections (those are unique to that skill)
- **No code duplication** — examples and patterns live in SKILL.md and supporting files
- **Consistent structure** across all 17 skills for easy scanning
- **Cross-linked** via relative paths so Related Skills work on GitHub and locally

## Test plan

- [x] All 18 `databricks-skills/*/README.md` files exist (17 new + 1 existing)
- [x] No SKILL.md or other existing files were modified (`git diff --name-only -- '*.md' ':!*README.md'` is empty)
- [x] Spot-checked `model-serving/`, `spark-declarative-pipelines/`, and `lakebase-provisioned/` for accuracy and template consistency
- [x] Directory trees match actual file listings
- [x] Related Skills links use correct relative paths