### PR TITLE
Reduce ad-hoc query costs with warehouse cache and batch SQL

### DIFF
--- a/databricks-tools-core/databricks_tools_core/sql/__init__.py
+++ b/databricks-tools-core/databricks_tools_core/sql/__init__.py
@@ -4,8 +4,8 @@ SQL - SQL Warehouse Operations
 Functions for executing SQL queries, managing SQL warehouses, and getting table statistics.
 """
 
-from .sql import execute_sql, execute_sql_multi
-from .warehouse import list_warehouses, get_best_warehouse
+from .sql import execute_sql, execute_sql_multi, execute_sql_batch
+from .warehouse import list_warehouses, get_best_warehouse, invalidate_warehouse_cache
 from .table_stats import get_table_details, get_volume_folder_details
 from .sql_utils import (
     SQLExecutionError,
@@ -22,9 +22,11 @@ __all__ = [
     # SQL execution
     "execute_sql",
     "execute_sql_multi",
+    "execute_sql_batch",
     # Warehouse management
     "list_warehouses",
     "get_best_warehouse",
+    "invalidate_warehouse_cache",
     # Table statistics
     "get_table_details",
     "get_volume_folder_details",

--- a/databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py
+++ b/databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py
@@ -86,6 +86,8 @@ class SQLExecutor:
         try:
             response = self.client.statement_execution.execute_statement(**exec_params)
         except Exception as e:
+            from ..warehouse import invalidate_warehouse_cache
+            invalidate_warehouse_cache()
             raise SQLExecutionError(
                 f"Failed to submit SQL query to warehouse '{self.warehouse_id}': {str(e)}. "
                 f"Check that the warehouse exists and is accessible."

--- a/databricks-tools-core/uv.lock
+++ b/databricks-tools-core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -754,7 +754,7 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.76.0"
+version = "0.91.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -763,9 +763,9 @@ dependencies = [
     { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/82/5efcfdca8779c84b5c6f61cc110d0938c9818e422f55c36a68d96b98c61f/databricks_sdk-0.76.0.tar.gz", hash = "sha256:fcfce4561b090b3c8e9cac2101f549766d9fb3bece31bb5720571919fa37d210", size = 822376, upload-time = "2025-12-17T17:11:31.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/a9/83dee5b4bbea94f21c4990aafdb1b1893d25d5bbbe5cd9a95ed2afaf0d42/databricks_sdk-0.91.0.tar.gz", hash = "sha256:7b16f424f509609dd86cb69073a9a80a755c00a7b4be8cdaac3595ce3421a274", size = 857905, upload-time = "2026-02-19T08:22:21.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/96/ee7742b94f996560c57d6fb8d2e10eab3c489e8a72187369ed0917baf8aa/databricks_sdk-0.76.0-py3-none-any.whl", hash = "sha256:6696dda22bc52c8f50a50d24e6ccd1c855f92c0f68f5afe4eb2e77d5b1b1a65f", size = 774688, upload-time = "2025-12-17T17:11:29.925Z" },
+    { url = "https://files.pythonhosted.org/packages/92/38/3afd8da94fa076226c470f33632d6df726c469738c01224068f009357985/databricks_sdk-0.91.0-py3-none-any.whl", hash = "sha256:f4481780e66a4c7d24d9d2acdf6778efdb82031532852ccc42b8619b81d0f73f", size = 808425, upload-time = "2026-02-19T08:22:19.161Z" },
 ]
 
 [[package]]
@@ -781,6 +781,7 @@ dependencies = [
     { name = "pymupdf", version = "1.24.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pymupdf", version = "1.26.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pymupdf", version = "1.26.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pyyaml" },
     { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "sqlfluff", version = "3.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -804,12 +805,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "databricks-sdk", specifier = ">=0.20.0" },
+    { name = "databricks-sdk", specifier = ">=0.81.0" },
     { name = "litellm", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "sqlfluff", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

- Add 60s TTL cache to `get_best_warehouse()` to avoid redundant Databricks API calls during sequential query sessions (10+ queries = 10+ warehouse lookups → 1)
- Add `execute_sql_batch()` that merges multiple independent SELECTs into a single UNION ALL warehouse call with JSON serialization, falling back to sequential on failure
- Expose as MCP tool with docstring guiding Claude to prefer it over repeated `execute_sql` calls
- Invalidate warehouse cache on submission errors so the next query re-discovers a working warehouse

## Context

97% of SMWLW Databricks costs ($2,589/month) come from ad-hoc queries. Each `execute_sql` call independently calls `get_best_warehouse()` (API hit) and submits a separate warehouse execution. This PR reduces both redundant API calls and warehouse executions.

## Test plan

- [x] All imports verified clean
- [x] Local logic tests pass (query validation, SQL generation, empty batch, non-SELECT rejection)
- [x] UNION ALL + `to_json(struct(*))` approach verified against live SMWLW warehouse via MCP
- [ ] Restart MCP server to verify `execute_sql_batch` tool appears and works end-to-end