### PR TITLE
Fix incorrect SDK methods and fabricated APIs in lakebase-provisioned reverse-etl skill

### DIFF
--- a/databricks-skills/databricks-lakebase-provisioned/reverse-etl.md
+++ b/databricks-skills/databricks-lakebase-provisioned/reverse-etl.md
@@ -1,8 +1,23 @@
-# Reverse ETL with Lakebase
+# Reverse ETL with Lakebase Provisioned
 
 ## Overview
 
 Reverse ETL allows you to sync data from Unity Catalog Delta tables into Lakebase Provisioned as PostgreSQL tables. This enables OLTP access patterns on data processed in the Lakehouse.
+
+## Sync Modes
+
+| Mode | Description | Best For | Notes |
+|------|-------------|----------|-------|
+| **Snapshot** | One-time full copy | Initial setup, small tables | 10x more efficient if modifying >10% of data |
+| **Triggered** | Scheduled updates on demand | Dashboards updated hourly/daily | Requires CDF on source table |
+| **Continuous** | Real-time streaming (seconds of latency) | Live applications | Highest cost, minimum 15s intervals, requires CDF |
+
+**Note:** Triggered and Continuous modes require Change Data Feed (CDF) enabled on the source table:
+
+```sql
+ALTER TABLE your_catalog.your_schema.your_table
+SET TBLPROPERTIES (delta.enableChangeDataFeed = true)
+```
 
 ## Creating Synced Tables
 
@@ -10,157 +25,79 @@ Reverse ETL allows you to sync data from Unity Catalog Delta tables into Lakebas
 
 ```python
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.database import (
+    SyncedDatabaseTable,
+    SyncedTableSpec,
+    SyncedTableSchedulingPolicy,
+)
 
 w = WorkspaceClient()
 
-# Create a synced table from Unity Catalog
-synced_table = w.database.create_synced_table(
-    instance_name="my-lakebase-instance",
-    source_table_name="catalog.schema.source_table",
-    target_table_name="target_table",
-    sync_mode="FULL",  # FULL or INCREMENTAL
+# Create a synced table from Unity Catalog to Lakebase Provisioned
+synced_table = w.database.create_synced_database_table(
+    SyncedDatabaseTable(
+        name="lakebase_catalog.schema.synced_table",
+        database_instance_name="my-lakebase-instance",
+        spec=SyncedTableSpec(
+            source_table_full_name="analytics.gold.user_profiles",
+            primary_key_columns=["user_id"],
+            scheduling_policy=SyncedTableSchedulingPolicy.TRIGGERED,
+        ),
+    )
 )
-
-print(f"Synced table created: {synced_table.target_table_name}")
+print(f"Created synced table: {synced_table.name}")
 ```
 
-### Using SQL
+**Key parameters:**
 
-```sql
--- Create synced table via SQL
-CREATE SYNCED TABLE my_lakebase.target_table
-FROM catalog.schema.source_table
-USING LAKEBASE INSTANCE 'my-lakebase-instance';
-```
+| Parameter | Description |
+|-----------|-------------|
+| `name` | Fully qualified target table name (catalog.schema.table) |
+| `database_instance_name` | Lakebase Provisioned instance name |
+| `source_table_full_name` | Fully qualified source Delta table (catalog.schema.table) |
+| `primary_key_columns` | List of primary key columns from the source table |
+| `scheduling_policy` | `SNAPSHOT`, `TRIGGERED`, or `CONTINUOUS` |
 
 ### Using CLI
 
 ```bash
-databricks database create-synced-table \
-    --instance-name my-lakebase-instance \
-    --source-table-name catalog.schema.source_table \
-    --target-table-name target_table \
-    --sync-mode FULL
+databricks database create-synced-database-table \
+    --json '{
+        "name": "lakebase_catalog.schema.synced_table",
+        "database_instance_name": "my-lakebase-instance",
+        "spec": {
+            "source_table_full_name": "analytics.gold.user_profiles",
+            "primary_key_columns": ["user_id"],
+            "scheduling_policy": "TRIGGERED"
+        }
+    }'
 ```
 
-## Sync Modes
+**Note:** There is no SQL syntax for creating synced tables. Use the Python SDK, CLI, or Catalog Explorer UI.
 
