### PR TITLE
Fix syntax error in install.sh (if closed with } instead of fi)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -856,10 +856,10 @@ save_version() {
     # Validate version format
     [[ "$ver" =~ (404|Not Found|error) ]] && ver="dev"
     echo "$ver" > "$INSTALL_DIR/version"
-    if [ "$SCOPE" = "project" ]; then 
+    if [ "$SCOPE" = "project" ]; then
         mkdir -p ".ai-dev-kit"
         echo "$ver" > ".ai-dev-kit/version"
-    }
+    fi
 }
 
 # Print summary


### PR DESCRIPTION
## Summary
- Fixes a syntax error on line 862 of `install.sh` that breaks the curl-based installer:
  ```
  bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh)
  /dev/fd/11: line 862: syntax error near unexpected token `}'
  ```
- The bug was introduced in commit `31f18dd` (PR #169) which expanded a one-liner `[ "$SCOPE" = "project" ] && { ... }` into a multi-line `if/then` block but closed it with `}` instead of `fi`.

## Fix
```diff
-    if [ "$SCOPE" = "project" ]; then 
+    if [ "$SCOPE" = "project" ]; then
         mkdir -p ".ai-dev-kit"
         echo "$ver" > ".ai-dev-kit/version"
-    }
+    fi
```

## Test plan
- [ ] Run `bash -n install.sh` — should pass with no syntax errors
- [ ] Run `bash <(curl -sL <raw-url>/install.sh)` — installer should complete without syntax error

🤖 Generated with [Claude Code](https://claude.com/claude-code)