### PR TITLE
Consolidate jobs MCP tools from 12 to 2 dispatchers

### DIFF
--- a/databricks-mcp-server/databricks_mcp_server/tools/jobs.py
+++ b/databricks-mcp-server/databricks_mcp_server/tools/jobs.py
@@ -1,4 +1,9 @@
-"""Jobs tools - Manage Databricks jobs and job runs."""
+"""
+Jobs MCP Tools
+
+Consolidated MCP tools for Databricks Jobs operations.
+2 tools covering: job CRUD and job run management.
+"""
 
 from typing import Any, Dict, List
 
@@ -29,182 +34,15 @@ def _delete_job_resource(resource_id: str) -> None:
 register_deleter("job", _delete_job_resource)
 
 
-@mcp.tool
-def list_jobs(
-    name: str = None,
-    limit: int = 25,
-    expand_tasks: bool = False,
-) -> List[Dict[str, Any]]:
-    """
-    List jobs in the workspace.
-
-    Args:
-        name: Optional name filter (partial match, case-insensitive).
-        limit: Maximum number of jobs to return (default: 25).
-        expand_tasks: If True, include full task definitions in results.
-
-    Returns:
-        List of job info dicts with job_id, name, creator, created_time, etc.
-    """
-    return _list_jobs(name=name, limit=limit, expand_tasks=expand_tasks)
+# =============================================================================
+# Tool 1: manage_jobs
+# =============================================================================
 
 
 @mcp.tool
