### PR TITLE
Modernize python-dev skill to use uv exclusively

### DIFF
--- a/.claude/skills/python-dev/SKILL.md
+++ b/.claude/skills/python-dev/SKILL.md
@@ -146,39 +146,62 @@ def test_calculate_total_negative_tax():
 ## Environment Management
 
 ### Dependency Management
-- **Use uv**: Dependency management via [uv](https://github.com/astral-sh/uv)
-- **Virtual environments**: Use virtual environments (`venv`) or `uv`
-- **Check existing venv**: Always check for existing `.venv` in current or parent directories before creating new one
-- **Activate before use**: Activate `.venv` before installing packages or executing scripts
-
-### Code Style
-- **Ruff**: Use Ruff for code style consistency and linting
+- **Use uv exclusively**: All packaging, environment, and script execution via [uv](https://github.com/astral-sh/uv)
+- **No pip/venv/conda**: Do not use `pip`, `python3 -m venv`, or `conda` — `uv` handles all of this
+- **pyproject.toml is the source of truth**: Define all dependencies in `pyproject.toml` (not `requirements.txt`)
 
 ### Environment Setup Example
 
 ```bash
-# Check for existing .venv
-if [ -d ".venv" ]; then
-    source .venv/bin/activate
-elif [ -d "../.venv" ]; then
-    source ../.venv/bin/activate
-else
-    # Create new venv or use uv
-    python3 -m venv .venv
-    source .venv/bin/activate
-fi
+# Install dependencies from pyproject.toml
+uv sync
 
-# Install dependencies
-pip install -r requirements.txt
+# Install with optional dev dependencies
+uv sync --extra dev
 
-# Or with uv
-uv pip install -r requirements.txt
+# Run a script (no activation needed)
+uv run python script.py
+
+# Run pytest
+uv run pytest
+
+# Add a new dependency
+uv add requests
+
+# Remove a dependency
+uv remove requests
 ```
 
-### Python Script Execution
-- Always activate virtual environment before running Python scripts
-- Use `python3` explicitly when not in venv
-- Check for `requirements.txt` or `pyproject.toml` for dependencies
+### Running Python Code
+- Use `uv run` to execute scripts — no manual venv activation needed
+- Use `uv run <tool>` for dev tools (pytest, ruff, etc.)
+- Dependencies are defined in `pyproject.toml` (not requirements.txt)
+
+### Linting & Formatting (Ruff)
+- **Ruff**: Use Ruff for linting AND formatting (replaces flake8, black, isort)
+
+```bash
+# Lint code
+uv run ruff check .
+
+# Lint and auto-fix
+uv run ruff check --fix .
+
+# Format code
+uv run ruff format .
+
+# Check formatting without changes
+uv run ruff format --check .
+```
+
+### Type Checking (Pyright)
+
+```bash
+# Check types
+uv run pyright
+```
+
+Note: Use `pyright` for type checking — do not use `mypy`.
 
 ## Best Practices Summary
 
@@ -187,5 +210,5 @@ uv pip install -r requirements.txt
 3. **Errors**: Specific exceptions, early validation, no bare except
 4. **Efficiency**: f-strings, comprehensions, context managers
 5. **Testing**: pytest only, TDD, tests in `./tests/`, all must pass
-6. **Environment**: uv or venv, check existing `.venv`, activate before use, Ruff for style
+6. **Environment**: Use `uv` exclusively for dependencies and execution, Ruff for linting/formatting, Pyright for type checking
 


### PR DESCRIPTION
## Summary

- **Rewrote Environment Management section** in the `python-dev` skill to use `uv` exclusively — removed all references to `pip`, `python3 -m venv`, `conda`, `requirements.txt`, and manual venv activation
- **Added dedicated Code Quality subsections** for Ruff (linting & formatting) and Pyright (type checking) with runnable command examples
- **Updated Best Practices summary** to reflect the modern toolchain (`uv`, Ruff, Pyright)

## Motivation

The skill previously contained conflicting guidance — it mentioned `uv` alongside `venv`, `pip install`, and `requirements.txt`, leaving ambiguity about which workflow to follow. This aligns the skill with the Astral.sh toolchain (`uv` + `ruff`) that the project already uses.

## What changed

| Section | Before | After |
|---------|--------|-------|
| Dependency Management | `uv` or `venv`, check `.venv`, activate | `uv` exclusively, `pyproject.toml` only |
| Environment Setup | Shell script with `venv`/`pip`/`uv pip` | `uv sync` / `uv run` / `uv add` examples |
| Script Execution | "Activate venv, use `python3`" | `uv run` — no activation needed |
| Code Style | Single Ruff bullet | Full Ruff section (check, fix, format) |
| Type Checking | Not mentioned | Pyright section |
| Best Practices #6 | "uv or venv, activate before use" | `uv` exclusively, Ruff, Pyright |

## What was removed

- `pip install -r requirements.txt`
- `python3 -m venv .venv` / `source .venv/bin/activate`
- `uv pip install` (deprecated subcommand pattern)
- `requirements.txt` as a dependency source

## Test plan

- [ ] Verify no remaining references to `pip`, `venv` (as a tool), or `requirements.txt` in the skill file
- [ ] Confirm markdown renders correctly (no broken code fences)
- [ ] Validate skill passes `.github/scripts/validate_skills.py` in CI