### PR TITLE
Improve model-serving skill: endpoint reference table, naming guidance etc.

### DIFF
--- a/databricks-skills/databricks-model-serving/3-genai-agents.md
+++ b/databricks-skills/databricks-model-serving/3-genai-agents.md
@@ -155,13 +155,16 @@ mlflow.models.set_model(AGENT)
 
 ## Using Databricks-Hosted Models
 
+Use exact endpoint names from the reference table in [SKILL.md](SKILL.md#foundation-model-api-endpoints).
+
 ```python
 from databricks_langchain import ChatDatabricks
 
-# Foundation Model APIs (pay-per-token)
+# Foundation Model APIs (pay-per-token) - use exact endpoint names
 llm = ChatDatabricks(endpoint="databricks-meta-llama-3-3-70b-instruct")
-llm = ChatDatabricks(endpoint="databricks-claude-3-7-sonnet")
-llm = ChatDatabricks(endpoint="databricks-dbrx-instruct")
+llm = ChatDatabricks(endpoint="databricks-claude-sonnet-4-6")
+llm = ChatDatabricks(endpoint="databricks-gpt-5-1")
+llm = ChatDatabricks(endpoint="databricks-gemini-3-flash")
 
 # Custom fine-tuned model endpoint
 llm = ChatDatabricks(endpoint="my-finetuned-model-endpoint")

--- a/databricks-skills/databricks-model-serving/4-tools-integration.md
+++ b/databricks-skills/databricks-model-serving/4-tools-integration.md
@@ -39,7 +39,6 @@ uc_toolkit = UCFunctionToolkit(
 | Function | Purpose |
 |----------|---------|
 | `system.ai.python_exec` | Execute Python code |
-| `system.ai.similarity_search` | Vector similarity search |
 
 ### Creating a UC Function
 

--- a/databricks-skills/databricks-model-serving/7-deployment.md
+++ b/databricks-skills/databricks-model-serving/7-deployment.md
@@ -144,13 +144,61 @@ endpoint = w.serving_endpoints.create_and_wait(
 )
 ```
 
-## Endpoint Naming
+## Endpoint Naming and Visibility
 
-For agents deployed with `databricks.agents.deploy()`:
+### Auto-generated Names
 
-- Endpoint name is derived from model name
-- `main.agents.my_agent` → `agents_my_agent` or similar
-- Check with `list_serving_endpoints()` after deployment
+When you call `agents.deploy()`, the endpoint name is auto-derived from the UC model path by replacing dots with underscores and prefixing with `agents_`:
+
+| UC Model Path | Auto-generated Endpoint Name |
+|---------------|------------------------------|
+| `main.agents.my_agent` | `agents_main-agents-my_agent` |
+| `catalog.schema.model` | `agents_catalog-schema-model` |
+| `users.jane.demo_bot` | `agents_users-jane-demo_bot` |
+
+The exact format can vary. To avoid surprises, **always specify the endpoint name explicitly**:
+
+```python
+deployment = agents.deploy(
+    "main.agents.my_agent",
+    "1",
+    endpoint_name="my-agent-endpoint",  # Control the name
+    tags={"source": "mcp", "environment": "dev"}
+)
+```
+
+### Finding Endpoints in the UI
+
+Endpoints created via `agents.deploy()` appear under **Serving** in the Databricks UI. If you don't see your endpoint:
+
+1. **Check the filter** - The Serving page defaults to "Owned by me". If the deployment ran as a service principal (e.g., via a job), switch to "All" to see it.
+2. **Verify via API** - Use `list_serving_endpoints()` or `get_serving_endpoint_status(name="...")` to confirm the endpoint exists and check its state.
+3. **Check the name** - The auto-generated name may not be what you expect. Print `deployment.endpoint_name` in the deploy script or check the job run output.
+
+### Deployment Script with Explicit Naming
+
+```python
+# deploy_agent.py - recommended pattern
+import sys
+from databricks import agents
+
+model_name = sys.argv[1] if len(sys.argv) > 1 else "main.agents.my_agent"
+version = sys.argv[2] if len(sys.argv) > 2 else "1"
+endpoint_name = sys.argv[3] if len(sys.argv) > 3 else None
+
+deploy_kwargs = {
+    "tags": {"source": "mcp", "environment": "dev"}
+}
+if endpoint_name:
+    deploy_kwargs["endpoint_name"] = endpoint_name
+
+print(f"Deploying {model_name} version {version}...")
+deployment = agents.deploy(model_name, version, **deploy_kwargs)
+
+print(f"Deployment complete!")
+print(f"Endpoint name: {deployment.endpoint_name}")
+print(f"Query URL: {deployment.query_endpoint}")
+```
 
 ## Deployment Job Template
 

--- a/databricks-skills/databricks-model-serving/SKILL.md
+++ b/databricks-skills/databricks-model-serving/SKILL.md
@@ -21,6 +21,59 @@ Deploy MLflow models and AI agents to scalable REST API endpoints.
 - Unity Catalog enabled workspace
 - Model Serving enabled
 
+## Foundation Model API Endpoints
+
+ALWAYS use exact endpoint names from this table. NEVER guess or abbreviate.
+
+### Chat / Instruct Models
+
+| Endpoint Name | Provider | Notes |
+|--------------|----------|-------|
+| `databricks-gpt-5-2` | OpenAI | Latest GPT, 400K context |
+| `databricks-gpt-5-1` | OpenAI | Instant + Thinking modes |
+| `databricks-gpt-5-1-codex-max` | OpenAI | Code-specialized (high perf) |
+| `databricks-gpt-5-1-codex-mini` | OpenAI | Code-specialized (cost-opt) |
+| `databricks-gpt-5` | OpenAI | 400K context, reasoning |
+| `databricks-gpt-5-mini` | OpenAI | Cost-optimized reasoning |
+| `databricks-gpt-5-nano` | OpenAI | High-throughput, lightweight |
+| `databricks-gpt-oss-120b` | OpenAI | Open-weight, 128K context |
+| `databricks-gpt-oss-20b` | OpenAI | Lightweight open-weight |
+| `databricks-claude-opus-4-6` | Anthropic | Most capable, 1M context |
+| `databricks-claude-sonnet-4-6` | Anthropic | Hybrid reasoning |
+| `databricks-claude-sonnet-4-5` | Anthropic | Hybrid reasoning |
+| `databricks-claude-opus-4-5` | Anthropic | Deep analysis, 200K context |
+| `databricks-claude-sonnet-4` | Anthropic | Hybrid reasoning |
+| `databricks-claude-opus-4-1` | Anthropic | 200K context, 32K output |
+| `databricks-claude-haiku-4-5` | Anthropic | Fastest, cost-effective |
+| `databricks-claude-3-7-sonnet` | Anthropic | Retiring April 2026 |
+| `databricks-meta-llama-3-3-70b-instruct` | Meta | 128K context, multilingual |
+| `databricks-meta-llama-3-1-405b-instruct` | Meta | Retiring May 2026 (PT) |
+| `databricks-meta-llama-3-1-8b-instruct` | Meta | Lightweight, 128K context |
+| `databricks-llama-4-maverick` | Meta | MoE architecture |
+| `databricks-gemini-3-1-pro` | Google | 1M context, hybrid reasoning |
+| `databricks-gemini-3-pro` | Google | 1M context, hybrid reasoning |
+| `databricks-gemini-3-flash` | Google | Fast, cost-efficient |
+| `databricks-gemini-2-5-pro` | Google | 1M context, Deep Think |
+| `databricks-gemini-2-5-flash` | Google | 1M context, hybrid reasoning |
+| `databricks-gemma-3-12b` | Google | 128K context, multilingual |
+| `databricks-qwen3-next-80b-a3b-instruct` | Alibaba | Efficient MoE |
+
+### Embedding Models
+
+| Endpoint Name | Dimensions | Max Tokens | Notes |
+|--------------|-----------|------------|-------|
+| `databricks-gte-large-en` | 1024 | 8192 | English, not normalized |
+| `databricks-bge-large-en` | 1024 | 512 | English, normalized |
+| `databricks-qwen3-embedding-0-6b` | up to 1024 | ~32K | 100+ languages, instruction-aware |
+
+### Common Defaults
+
+- **Agent LLM**: `databricks-meta-llama-3-3-70b-instruct` (good balance of quality/cost)
+- **Embedding**: `databricks-gte-large-en`
+- **Code tasks**: `databricks-gpt-5-1-codex-mini` or `databricks-gpt-5-1-codex-max`
+
+> These are pay-per-token endpoints available in every workspace. For production, consider provisioned throughput mode. See [supported models](https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/supported-models).
+
 ## Reference Files
 
 | Topic | File | When to Read |


### PR DESCRIPTION
chnages:

- Add Foundation Model API endpoint reference table to SKILL.md with all current pay-per-token endpoints (chat, embedding) so the agent never guesses endpoint names (e.g. missing -en suffix on databricks-gte-large-en)
- Expand endpoint naming/visibility section in 7-deployment.md: explicit naming convention, recommend endpoint_name parameter, UI filter guidance
- Replace retired model names with current models in 3-genai-agents.md