### PR TITLE
Add defer_loading: true to installer MCP configs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -741,7 +741,7 @@ import json, sys
 try:
     with open('$path') as f: cfg = json.load(f)
 except: cfg = {}
-cfg.setdefault('mcpServers', {})['databricks'] = {'command': '$VENV_PYTHON', 'args': ['$MCP_ENTRY'], 'env': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'}}
+cfg.setdefault('mcpServers', {})['databricks'] = {'command': '$VENV_PYTHON', 'args': ['$MCP_ENTRY'], 'defer_loading': True, 'env': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'}}
 with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
 " 2>/dev/null && return
     fi
@@ -752,6 +752,7 @@ with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
     "databricks": {
       "command": "$VENV_PYTHON",
       "args": ["$MCP_ENTRY"],
+      "defer_loading": true,
       "env": {"DATABRICKS_CONFIG_PROFILE": "$PROFILE"}
     }
   }


### PR DESCRIPTION
Claude docs: https://www.anthropic.com/engineering/advanced-tool-use#:~:text=How%20the%20Tool%20Search%20Tool%20works

Basically, this should reduce the amount of context that our skills take when installed and make the llm selectively use them

## Summary
- Adds `"defer_loading": true` to the MCP JSON configs generated by `install.sh` for Claude Code and Cursor
- This was already documented in the README and used in the repo's own `.mcp.json`, but the installer wasn't setting it for end users
- Improves startup time by deferring tool loading until tools are actually needed

## Test plan
- [x] Run `install.sh` with `--tools claude` and verify `.mcp.json` includes `defer_loading: true`
- [x] Run `install.sh` with `--tools cursor` and verify `.cursor/mcp.json` includes `defer_loading: true`
- [x] Verify existing configs are updated correctly (Python JSON merger path)
- [ ] Verify fresh installs include it (heredoc fallback path)

Made with [Cursor](https://cursor.com)