### PR TITLE
Add setup script and improve install docs for builder app

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Full-stack web application with chat UI for Databricks development:
 
 ```bash
 cd ai-dev-kit/databricks-builder-app
-./setup.sh
+./scripts/setup.sh
 # Follow instructions to start the app
 ```
 
@@ -190,6 +190,9 @@ The source in this project is provided subject to the [Databricks License](https
 
 ---
 
-## Acknowledgments
+<details>
+<summary><strong>Acknowledgments</strong></summary>
 
 MCP Databricks Command Execution API from [databricks-exec-code](https://github.com/databricks-solutions/databricks-exec-code-mcp) by Natyra Bajraktari and Henryk Borzymowski.
+
+</details>

--- a/databricks-builder-app/.gitignore
+++ b/databricks-builder-app/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 .venv/
 
 # Environment
+.env
 .env.local
 app.yaml
 

--- a/databricks-builder-app/scripts/setup.sh
+++ b/databricks-builder-app/scripts/setup.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Setup script for Databricks Builder App
+# Installs dependencies and prepares the environment for local development
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$PROJECT_DIR")"
+
+cd "$PROJECT_DIR"
+
+echo "=========================================="
+echo "  Databricks Builder App Setup"
+echo "=========================================="
+echo ""
+
+# ── Check prerequisites ──────────────────────────────────────────────────────
+
+# Check for uv
+if ! command -v uv &> /dev/null; then
+    echo "Error: 'uv' is not installed."
+    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+echo "✓ uv is installed"
+
+# Check for node
+if ! command -v node &> /dev/null; then
+    echo "Error: 'node' is not installed."
+    echo "Install Node.js 18+ from: https://nodejs.org/"
+    exit 1
+fi
+
+NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+    echo "Error: Node.js 18+ is required (found $(node -v))"
+    exit 1
+fi
+echo "✓ Node.js $(node -v) is installed"
+
+# Check for npm
+if ! command -v npm &> /dev/null; then
+    echo "Error: 'npm' is not installed."
+    exit 1
+fi
+echo "✓ npm is installed"
+
+# ── Environment file ─────────────────────────────────────────────────────────
+
+echo ""
+if [ ! -f "$PROJECT_DIR/.env" ]; then
+    echo "Creating .env from .env.example..."
+    cp "$PROJECT_DIR/.env.example" "$PROJECT_DIR/.env"
+    echo "✓ Created .env"
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║  ACTION REQUIRED: Configure your .env file                     ║"
+    echo "╠══════════════════════════════════════════════════════════════════╣"
+    echo "║                                                                ║"
+    echo "║  Open databricks-builder-app/.env and fill in your values:     ║"
+    echo "║                                                                ║"
+    echo "║  1. DATABRICKS_HOST  - Your workspace URL                      ║"
+    echo "║  2. DATABRICKS_TOKEN - Your personal access token              ║"
+    echo "║  3. LAKEBASE_PG_URL  - PostgreSQL connection string            ║"
+    echo "║     (or LAKEBASE_INSTANCE_NAME for Databricks Apps)            ║"
+    echo "║                                                                ║"
+    echo "║  See .env.example for all available options.                   ║"
+    echo "║                                                                ║"
+    echo "╚══════════════════════════════════════════════════════════════════╝"
+    echo ""
+    ENV_CREATED=true
+else
+    echo "✓ .env file already exists"
+    ENV_CREATED=false
+fi
+
+# ── Install backend dependencies ─────────────────────────────────────────────
+
+echo ""
+echo "Installing backend dependencies..."
+uv sync --quiet
+echo "✓ Backend dependencies installed"
+
+# ── Install sibling packages ─────────────────────────────────────────────────
+
+echo ""
+echo "Installing sibling packages (databricks-tools-core, databricks-mcp-server)..."
+if [ -d "$REPO_ROOT/databricks-tools-core" ] && [ -d "$REPO_ROOT/databricks-mcp-server" ]; then
+    uv pip install -e "$REPO_ROOT/databricks-tools-core" -e "$REPO_ROOT/databricks-mcp-server" --quiet
+    echo "✓ Sibling packages installed"
+else
+    echo "⚠ Sibling packages not found at repo root. If you cloned just this"
+    echo "  directory, install them manually:"
+    echo "    pip install databricks-tools-core databricks-mcp-server"
+fi
+
+# ── Install frontend dependencies ────────────────────────────────────────────
+
+echo ""
+echo "Installing frontend dependencies..."
+cd "$PROJECT_DIR/client"
+npm install --silent 2>/dev/null || npm install
+cd "$SCRIPT_DIR"
+echo "✓ Frontend dependencies installed"
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=========================================="
+echo "  Setup complete!"
+echo "=========================================="
+echo ""
+
+if [ "$ENV_CREATED" = true ]; then
+    echo "Next steps:"
+    echo "  1. Edit .env with your Databricks credentials and database config"
+    echo "  2. Run: ./scripts/start_dev.sh"
+    echo ""
+else
+    echo "Next steps:"
+    echo "  Run: ./scripts/start_dev.sh"
+    echo ""
+fi
+
+echo "This will start:"
+echo "  Backend:  http://localhost:8000"
+echo "  Frontend: http://localhost:3000"
+echo ""


### PR DESCRIPTION
- Add scripts/setup.sh that checks prerequisites, creates .env from .env.example, and installs all backend/frontend dependencies
- Update builder app README with streamlined quick start using setup.sh and explicit .env configuration instructions
- Add .env to .gitignore (was missing — only .env.local was ignored)
- Update root README to reference scripts/setup.sh path and make acknowledgments section collapsible