### PR TITLE
Fix Claude Code plugin structure for marketplace compatibility

### DIFF
--- a/.claude-plugin/hooks.json
+++ b/.claude-plugin/hooks.json
@@ -1,8 +1,0 @@
-{
-  "hooks": [
-    {
-      "event": "plugin-installed",
-      "command": "bash ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/setup.sh"
-    }
-  ]
-}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "databricks-ai-dev-kit",
+  "owner": {
+    "name": "Databricks Solutions"
+  },
+  "metadata": {
+    "description": "Official Databricks AI Dev Kit plugin marketplace",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "databricks-ai-dev-kit",
+      "source": "./",
+      "description": "Databricks development toolkit with 19 skills and MCP tools for direct Databricks operations",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,8 +5,9 @@
   "author": {
     "name": "Databricks Solutions"
   },
+  "repository": "https://github.com/databricks-solutions/ai-dev-kit",
   "homepage": "https://github.com/databricks-solutions/ai-dev-kit",
   "license": "DB License (see repo)",
-  "keywords": ["databricks", "spark", "mlflow", "data-engineering", "ai-agents"],
+  "keywords": ["databricks", "spark", "mlflow", "data-engineering", "ai-agents", "mcp"],
   "skills": "./databricks-skills/"
 }

--- a/.claude-plugin/setup.sh
+++ b/.claude-plugin/setup.sh
@@ -9,72 +9,41 @@ PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && p
 TOOLS_CORE_DIR="${PLUGIN_ROOT}/databricks-tools-core"
 MCP_SERVER_DIR="${PLUGIN_ROOT}/databricks-mcp-server"
 
-echo "======================================"
-echo "Setting up Databricks AI Dev Kit"
-echo "======================================"
-echo ""
+# Idempotency check: skip if already set up and working
+if [ -f "${PLUGIN_ROOT}/.venv/bin/python" ] && \
+   "${PLUGIN_ROOT}/.venv/bin/python" -c "import databricks_mcp_server" 2>/dev/null; then
+    echo "Databricks AI Dev Kit already set up."
+    exit 0
+fi
+
+echo "Setting up Databricks AI Dev Kit..." >&2
 
 # Check for uv
 if ! command -v uv &> /dev/null; then
-    echo "Error: 'uv' is required but not installed."
-    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo "Error: 'uv' is required but not installed." >&2
+    echo "Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
     exit 1
 fi
-echo "uv is installed"
 
 # Check if tools-core directory exists
 if [ ! -d "$TOOLS_CORE_DIR" ]; then
-    echo "Error: databricks-tools-core not found at $TOOLS_CORE_DIR"
+    echo "Error: databricks-tools-core not found at $TOOLS_CORE_DIR" >&2
     exit 1
 fi
-echo "databricks-tools-core found"
 
 # Create virtual environment at plugin root
-echo ""
-echo "Creating virtual environment..."
 cd "$PLUGIN_ROOT"
-uv venv --python 3.11
-echo "Virtual environment created"
+uv venv --python 3.11 >&2
 
 # Install dependencies
-echo ""
-echo "Installing databricks-tools-core..."
-uv pip install --python .venv/bin/python -e "$TOOLS_CORE_DIR" --quiet
-echo "databricks-tools-core installed"
-
-echo ""
-echo "Installing databricks-mcp-server..."
-uv pip install --python .venv/bin/python -e "$MCP_SERVER_DIR" --quiet
-echo "databricks-mcp-server installed"
+uv pip install --python .venv/bin/python -e "$TOOLS_CORE_DIR" --quiet >&2
+uv pip install --python .venv/bin/python -e "$MCP_SERVER_DIR" --quiet >&2
 
 # Verify installation
-echo ""
-echo "Verifying installation..."
 if .venv/bin/python -c "import databricks_mcp_server" 2>/dev/null; then
-    echo "MCP server verified"
+    touch "${PLUGIN_ROOT}/.venv/.setup-complete"
+    echo "Databricks AI Dev Kit setup complete."
 else
-    echo "Warning: Could not verify MCP server import"
+    echo "Error: Could not verify MCP server import after install." >&2
+    exit 1
 fi
-
-echo ""
-echo "======================================"
-echo "Databricks AI Dev Kit setup complete!"
-echo "======================================"
-echo ""
-echo "To enable the MCP server, add this to your project's .mcp.json:"
-echo ""
-cat <<'EOF'
-{
-  "mcpServers": {
-    "databricks": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/databricks-mcp-server/run_server.py"],
-      "defer_loading": true
-    }
-  }
-}
-EOF
-echo ""
-echo "Or run this command to add it via CLI:"
-echo "  claude mcp add-json databricks '{\"command\":\"\${CLAUDE_PLUGIN_ROOT}/.venv/bin/python\",\"args\":[\"\${CLAUDE_PLUGIN_ROOT}/databricks-mcp-server/run_server.py\"],\"defer_loading\":true}'"
-echo ""

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "databricks": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/.venv/bin/python",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/databricks-mcp-server/run_server.py"],
+      "defer_loading": true
+    }
+  }
+}

--- a/ai-dev-project/.mcp.json
+++ b/ai-dev-project/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "databricks": {
-      "command": "/Users/cal.reynolds/Downloads/skunkworks/ai-dev-kit/databricks-mcp-server/.venv/bin/python",
-      "args": ["/Users/cal.reynolds/Downloads/skunkworks/ai-dev-kit/databricks-mcp-server/run_server.py"]
+      "command": "../.venv/bin/python",
+      "args": ["../databricks-mcp-server/run_server.py"]
     }
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/.claude-plugin/setup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The existing Claude Code plugin scaffolding has several issues that prevent it from working as a marketplace-installable plugin. The hook references a non-existent event, the MCP server doesn't auto-register, and the setup script re-runs a full install on every session. This PR addresses these issues so the plugin can be discovered, installed, and used seamlessly via the Claude Code plugin marketplace.

## Summary

- Add `.mcp.json` at plugin root so the Databricks MCP server auto-registers (uses `${CLAUDE_PLUGIN_ROOT}` for portability, `defer_loading: true`)
- Replace broken `plugin-installed` hook with `SessionStart` in `hooks/hooks.json` (standard location)
- Make `setup.sh` idempotent — skips install if venv already exists, errors go to stderr
- Add `marketplace.json` for plugin discovery via `/plugin marketplace`
- Fix hardcoded developer path in `ai-dev-project/.mcp.json` with relative paths
- Add `repository` field and `mcp` keyword to `plugin.json`

## What was broken

- `.claude-plugin/hooks.json` referenced a `plugin-installed` event that doesn't exist in Claude Code
- No `.mcp.json` at root meant the MCP server never auto-registered
- `setup.sh` re-ran full install every session (slow on SessionStart)
- `ai-dev-project/.mcp.json` had a hardcoded `/Users/cal.reynolds/...` path

## Test plan

- [x] `claude plugin validate .` passes
- [x] `claude --plugin-dir .` loads all 19 skills with `databricks-ai-dev-kit:` namespace
- [x] MCP server registers with deferred loading
- [x] `setup.sh` second run exits in <0.1s (idempotent)
- [x] Tested `spark-declarative-pipelines` skill end-to-end with live Databricks connection
- [x] Marketplace install from forked repo succeeds via `/plugin marketplace add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)