### PR TITLE
Fix Streamlit app.yaml 

### DIFF
--- a/databricks-skills/databricks-app-python/2-app-resources.md
+++ b/databricks-skills/databricks-app-python/2-app-resources.md
@@ -31,16 +31,13 @@ Use `valueFrom` to reference resources — never hardcode IDs:
 ```yaml
 env:
   - name: DATABRICKS_WAREHOUSE_ID
-    valueFrom:
-      resource: sql-warehouse
+    valueFrom: sql-warehouse
 
   - name: SERVING_ENDPOINT_NAME
-    valueFrom:
-      resource: serving-endpoint
+    valueFrom: serving-endpoint
 
   - name: DB_CONNECTION_STRING
-    valueFrom:
-      resource: database
+    valueFrom: database
 ```
 
 Add resources via the Databricks Apps UI when creating or editing an app:

--- a/databricks-skills/databricks-app-python/3-frameworks.md
+++ b/databricks-skills/databricks-app-python/3-frameworks.md
@@ -64,7 +64,7 @@ def get_connection():
 | Detail | Value |
 |--------|-------|
 | Pre-installed version | 1.38.0 |
-| app.yaml command | `["streamlit", "run", "app.py", "--server.port", "8080", "--server.address", "0.0.0.0", "--server.headless", "true"]` |
+| app.yaml command | `["streamlit", "run", "app.py"]` |
 | Auth header | `st.context.headers.get('x-forwarded-access-token')` |
 
 **Databricks tips**:

--- a/databricks-skills/databricks-app-python/4-deployment.md
+++ b/databricks-skills/databricks-app-python/4-deployment.md
@@ -19,8 +19,7 @@ command:
 
 env:
   - name: DATABRICKS_WAREHOUSE_ID
-    valueFrom:
-      resource: sql-warehouse
+    valueFrom: sql-warehouse
   - name: USE_MOCK_BACKEND
     value: "false"
 ```
@@ -30,7 +29,7 @@ env:
 | Framework | Command |
 |-----------|---------|
 | Dash | `["python", "app.py"]` |
-| Streamlit | `["streamlit", "run", "app.py", "--server.port", "8080", "--server.address", "0.0.0.0", "--server.headless", "true"]` |
+| Streamlit | `["streamlit", "run", "app.py"]` |
 | Gradio | `["python", "app.py"]` |
 | Flask | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8080"]` |
 | FastAPI | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]` |

--- a/databricks-skills/databricks-app-python/SKILL.md
+++ b/databricks-skills/databricks-app-python/SKILL.md
@@ -36,7 +36,7 @@ Copy this checklist and verify each item:
 | Framework | Best For | app.yaml Command |
 |-----------|----------|------------------|
 | **Dash** | Production dashboards, BI tools, complex interactivity | `["python", "app.py"]` |
-| **Streamlit** | Rapid prototyping, data science apps, internal tools | `["streamlit", "run", "app.py", "--server.port", "8080", "--server.address", "0.0.0.0", "--server.headless", "true"]` |
+| **Streamlit** | Rapid prototyping, data science apps, internal tools | `["streamlit", "run", "app.py"]` |
 | **Gradio** | ML demos, model interfaces, chat UIs | `["python", "app.py"]` |
 | **Flask** | Custom REST APIs, lightweight apps, webhooks | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8080"]` |
 | **FastAPI** | Async APIs, auto-generated OpenAPI docs | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]` |


### PR DESCRIPTION
The command element removed extraneous entries and now looks like:
```
command:
  - "streamlit"
  - "run"
  - "app.py"
```
This fixes "App not available" upon deployment.

Entries in the env element now look like:
```
env:
  - name: DATABRICKS_WAREHOUSE_ID
    valueFrom: sql-warehouse
```

This fixes the following error: "Error deploying app: error reading app.yaml file"

The following prompt was used to generate an app.yaml file: "create an app.yaml file for a databricks streamlit app"

The newly created file was tested with a new Streamlit App without any issues.