-### Full Sync
-
-Complete replacement of target table on each sync:
+## Checking Synced Table Status
 
 ```python
-synced_table = w.database.create_synced_table(
-    instance_name="my-lakebase-instance",
-    source_table_name="catalog.schema.customers",
-    target_table_name="customers",
-    sync_mode="FULL"
-)
+status = w.database.get_synced_database_table(name="lakebase_catalog.schema.synced_table")
+print(f"State: {status.data_synchronization_status.detailed_state}")
+print(f"Message: {status.data_synchronization_status.message}")
 ```
 
-**Use when:**
-- Source table is small-medium size
-- Need complete consistency with source
-- Incremental changes are complex to track
+## Deleting a Synced Table
 
-### Incremental Sync
+Delete from both Unity Catalog and Postgres:
 
-Only sync changed rows (requires change tracking):
+1. **Unity Catalog:** Delete via Catalog Explorer or SDK
+2. **Postgres:** Drop the table to free storage
 
 ```python
-synced_table = w.database.create_synced_table(
-    instance_name="my-lakebase-instance",
-    source_table_name="catalog.schema.events",
-    target_table_name="events",
-    sync_mode="INCREMENTAL",
-    incremental_column="updated_at"  # Column to track changes
-)
+# Delete the synced table via SDK
+w.database.delete_synced_database_table(name="lakebase_catalog.schema.synced_table")
 ```
 
-**Use when:**
-- Source table is large
-- Have reliable change tracking column
-- Minimize sync time and resource usage
-
-## Managing Synced Tables
-
-### List Synced Tables
-
-```python
-synced_tables = w.database.list_synced_tables(
-    instance_name="my-lakebase-instance"
-)
-for table in synced_tables:
-    print(f"{table.target_table_name}: {table.sync_status}")
-```
-
-### Trigger Manual Sync
-
-```python
-w.database.sync_table(
-    instance_name="my-lakebase-instance",
-    table_name="customers"
-)
-```
-
-### Delete Synced Table
-
-```python
-w.database.delete_synced_table(
-    instance_name="my-lakebase-instance",
-    table_name="customers"
-)
-```
-
-## Scheduling Syncs
-
-### Using Databricks Jobs
-
-```python
-from databricks.sdk import WorkspaceClient
-from databricks.sdk.service.jobs import Task, NotebookTask, CronSchedule
-
-w = WorkspaceClient()
-
-# Create job to sync tables on schedule
-job = w.jobs.create(
-    name="Lakebase Sync Job",
-    tasks=[
-        Task(
-            task_key="sync_customers",
-            notebook_task=NotebookTask(
-                notebook_path="/Repos/sync/sync_customers"
-            )
-        )
-    ],
-    schedule=CronSchedule(
-        quartz_cron_expression="0 0 * * * ?",  # Every hour
-        timezone_id="UTC"
-    )
-)
-```
-
-### Sync Notebook Example
-
-```python
-# Databricks notebook: sync_customers
-
-from databricks.sdk import WorkspaceClient
-
-w = WorkspaceClient()
-
-# Trigger sync for specific tables
-tables_to_sync = ["customers", "orders", "products"]
-
-for table in tables_to_sync:
-    try:
-        w.database.sync_table(
-            instance_name="my-lakebase-instance",
-            table_name=table
-        )
-        print(f"Synced: {table}")
-    except Exception as e:
-        print(f"Failed to sync {table}: {e}")
+```sql
+-- Drop the Postgres table to free storage
+DROP TABLE your_database.your_schema.your_table;
 ```
 
 ## Use Cases
@@ -168,59 +105,67 @@ for table in tables_to_sync:
 ### 1. Product Catalog for Web App
 
 ```python
