### PR TITLE
installer: standardize codex installs on .codex paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ AI-Driven Development (vibe coding) on Databricks just got a whole lot better. T
 - AI coding environment
   - [Claude Code](https://claude.ai/code)
   - [Cursor](https://cursor.com)
+  - [OpenAI Codex](https://developers.openai.com/codex)
 
 
 ### Install in existing project
 By default this will install at a project level rather than a user level. This is often a good fit, but requires you to run your client from the exact directory that was used for the install.  
-_Note: Project configuration files can be re-used in other projects. You find these configs under .claude or .cursor_
+_Note: Project configuration files can be re-used in other projects. You can find these configs under `.claude`, `.cursor`, `.codex`, or `.vscode` depending on tool selection._
 
 #### Mac / Linux
 
@@ -83,7 +84,13 @@ bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-ki
 **Install for specific tools only**
 
 ```bash
-bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools cursor
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools codex
+```
+
+**Install Codex globally**
+
+```bash
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools codex --global
 ```
 
 </details>
@@ -123,7 +130,13 @@ irm https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/insta
 **Install for specific tools only**
 
 ```powershell
-.\install.ps1 -Tools cursor
+.\install.ps1 -Tools codex
+```
+
+**Install Codex globally**
+
+```powershell
+.\install.ps1 -Tools codex -Global
 ```
 
 </details>

--- a/install.ps1
+++ b/install.ps1
@@ -717,7 +717,7 @@ function Install-Skills {
                 }
             }
             "copilot" { $dirs += Join-Path $BaseDir ".github\skills" }
-            "codex"   { $dirs += Join-Path $BaseDir ".agents\skills" }
+            "codex"   { $dirs += Join-Path $BaseDir ".codex\skills" }
         }
     }
     $dirs = $dirs | Select-Object -Unique
@@ -1003,7 +1003,7 @@ function Invoke-PromptScope {
     
     $labels = @("Project", "Global")
     $values = @("project", "global")
-    $hints = @("Install in current directory (.cursor/ and .claude/)", "Install in home directory (~/.cursor/ and ~/.claude/)")
+    $hints = @("Install in current directory (.cursor/, .claude/, and .codex/)", "Install in home directory (~/.cursor/, ~/.claude/, and ~/.codex/)")
     $count = 2
     $selected = 0
     $cursor = 0
@@ -1013,8 +1013,8 @@ function Invoke-PromptScope {
     if (-not $isInteractive) {
         # Fallback: numbered list
         Write-Host ""
-        Write-Host "  1. (*) Project  Install in current directory (.cursor/ and .claude/)"
-        Write-Host "  2. ( ) Global   Install in home directory (~/.cursor/ and ~/.claude/)"
+        Write-Host "  1. (*) Project  Install in current directory (.cursor/, .claude/, and .codex/)"
+        Write-Host "  2. ( ) Global   Install in home directory (~/.cursor/, ~/.claude/, and ~/.codex/)"
         Write-Host ""
         Write-Host "  Enter number to select (or press Enter for default): " -NoNewline
         $input_ = Read-Host

--- a/install.sh
+++ b/install.sh
@@ -657,7 +657,7 @@ install_skills() {
             claude) dirs="$base_dir/.claude/skills" ;;
             cursor) echo "$TOOLS" | grep -q claude || dirs="$dirs $base_dir/.cursor/skills" ;;
             copilot) dirs="$dirs $base_dir/.github/skills" ;;
-            codex) dirs="$dirs $base_dir/.agents/skills" ;;
+            codex) dirs="$dirs $base_dir/.codex/skills" ;;
         esac
     done
 
@@ -868,7 +868,7 @@ prompt_scope() {
     # Simple radio selector without Confirm button
     local -a labels=("Project" "Global")
     local -a values=("project" "global")
-    local -a hints=("Install in current directory (.cursor/ and .claude/)" "Install in home directory (~/.cursor/ and ~/.claude/)")
+    local -a hints=("Install in current directory (.cursor/, .claude/, and .codex/)" "Install in home directory (~/.cursor/, ~/.claude/, and ~/.codex/)")
     local count=2
     local selected=0
     local cursor=0


### PR DESCRIPTION
## Summary
- switch Codex skill install target from `.agents/skills` to `.codex/skills` in both install scripts
- update interactive scope hints to include Codex directories for project/global installs
- refresh README examples to show Codex-specific install commands and global Codex install usage

## Testing
- not run (docs + installer path updates only)