### PR TITLE
Fix skill validation CI to auto-discover variables from install_skill…

### DIFF
--- a/.github/scripts/validate_skills.py
+++ b/.github/scripts/validate_skills.py
@@ -3,9 +3,12 @@
 
 Checks:
 1. Every skill directory has a SKILL.md file
-2. SKILL.md has valid YAML frontmatter with a 'name' field
-3. Local skill directories match DATABRICKS_SKILLS in install_skills.sh
-   (MLflow skills are remote-only and excluded from directory checks)
+2. SKILL.md has valid YAML frontmatter per best practices:
+   - name: required, ≤64 chars, lowercase letters/numbers/hyphens only,
+     no XML tags, no reserved words ("anthropic", "claude")
+   - description: required, non-empty, ≤1024 chars, no XML tags
+3. Local skill directories are registered in install_skills.sh
+   (skill-list variables are auto-discovered, not hardcoded)
 """
 
 import re
@@ -17,6 +20,10 @@ import yaml
 SKILLS_DIR = Path("databricks-skills")
 INSTALL_SCRIPT = SKILLS_DIR / "install_skills.sh"
 SKIP_DIRS = {"TEMPLATE"}
+
+RESERVED_WORDS = {"anthropic", "claude"}
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+XML_TAG_RE = re.compile(r"<[^>]+>")
 
 
 def parse_frontmatter(content: str) -> dict | None:
@@ -30,30 +37,89 @@ def parse_frontmatter(content: str) -> dict | None:
     return None
 
 
-def get_skills_from_variable(content: str, var_name: str) -> set[str]:
-    """Parse a skill list variable from install_skills.sh."""
-    match = re.search(rf'^{var_name}="([^"]+)"', content, re.MULTILINE)
-    if match:
-        return set(match.group(1).split())
-    return set()
+def validate_name(name: str) -> list[str]:
+    """Validate the name field per best practices."""
+    errors = []
+    if len(name) > 64:
+        errors.append(f"name '{name}' exceeds 64 characters ({len(name)})")
+    if not NAME_RE.match(name):
+        errors.append(f"name '{name}' must contain only lowercase letters, numbers, and hyphens")
+    if XML_TAG_RE.search(name):
+        errors.append(f"name '{name}' must not contain XML tags")
+    for word in RESERVED_WORDS:
+        if word in name:
+            errors.append(f"name '{name}' must not contain reserved word '{word}'")
+    return errors
+
+
+def validate_description(description: str) -> list[str]:
+    """Validate the description field per best practices."""
+    errors = []
+    if not description or not description.strip():
+        errors.append("description must not be empty")
+    if len(description) > 1024:
+        errors.append(f"description exceeds 1024 characters ({len(description)})")
+    if XML_TAG_RE.search(description):
+        errors.append("description must not contain XML tags")
+    return errors
+
+
+def parse_skill_variables(
+    content: str,
+) -> tuple[dict[str, list[str]], set[str]]:
+    """Auto-discover skill-list variables from install_skills.sh.
+
+    Finds all UPPER_CASE="..." variable definitions, resolves $VAR
+    references, and returns only variables whose values look like
+    space-separated skill names (lowercase-hyphenated strings).
+
+    Returns:
+        (resolved_vars, composite_var_names) — composite variables are those
+        defined via $VAR references (e.g. ALL_SKILLS="$A $B"). They are
+        resolved for the orphan check but excluded from per-variable
+        missing-directory checks since their components are validated
+        individually.
+    """
+    # First pass: collect raw variable values
+    raw_vars: dict[str, str] = {}
+    for match in re.finditer(r'^([A-Z_]+)="([^"]*)"', content, re.MULTILINE):
+        raw_vars[match.group(1)] = match.group(2).strip()
+
+    # Second pass: resolve variable references and filter to skill lists
+    resolved: dict[str, list[str]] = {}
+    composite_vars: set[str] = set()
+    for var_name, var_value in raw_vars.items():
+        skills: list[str] = []
+        has_ref = False
+        for token in var_value.split():
+            if token.startswith("$"):
+                has_ref = True
+                ref_name = token.lstrip("$")
+                if ref_name in raw_vars:
+                    skills.extend(raw_vars[ref_name].split())
+            else:
+                skills.append(token)
+        # Only keep variables whose tokens all look like skill names
+        if skills and all(NAME_RE.match(s) for s in skills):
+            resolved[var_name] = skills
+            if has_ref:
+                composite_vars.add(var_name)
+
+    return resolved, composite_vars
+
+
+def get_local_skill_dirs() -> set[str]:
+    """Get actual skill directories on the filesystem."""
+    return {
+        d.name for d in SKILLS_DIR.iterdir() if d.is_dir() and d.name not in SKIP_DIRS and not d.name.startswith(".")
+    }
 
 
 def main() -> int:
-    errors = []
+    errors: list[str] = []
+    actual_skills = get_local_skill_dirs()
 
-    content = INSTALL_SCRIPT.read_text()
-
-    # Parse DATABRICKS_SKILLS (local skills with directories in this repo)
-    databricks_skills = get_skills_from_variable(content, "DATABRICKS_SKILLS")
-
-    # Get actual skill directories
-    actual_skills = {
-        d.name
-        for d in SKILLS_DIR.iterdir()
-        if d.is_dir() and d.name not in SKIP_DIRS and not d.name.startswith(".")
-    }
-
-    # Validate each skill directory
+    # --- Validate each skill directory's SKILL.md and frontmatter ---
     for skill_dir in sorted(SKILLS_DIR.iterdir()):
         if not skill_dir.is_dir():
             continue
@@ -62,41 +128,69 @@ def main() -> int:
 
         skill_md = skill_dir / "SKILL.md"
 
-        # Check SKILL.md exists
         if not skill_md.exists():
             errors.append(f"{skill_dir.name}: Missing SKILL.md")
             continue
 
-        # Check frontmatter
         content = skill_md.read_text()
         frontmatter = parse_frontmatter(content)
 
         if frontmatter is None:
             errors.append(f"{skill_dir.name}: Invalid or missing frontmatter in SKILL.md")
-        elif "name" not in frontmatter:
+            continue
+
+        # Validate name
+        if "name" not in frontmatter:
             errors.append(f"{skill_dir.name}: Missing 'name' field in frontmatter")
+        else:
+            for err in validate_name(str(frontmatter["name"])):
+                errors.append(f"{skill_dir.name}: {err}")
 
-    # Check for local skill directories not registered in DATABRICKS_SKILLS
-    orphaned = actual_skills - databricks_skills
+        # Validate description
+        if "description" not in frontmatter:
+            errors.append(f"{skill_dir.name}: Missing 'description' field in frontmatter")
+        else:
+            for err in validate_description(str(frontmatter["description"])):
+                errors.append(f"{skill_dir.name}: {err}")
+
+    # --- Cross-reference with install_skills.sh ---
+    install_content = INSTALL_SCRIPT.read_text()
+    skill_vars, composite_vars = parse_skill_variables(install_content)
+
+    # Collect every skill name mentioned across all variables
+    all_registered: set[str] = set()
+    for skills in skill_vars.values():
+        all_registered.update(skills)
+
+    # Every local directory should appear in at least one variable
+    orphaned = actual_skills - all_registered
     if orphaned:
-        errors.append(f"Skills exist but not in install_skills.sh DATABRICKS_SKILLS: {sorted(orphaned)}")
+        errors.append(f"Skill directories not registered in install_skills.sh: {sorted(orphaned)}")
 
-    # Check for DATABRICKS_SKILLS entries missing a local directory
-    missing = databricks_skills - actual_skills
-    if missing:
-        errors.append(f"Skills in install_skills.sh DATABRICKS_SKILLS but no directory found: {sorted(missing)}")
+    # For each *primary* (non-composite) variable where the majority of
+    # skills have local dirs, treat it as a "local" variable and flag any
+    # missing directories.  Composite variables (e.g. ALL_SKILLS) are
+    # skipped because their component variables are validated individually.
+    for var_name, skills in skill_vars.items():
+        if var_name in composite_vars:
+            continue
+        skills_set = set(skills)
+        local_count = len(skills_set & actual_skills)
+        if local_count > len(skills_set) / 2:
+            missing = skills_set - actual_skills
+            if missing:
+                errors.append(f"Skills in {var_name} but no directory found: {sorted(missing)}")
 
-    # Report results
+    # --- Report ---
     if errors:
         print("Skill validation failed:\n")
         for error in errors:
-            # GitHub Actions annotation format - shows as error in UI
             print(f"::error::{error}")
         print()
         print(f"Found {len(errors)} error(s)")
         return 1
 
-    print(f"All {len(actual_skills)} skills validated successfully")
+    print(f"All {len(actual_skills)} local skills validated successfully")
     return 0
 
 

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="agent-bricks aibi-dashboards asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-docs databricks-genie databricks-jobs databricks-python-sdk databricks-unity-catalog lakebase-provisioned mlflow-evaluation model-serving spark-declarative-pipelines synthetic-data-generation unstructured-pdf-generation vector-search"
+DATABRICKS_SKILLS="agent-bricks aibi-dashboards asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-docs databricks-genie databricks-jobs databricks-python-sdk databricks-unity-catalog lakebase-provisioned mlflow-evaluation model-serving spark-declarative-pipelines spark-structured-streaming synthetic-data-generation unstructured-pdf-generation vector-search"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -68,6 +68,7 @@ get_skill_description() {
         "lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
         "model-serving") echo "Model Serving - deploy MLflow models and AI agents" ;;
         "spark-declarative-pipelines") echo "Spark Declarative Pipelines (SDP/LDP/DLT)" ;;
+        "spark-structured-streaming") echo "Spark Structured Streaming - real-time data processing" ;;
         "synthetic-data-generation") echo "Synthetic test data generation" ;;
         "unstructured-pdf-generation") echo "Generate synthetic PDFs for RAG" ;;
         "vector-search") echo "Vector Search - endpoints, indexes, and queries for RAG" ;;
@@ -100,6 +101,7 @@ get_skill_extra_files() {
         "mlflow-evaluation") echo "references/CRITICAL-interfaces.md references/GOTCHAS.md references/patterns-context-optimization.md references/patterns-datasets.md references/patterns-evaluation.md references/patterns-scorers.md references/patterns-trace-analysis.md references/user-journeys.md" ;;
         "model-serving") echo "1-classical-ml.md 2-custom-pyfunc.md 3-genai-agents.md 4-tools-integration.md 5-development-testing.md 6-logging-registration.md 7-deployment.md 8-querying-endpoints.md 9-package-requirements.md" ;;
         "spark-declarative-pipelines") echo "1-ingestion-patterns.md 2-streaming-patterns.md 3-scd-patterns.md 4-performance-tuning.md 5-python-api.md 6-dlt-migration.md 7-advanced-configuration.md 8-project-initialization.md" ;;
+        "spark-structured-streaming") echo "checkpoint-best-practices.md kafka-streaming.md merge-operations.md multi-sink-writes.md stateful-operations.md stream-static-joins.md stream-stream-joins.md streaming-best-practices.md trigger-and-cost-optimization.md" ;;
         "vector-search") echo "index-types.md" ;;
         *) echo "" ;;
     esac


### PR DESCRIPTION
Fixing CI to validate skills

The validation script was hardcoding DATABRICKS_SKILLS as the only variable to check, which broke when new skill groups were added or when composite variables like ALL_SKILLS referenced $VAR tokens.

Changes:
- Auto-discover all skill-list variables from install_skills.sh
- Resolve $VAR references (e.g. ALL_SKILLS="$DATABRICKS_SKILLS $MLFLOW_SKILLS")
- Skip composite variables for per-variable checks (validated via components)
- Add best-practice frontmatter validation (name constraints, description required)
- Register spark-structured-streaming in install_skills.sh