-# Sync product data for e-commerce app
-w.database.create_synced_table(
-    instance_name="ecommerce-db",
-    source_table_name="gold.products.catalog",
-    target_table_name="products",
-    sync_mode="FULL"
+w.database.create_synced_database_table(
+    SyncedDatabaseTable(
+        name="ecommerce_catalog.public.products",
+        database_instance_name="ecommerce-db",
+        spec=SyncedTableSpec(
+            source_table_full_name="gold.products.catalog",
+            primary_key_columns=["product_id"],
+            scheduling_policy=SyncedTableSchedulingPolicy.TRIGGERED,
+        ),
+    )
 )
-
-# Application queries PostgreSQL directly
-# with low-latency point lookups
+# Application queries PostgreSQL directly with low-latency point lookups
 ```
 
 ### 2. User Profiles for Authentication
 
 ```python
-# Sync user profiles for auth service
-w.database.create_synced_table(
-    instance_name="auth-db",
-    source_table_name="gold.users.profiles",
-    target_table_name="user_profiles",
-    sync_mode="INCREMENTAL",
-    incremental_column="last_modified"
+w.database.create_synced_database_table(
+    SyncedDatabaseTable(
+        name="auth_catalog.public.user_profiles",
+        database_instance_name="auth-db",
+        spec=SyncedTableSpec(
+            source_table_full_name="gold.users.profiles",
+            primary_key_columns=["user_id"],
+            scheduling_policy=SyncedTableSchedulingPolicy.CONTINUOUS,
+        ),
+    )
 )
 ```
 
 ### 3. Feature Store for Real-time ML
 
 ```python
-# Sync features for online serving
-w.database.create_synced_table(
-    instance_name="feature-store-db",
-    source_table_name="ml.features.user_features",
-    target_table_name="user_features",
-    sync_mode="INCREMENTAL",
-    incremental_column="computed_at"
+w.database.create_synced_database_table(
+    SyncedDatabaseTable(
+        name="ml_catalog.public.user_features",
+        database_instance_name="feature-store-db",
+        spec=SyncedTableSpec(
+            source_table_full_name="ml.features.user_features",
+            primary_key_columns=["user_id"],
+            scheduling_policy=SyncedTableSchedulingPolicy.CONTINUOUS,
+        ),
+    )
 )
-
 # ML model queries features with low latency
 ```
 
 ## Best Practices
 
-1. **Choose appropriate sync mode**: Use FULL for small tables, INCREMENTAL for large tables with change tracking
-2. **Schedule during low-traffic periods**: Heavy syncs can impact both source and target
-3. **Monitor sync status**: Check for failures and latency
-4. **Index target tables**: Create appropriate indexes in PostgreSQL for query patterns
-5. **Handle schema changes**: Synced tables need updates when source schema changes
+1. **Enable CDF** on source tables before creating Triggered or Continuous synced tables
+2. **Choose appropriate sync mode**: Snapshot for small tables or one-time loads, Triggered for hourly/daily refreshes, Continuous for real-time
+3. **Monitor sync status**: Check for failures and latency via Catalog Explorer or `get_synced_database_table()`
+4. **Index target tables**: Create appropriate indexes in PostgreSQL for your query patterns
+5. **Handle schema changes**: Only additive changes (e.g., adding columns) are supported for Triggered/Continuous modes
+6. **Account for connection limits**: Each synced table uses up to 16 connections
 
 ## Common Issues
 
 | Issue | Solution |
 |-------|----------|
-| **Sync takes too long** | Switch to INCREMENTAL mode; add indexes on source |
-| **Schema mismatch** | Drop and recreate synced table after source schema changes |
-| **Sync fails with timeout** | Increase sync timeout; reduce batch size |
+| **Sync fails with CDF error** | Enable Change Data Feed on source table before using Triggered or Continuous mode |
+| **Schema mismatch** | Only additive schema changes are supported; for breaking changes, delete and recreate the synced table |
+| **Sync takes too long** | Switch to Triggered mode for scheduled updates; use Snapshot for initial bulk loads |
 | **Target table locked** | Avoid DDL on target during sync operations |


### PR DESCRIPTION
## Summary                                                                                                                           
  - Replaced fabricated `create_synced_table()`, `sync_table()`, `list_synced_tables()`, and `delete_synced_table()` methods with
  correct SDK equivalents (`create_synced_database_table()`, `get_synced_database_table()`, `delete_synced_database_table()`)
  - Removed non-existent `CREATE SYNCED TABLE` SQL syntax
  - Fixed CLI command from `create-synced-table` with individual flags to `create-synced-database-table --json`
  - Replaced fabricated `FULL`/`INCREMENTAL` sync modes with correct `SNAPSHOT`/`TRIGGERED`/`CONTINUOUS` scheduling policies
  - Removed fabricated "Scheduling Syncs" section built around non-existent `sync_table()` method
  - Updated all use case examples to use correct `SyncedDatabaseTable` object pattern

## Context                                                                                                                           
  The existing `reverse-etl.md` in the provisioned skill contained fabricated API signatures and non-existent SQL syntax. This PR aligns the skill with the actual SDK implementation at `databricks-tools-core/databricks_tools_core/lakebase/synced_tables.py` and  the official Databricks documentation.

## Test plan
  - [ ] Verified all SDK method names match `synced_tables.py` implementation
  - [ ] Verified sync modes match `SyncedTableSchedulingPolicy` enum values
  - [ ] Verified CLI command format in `reverse-etl.md` reference
  - [ ] Verified data points (efficiency, 15s min interval, CDF requirements) against [public docs]