### PR TITLE
Fix syntax error in save_version(): add fi instead of }

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -859,7 +859,7 @@ save_version() {
     if [ "$SCOPE" = "project" ]; then 
         mkdir -p ".ai-dev-kit"
         echo "$ver" > ".ai-dev-kit/version"
-    }
+    fi
 }
 
 # Print summary


### PR DESCRIPTION
Just fixing a small syntax error in the save_version function in install.sh
- Replacing } with fi