-def get_job(job_id: int) -> Dict[str, Any]:
-    """
-    Get detailed job configuration.
-
-    Args:
-        job_id: Job ID to retrieve.
-
-    Returns:
-        Dictionary with full job configuration including tasks, clusters, schedule, etc.
-    """
-    return _get_job(job_id=job_id)
-
-
-@mcp.tool
-def find_job_by_name(name: str) -> int | None:
-    """
-    Find a job by exact name and return its ID.
-
-    Args:
-        name: Job name to search for (exact match).
-
-    Returns:
-        Job ID if found, None otherwise.
-    """
-    return _find_job_by_name(name=name)
-
-
-@mcp.tool
-def create_job(
-    name: str,
-    tasks: List[Dict[str, Any]],
-    job_clusters: List[Dict[str, Any]] = None,
-    environments: List[Dict[str, Any]] = None,
-    tags: Dict[str, str] = None,
-    timeout_seconds: int = None,
-    max_concurrent_runs: int = 1,
-    email_notifications: Dict[str, Any] = None,
-    webhook_notifications: Dict[str, Any] = None,
-    notification_settings: Dict[str, Any] = None,
-    schedule: Dict[str, Any] = None,
-    queue: Dict[str, Any] = None,
-    run_as: Dict[str, Any] = None,
-    git_source: Dict[str, Any] = None,
-    parameters: List[Dict[str, Any]] = None,
-    health: Dict[str, Any] = None,
-    deployment: Dict[str, Any] = None,
-) -> Dict[str, Any]:
-    """
-    Create a new Databricks job with serverless compute by default.
-
-    Args:
-        name: Job name.
-        tasks: List of task definitions. Each task should have:
-            - task_key: Unique identifier
-            - description: Optional task description
-            - depends_on: Optional list of task dependencies
-            - [task_type]: One of spark_python_task, notebook_task, python_wheel_task,
-                          spark_jar_task, spark_submit_task, pipeline_task, sql_task, dbt_task, run_job_task
-            - [compute]: One of new_cluster, existing_cluster_id, job_cluster_key, compute_key
-        job_clusters: Optional list of job cluster definitions (for non-serverless tasks).
-        environments: Optional list of environment definitions for serverless tasks with
-            custom dependencies. Each dict should have:
-            - environment_key: Unique identifier (referenced by tasks via environment_key)
-            - spec: Dict with client (base environment version, defaults to "4" if omitted)
-                    and dependencies (list of pip packages like "pandas==2.0.0")
-            Example: [{
-                       "environment_key": "ml_env",
-                       "spec": {"client": "4", "dependencies": ["pandas==2.0.0", "scikit-learn"]}
-                     }].
-        tags: Optional tags dict for organization.
-        timeout_seconds: Job-level timeout (0 means no timeout).
-        max_concurrent_runs: Maximum number of concurrent runs (default: 1).
-        email_notifications: Email notification settings.
-        webhook_notifications: Webhook notification settings.
-        notification_settings: Notification settings for run lifecycle events.
-        schedule: Optional schedule configuration.
-        queue: Optional queue settings for job queueing.
-        run_as: Optional run-as user/service principal.
-        git_source: Optional Git source configuration.
-        parameters: Optional job parameters.
-        health: Optional health monitoring rules.
-        deployment: Optional deployment configuration.
-
-    Returns:
-        Dictionary with job_id and other creation metadata.
-
-    Example:
-        >>> tasks = [
-        ...     {
-        ...         "task_key": "data_ingestion",
-        ...         "notebook_task": {
-        ...             "notebook_path": "/Workspace/ETL/ingest",
-        ...             "source": "WORKSPACE"
-        ...         }
-        ...     }
-        ... ]
-        >>> job = create_job(name="my_etl_job", tasks=tasks)
-        >>> print(job["job_id"])
-    """
-    # Idempotency guard: check if a job with this name already exists.
-    # Prevents duplicate creation when agents retry after MCP timeouts.
-    existing_job_id = _find_job_by_name(name=name)
-    if existing_job_id is not None:
-        return {
-            "job_id": existing_job_id,
-            "already_exists": True,
-            "message": (
-                f"Job '{name}' already exists with job_id={existing_job_id}. "
-                "Returning existing job instead of creating a duplicate. "
-                "Use update_job() to modify it, or delete_job() first to recreate."
-            ),
-        }
-
-    # Auto-inject default tags; user-provided tags take precedence
-    merged_tags = {**get_default_tags(), **(tags or {})}
-    result = _create_job(
-        name=name,
-        tasks=tasks,
-        job_clusters=job_clusters,
-        environments=environments,
-        tags=merged_tags,
-        timeout_seconds=timeout_seconds,
-        max_concurrent_runs=max_concurrent_runs,
-        email_notifications=email_notifications,
-        webhook_notifications=webhook_notifications,
-        notification_settings=notification_settings,
-        schedule=schedule,
-        queue=queue,
-        run_as=run_as,
-        git_source=git_source,
-        parameters=parameters,
-        health=health,
-        deployment=deployment,
-    )
-
-    # Track resource on successful create
-    try:
-        job_id = result.get("job_id") if isinstance(result, dict) else None
-        if job_id:
-            from ..manifest import track_resource
-
-            track_resource(
-                resource_type="job",
-                name=name,
-                resource_id=str(job_id),
-            )
-    except Exception:
-        pass  # best-effort tracking
-
-    return result
-
-
-@mcp.tool
-def update_job(
-    job_id: int,
+def manage_jobs(
+    action: str,
+    job_id: int = None,
     name: str = None,
     tasks: List[Dict[str, Any]] = None,
     job_clusters: List[Dict[str, Any]] = None,
@@ -222,75 +60,172 @@ def update_job(
     parameters: List[Dict[str, Any]] = None,
     health: Dict[str, Any] = None,
     deployment: Dict[str, Any] = None,
-) -> None:
+    limit: int = 25,
+    expand_tasks: bool = False,
+) -> Dict[str, Any]:
     """
-    Update an existing job's configuration.
+    Manage Databricks jobs: create, get, list, find by name, update, and delete.
 
-    Only provided parameters will be updated. To remove a field, explicitly set it to None
-    or an empty value.
+    Actions:
+    - create: Create a new job (requires name, tasks). Uses serverless compute by default.
+        Idempotent: if a job with the same name exists, returns it instead of creating a duplicate.
+        Auto-merges default tags; user-provided tags take precedence.
+    - get: Get detailed job configuration (requires job_id).
+    - list: List jobs with optional name filter.
+    - find_by_name: Find a job by exact name and return its ID.
+    - update: Update an existing job's configuration (requires job_id).
+    - delete: Delete a job permanently (requires job_id).
 
     Args:
-        job_id: Job ID to update.
-        name: New job name.
-        tasks: New task definitions.
-        job_clusters: New job cluster definitions.
-        environments: New environment definitions for serverless tasks with dependencies.
-        tags: New tags (replaces existing).
-        timeout_seconds: New timeout.
-        max_concurrent_runs: New max concurrent runs.
-        email_notifications: New email notifications.
-        webhook_notifications: New webhook notifications.
-        notification_settings: New notification settings.
-        schedule: New schedule configuration.
-        queue: New queue settings.
-        run_as: New run-as configuration.
-        git_source: New Git source configuration.
-        parameters: New job parameters.
-        health: New health monitoring rules.
-        deployment: New deployment configuration.
+        action: "create", "get", "list", "find_by_name", "update", or "delete"
+        job_id: Job ID (for get, update, delete)
+        name: Job name (for create, find_by_name, or list filter)
+        tasks: List of task definitions (for create/update). Each task should have:
+            - task_key: Unique identifier
+            - description: Optional task description
+            - depends_on: Optional list of task dependencies
+            - [task_type]: One of spark_python_task, notebook_task, python_wheel_task,
+                          spark_jar_task, spark_submit_task, pipeline_task, sql_task, dbt_task, run_job_task
+            - [compute]: One of new_cluster, existing_cluster_id, job_cluster_key, compute_key
+        job_clusters: Job cluster definitions (for create/update, non-serverless tasks)
+        environments: Environment definitions for serverless tasks with custom dependencies (for create/update).
+            Each dict: environment_key, spec (with client and dependencies list)
+        tags: Tags dict for organization (for create/update)
+        timeout_seconds: Job-level timeout in seconds (for create/update)
+        max_concurrent_runs: Maximum concurrent runs (for create/update)
+        email_notifications: Email notification settings (for create/update)
+        webhook_notifications: Webhook notification settings (for create/update)
+        notification_settings: Notification settings for run lifecycle events (for create/update)
+        schedule: Schedule configuration (for create/update)
+        queue: Queue settings (for create/update)
+        run_as: Run-as user/service principal (for create/update)
+        git_source: Git source configuration (for create/update)
+        parameters: Job parameters (for create/update)
+        health: Health monitoring rules (for create/update)
+        deployment: Deployment configuration (for create/update)
+        limit: Maximum number of jobs to return for list (default: 25)
+        expand_tasks: If True, include full task definitions in list results (default: False)
+
+    Returns:
+        Dict with operation result:
+        - create: {"job_id": int, ...} or {"job_id": int, "already_exists": True, ...}
+        - get: Full job configuration dict
+        - list: {"items": [...]}
+        - find_by_name: {"job_id": int | None}
+        - update: {"status": "updated", "job_id": int}
+        - delete: {"status": "deleted", "job_id": int}
     """
-    _update_job(
-        job_id=job_id,
-        name=name,
-        tasks=tasks,
-        job_clusters=job_clusters,
-        environments=environments,
-        tags=tags,
-        timeout_seconds=timeout_seconds,
-        max_concurrent_runs=max_concurrent_runs,
-        email_notifications=email_notifications,
-        webhook_notifications=webhook_notifications,
-        notification_settings=notification_settings,
-        schedule=schedule,
-        queue=queue,
-        run_as=run_as,
-        git_source=git_source,
-        parameters=parameters,
-        health=health,
-        deployment=deployment,
-    )
+    act = action.lower()
+
+    if act == "create":
+        # Idempotency guard: check if a job with this name already exists.
+        # Prevents duplicate creation when agents retry after MCP timeouts.
+        existing_job_id = _find_job_by_name(name=name)
+        if existing_job_id is not None:
+            return {
+                "job_id": existing_job_id,
+                "already_exists": True,
+                "message": (
+                    f"Job '{name}' already exists with job_id={existing_job_id}. "
+                    "Returning existing job instead of creating a duplicate. "
+                    "Use manage_jobs(action='update') to modify it, or "
+                    "manage_jobs(action='delete') first to recreate."
+                ),
+            }
+
+        # Auto-inject default tags; user-provided tags take precedence
+        merged_tags = {**get_default_tags(), **(tags or {})}
+        result = _create_job(
+            name=name,
+            tasks=tasks,
+            job_clusters=job_clusters,
+            environments=environments,
+            tags=merged_tags,
+            timeout_seconds=timeout_seconds,
+            max_concurrent_runs=max_concurrent_runs or 1,
+            email_notifications=email_notifications,
+            webhook_notifications=webhook_notifications,
+            notification_settings=notification_settings,
+            schedule=schedule,
+            queue=queue,
+            run_as=run_as,
+            git_source=git_source,
+            parameters=parameters,
+            health=health,
+            deployment=deployment,
+        )
+
+        # Track resource on successful create
+        try:
+            job_id_val = result.get("job_id") if isinstance(result, dict) else None
+            if job_id_val:
+                from ..manifest import track_resource
+
+                track_resource(
+                    resource_type="job",
+                    name=name,
+                    resource_id=str(job_id_val),
+                )
+        except Exception:
+            pass  # best-effort tracking
+
+        return result
+
+    elif act == "get":
+        return _get_job(job_id=job_id)
+
+    elif act == "list":
+        return {"items": _list_jobs(name=name, limit=limit, expand_tasks=expand_tasks)}
+
+    elif act == "find_by_name":
+        return {"job_id": _find_job_by_name(name=name)}
+
+    elif act == "update":
+        _update_job(
+            job_id=job_id,
+            name=name,
+            tasks=tasks,
+            job_clusters=job_clusters,
+            environments=environments,
+            tags=tags,
+            timeout_seconds=timeout_seconds,
+            max_concurrent_runs=max_concurrent_runs,
+            email_notifications=email_notifications,
+            webhook_notifications=webhook_notifications,
+            notification_settings=notification_settings,
+            schedule=schedule,
+            queue=queue,
+            run_as=run_as,
+            git_source=git_source,
+            parameters=parameters,
+            health=health,
+            deployment=deployment,
+        )
+        return {"status": "updated", "job_id": job_id}
+
+    elif act == "delete":
+        _delete_job(job_id=job_id)
+        try:
+            from ..manifest import remove_resource
+
+            remove_resource(resource_type="job", resource_id=str(job_id))
+        except Exception:
+            pass
+        return {"status": "deleted", "job_id": job_id}
+
+    raise ValueError(f"Invalid action: '{action}'. Valid: create, get, list, find_by_name, update, delete")
+
+
+# =============================================================================
+# Tool 2: manage_job_runs
+# =============================================================================
 
 
 @mcp.tool
-def delete_job(job_id: int) -> None:
-    """
-    Delete a job permanently.
-
-    Args:
-        job_id: Job ID to delete.
-    """
-    _delete_job(job_id=job_id)
-    try:
-        from ..manifest import remove_resource
-
-        remove_resource(resource_type="job", resource_id=str(job_id))
-    except Exception:
-        pass
-
-
-@mcp.tool
-def run_job_now(
-    job_id: int,
+def manage_job_runs(
+    action: str,
+    job_id: int = None,
+    run_id: int = None,
     idempotency_token: str = None,
     jar_params: List[str] = None,
     notebook_params: Dict[str, str] = None,
@@ -301,157 +236,102 @@ def run_job_now(
     sql_params: Dict[str, str] = None,
     dbt_commands: List[str] = None,
     queue: Dict[str, Any] = None,
-) -> int:
-    """
-    Trigger a job run immediately and return the run ID.
-
-    Args:
-        job_id: Job ID to run.
-        idempotency_token: Optional token to ensure idempotent job runs.
-        jar_params: Parameters for JAR tasks.
-        notebook_params: Parameters for notebook tasks.
-        python_params: Parameters for Python tasks.
-        spark_submit_params: Parameters for spark-submit tasks.
-        python_named_params: Named parameters for Python tasks.
-        pipeline_params: Parameters for pipeline tasks.
-        sql_params: Parameters for SQL tasks.
-        dbt_commands: Commands for dbt tasks.
-        queue: Queue settings for this run.
-
-    Returns:
-        Run ID (integer) for tracking the run.
-
-    Example:
-        >>> run_id = run_job_now(job_id=123, notebook_params={"env": "prod"})
-        >>> print(f"Started run {run_id}")
-    """
-    return _run_job_now(
-        job_id=job_id,
-        idempotency_token=idempotency_token,
-        jar_params=jar_params,
-        notebook_params=notebook_params,
-        python_params=python_params,
-        spark_submit_params=spark_submit_params,
-        python_named_params=python_named_params,
-        pipeline_params=pipeline_params,
-        sql_params=sql_params,
-        dbt_commands=dbt_commands,
-        queue=queue,
-    )
-
-
-@mcp.tool
-def get_run(run_id: int) -> Dict[str, Any]:
-    """
-    Get detailed run status and information.
-
-    Args:
-        run_id: Run ID to retrieve.
-
-    Returns:
-        Dictionary with run details including state, start_time, end_time, tasks, etc.
-    """
-    return _get_run(run_id=run_id)
-
-
-@mcp.tool
-def get_run_output(run_id: int) -> Dict[str, Any]:
-    """
-    Get run output including logs and results.
-
-    Args:
-        run_id: Run ID to get output for.
-
-    Returns:
-        Dictionary with run output including logs, error messages, and task outputs.
-    """
-    return _get_run_output(run_id=run_id)
-
-
-@mcp.tool
-def cancel_run(run_id: int) -> None:
-    """
-    Cancel a running job.
-
-    Args:
-        run_id: Run ID to cancel.
-    """
-    _cancel_run(run_id=run_id)
-
-
-@mcp.tool
-def list_runs(
-    job_id: int = None,
     active_only: bool = False,
     completed_only: bool = False,
     limit: int = 25,
     offset: int = 0,
     start_time_from: int = None,
     start_time_to: int = None,
-) -> List[Dict[str, Any]]:
-    """
-    List job runs with optional filters.
-
-    Args:
-        job_id: Optional filter by specific job ID.
-        active_only: If True, only return active runs (RUNNING, PENDING, etc.).
-        completed_only: If True, only return completed runs.
-        limit: Maximum number of runs to return (default: 25, max: 1000).
-        offset: Offset for pagination.
-        start_time_from: Filter by start time (epoch milliseconds).
-        start_time_to: Filter by start time (epoch milliseconds).
-
-    Returns:
-        List of run info dicts with run_id, state, start_time, job_id, etc.
-
-    Example:
-        >>> # Get last 10 runs for a specific job
-        >>> runs = list_runs(job_id=123, limit=10)
-        >>>
-        >>> # Get all active runs
-        >>> active_runs = list_runs(active_only=True)
-    """
-    return _list_runs(
-        job_id=job_id,
-        active_only=active_only,
-        completed_only=completed_only,
-        limit=limit,
-        offset=offset,
-        start_time_from=start_time_from,
-        start_time_to=start_time_to,
-    )
-
-
-@mcp.tool
-def wait_for_run(
-    run_id: int,
     timeout: int = 3600,
     poll_interval: int = 10,
 ) -> Dict[str, Any]:
     """
-    Wait for a job run to complete and return detailed results.
+    Manage Databricks job runs: trigger, monitor, and control.
+
+    Actions:
+    - run_now: Trigger a job run immediately (requires job_id).
+    - get: Get detailed run status and information (requires run_id).
+    - get_output: Get run output including logs and results (requires run_id).
+    - cancel: Cancel a running job (requires run_id).
+    - list: List job runs with optional filters.
+    - wait: Wait for a job run to complete and return detailed results (requires run_id).
 
     Args:
-        run_id: Run ID to wait for.
-        timeout: Maximum wait time in seconds (default: 3600 = 1 hour).
-        poll_interval: Time between status checks in seconds (default: 10).
+        action: "run_now", "get", "get_output", "cancel", "list", or "wait"
+        job_id: Job ID (for run_now, or list filter)
+        run_id: Run ID (for get, get_output, cancel, wait)
+        idempotency_token: Token to ensure idempotent job runs (for run_now)
+        jar_params: Parameters for JAR tasks (for run_now)
+        notebook_params: Parameters for notebook tasks (for run_now)
+        python_params: Parameters for Python tasks (for run_now)
+        spark_submit_params: Parameters for spark-submit tasks (for run_now)
+        python_named_params: Named parameters for Python tasks (for run_now)
+        pipeline_params: Parameters for pipeline tasks (for run_now)
+        sql_params: Parameters for SQL tasks (for run_now)
+        dbt_commands: Commands for dbt tasks (for run_now)
+        queue: Queue settings for this run (for run_now)
+        active_only: If True, only return active runs (for list)
+        completed_only: If True, only return completed runs (for list)
+        limit: Maximum number of runs to return (for list, default: 25)
+        offset: Offset for pagination (for list)
+        start_time_from: Filter by start time in epoch milliseconds (for list)
+        start_time_to: Filter by start time in epoch milliseconds (for list)
+        timeout: Maximum wait time in seconds (for wait, default: 3600)
+        poll_interval: Time between status checks in seconds (for wait, default: 10)
 
     Returns:
-        Dictionary with detailed run status including:
-        - success: True if run completed successfully
-        - lifecycle_state: Final lifecycle state (TERMINATED, SKIPPED, etc.)
-        - result_state: Final result state (SUCCESS, FAILED, etc.)
-        - duration_seconds: Total time taken
-        - error_message: Error message if failed
-        - run_page_url: Link to run in Databricks UI
-
-    Example:
-        >>> run_id = run_job_now(job_id=123)
-        >>> result = wait_for_run(run_id=run_id, timeout=1800)
-        >>> if result["success"]:
-        ...     print(f"Job completed in {result['duration_seconds']}s")
-        ... else:
-        ...     print(f"Job failed: {result['error_message']}")
+        Dict with operation result:
+        - run_now: {"run_id": int}
+        - get: Run details dict with state, start_time, end_time, tasks, etc.
+        - get_output: Run output dict with logs, error messages, and task outputs
+        - cancel: {"status": "cancelled", "run_id": int}
+        - list: {"items": [...]}
+        - wait: Detailed run result dict with success, lifecycle_state, result_state,
+                duration_seconds, error_message, run_page_url
     """
-    result = _wait_for_run(run_id=run_id, timeout=timeout, poll_interval=poll_interval)
-    return result.to_dict()
+    act = action.lower()
+
+    if act == "run_now":
+        run_id_result = _run_job_now(
+            job_id=job_id,
+            idempotency_token=idempotency_token,
+            jar_params=jar_params,
+            notebook_params=notebook_params,
+            python_params=python_params,
+            spark_submit_params=spark_submit_params,
+            python_named_params=python_named_params,
+            pipeline_params=pipeline_params,
+            sql_params=sql_params,
+            dbt_commands=dbt_commands,
+            queue=queue,
+        )
+        return {"run_id": run_id_result}
+
+    elif act == "get":
+        return _get_run(run_id=run_id)
+
+    elif act == "get_output":
+        return _get_run_output(run_id=run_id)
+
+    elif act == "cancel":
+        _cancel_run(run_id=run_id)
+        return {"status": "cancelled", "run_id": run_id}
+
+    elif act == "list":
+        return {
+            "items": _list_runs(
+                job_id=job_id,
+                active_only=active_only,
+                completed_only=completed_only,
+                limit=limit,
+                offset=offset,
+                start_time_from=start_time_from,
+                start_time_to=start_time_to,
+            )
+        }
+
+    elif act == "wait":
+        result = _wait_for_run(run_id=run_id, timeout=timeout, poll_interval=poll_interval)
+        return result.to_dict()
+
+    raise ValueError(f"Invalid action: '{action}'. Valid: run_now, get, get_output, cancel, list, wait")

--- a/databricks-skills/databricks-jobs/task-types.md
+++ b/databricks-skills/databricks-jobs/task-types.md
@@ -618,7 +618,7 @@ Define reusable Python environments for serverless tasks with custom pip depende
 > **IMPORTANT:** The `client` field is **required** in the environment `spec`. It specifies the
 > base serverless environment version. Use `"4"` as the value. Without it, the API returns:
 > `"Either base environment or version must be provided for environment"`.
-> The MCP `create_job` tool auto-injects `client: "4"` if omitted, but CLI/SDK calls require it explicitly.
+> The MCP `manage_jobs` tool (action="create") auto-injects `client: "4"` if omitted, but CLI/SDK calls require it explicitly.
 
 ### DABs YAML
 

--- a/databricks-skills/databricks-model-serving/7-deployment.md
+++ b/databricks-skills/databricks-model-serving/7-deployment.md
@@ -41,10 +41,11 @@ print(f"Endpoint: {deployment.endpoint_name}")
 
 ### Step 2: Create Deployment Job (One-Time)
 
-Use the `create_job` MCP tool:
+Use the `manage_jobs` MCP tool with action="create":
 
 ```
-create_job(
+manage_jobs(
+    action="create",
     name="deploy-agent-job",
     tasks=[
         {
@@ -66,10 +67,11 @@ Save the returned `job_id`.
 
 ### Step 3: Run Deployment (Async)
 
-Use `run_job_now` - returns immediately:
+Use `manage_job_runs` with action="run_now" - returns immediately:
 
 ```
-run_job_now(
+manage_job_runs(
+    action="run_now",
     job_id="<job_id>",
     job_parameters={"model_name": "main.agents.my_agent", "version": "1"}
 )
@@ -82,7 +84,7 @@ Save the returned `run_id`.
 Check job run status:
 
 ```
-get_run(run_id="<run_id>")
+manage_job_runs(action="get", run_id="<run_id>")
 ```
 
 Or check endpoint directly:
@@ -214,9 +216,9 @@ client.update_endpoint(
 | Step | MCP Tool | Waits? |
 |------|----------|--------|
 | Upload deploy script | `upload_folder` | Yes |
-| Create job (one-time) | `create_job` | Yes |
-| Run deployment | `run_job_now` | **No** - returns immediately |
-| Check job status | `get_run` | Yes |
+| Create job (one-time) | `manage_jobs` (action="create") | Yes |
+| Run deployment | `manage_job_runs` (action="run_now") | **No** - returns immediately |
+| Check job status | `manage_job_runs` (action="get") | Yes |
 | Check endpoint status | `get_serving_endpoint_status` | Yes |
 
 ## After Deployment

--- a/databricks-skills/databricks-model-serving/SKILL.md
+++ b/databricks-skills/databricks-model-serving/SKILL.md
@@ -135,9 +135,9 @@ Then deploy via UI or SDK. See [1-classical-ml.md](1-classical-ml.md).
 
 | Tool | Purpose |
 |------|---------|
-| `create_job` | Create deployment job (one-time) |
-| `run_job_now` | Kick off deployment (async) |
-| `get_run` | Check deployment job status |
+| `manage_jobs` (action="create") | Create deployment job (one-time) |
+| `manage_job_runs` (action="run_now") | Kick off deployment (async) |
+| `manage_job_runs` (action="get") | Check deployment job status |
 
 ### Querying
 


### PR DESCRIPTION
## Summary

- Consolidates 12 individual jobs MCP tools into 2 dispatcher tools (`manage_jobs`, `manage_job_runs`) following the established UC pattern (`manage_uc_objects`, `manage_uc_grants`, etc.)
- `manage_jobs` handles: create, get, list, find_by_name, update, delete
- `manage_job_runs` handles: run_now, get, get_output, cancel, list, wait
- Updates all skill references (databricks-jobs, databricks-model-serving) to use the new tool names

All cross-cutting concerns preserved: idempotency guard on create, default tag auto-merge, manifest resource tracking/cleanup, and register_deleter. Tools-core layer is untouched — changes are purely in the MCP wrapper layer.

## Test plan

- [x] Verify `manage_jobs` dispatches correctly for all 6 actions
- [x] Verify `manage_job_runs` dispatches correctly for all 6 actions
- [x] Confirm idempotency guard works on `manage_jobs(action="create")`
- [x] Confirm manifest tracking on create/delete
- [x] Run existing tools-core integration tests (unchanged, should pass)
- [x] Verify skill docs render correctly with new tool references

🤖 Generated with [Claude Code](https://claude.com/claude-code)