### PR TITLE
fix(databricks-app-python): correct port from 8080 to DATABRICKS_APP_PORT (8000)

### DIFF
--- a/databricks-skills/databricks-app-python/3-frameworks.md
+++ b/databricks-skills/databricks-app-python/3-frameworks.md
@@ -25,7 +25,7 @@ app = dash.Dash(
 |--------|-------|
 | Pre-installed version | 2.18.1 |
 | app.yaml command | `["python", "app.py"]` |
-| Default port | 8050 (set `DATABRICKS_APP_PORT=8080` or use `app.run(port=8080)`) |
+| Default port | 8050 — override in code: `app.run(port=int(os.environ.get("DATABRICKS_APP_PORT", 8000)))` |
 | Auth header | `request.headers.get('x-forwarded-access-token')` (Flask under the hood) |
 
 **Databricks tips**:
@@ -84,6 +84,7 @@ def get_connection():
 **Critical**: Use `gr.Request` parameter to access auth headers.
 
 ```python
+import os
 import gradio as gr
 import requests
 from databricks.sdk.core import Config
@@ -102,14 +103,15 @@ def predict(message, request: gr.Request):
     return resp.json()["predictions"][0]
 
 demo = gr.Interface(fn=predict, inputs="text", outputs="text")
-demo.launch(server_name="0.0.0.0", server_port=8080)
+port = int(os.environ.get("DATABRICKS_APP_PORT", 8000))
+demo.launch(server_name="0.0.0.0", server_port=port)
 ```
 
 | Detail | Value |
 |--------|-------|
 | Pre-installed version | 4.44.0 |
 | app.yaml command | `["python", "app.py"]` |
-| Default port | 7860 (override with `server_port=8080` or `GRADIO_SERVER_PORT=8080`) |
+| Default port | 7860 — override in code: `server_port=int(os.environ.get("DATABRICKS_APP_PORT", 8000))` |
 | Auth header | `request.headers.get('x-forwarded-access-token')` via `gr.Request` |
 
 **Databricks tips**:
@@ -150,7 +152,7 @@ def get_data():
 | Detail | Value |
 |--------|-------|
 | Pre-installed version | 3.0.3 |
-| app.yaml command | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8080"]` |
+| app.yaml command | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8000"]` |
 | Auth header | `request.headers.get('x-forwarded-access-token')` |
 
 **Databricks tips**:
@@ -190,7 +192,7 @@ async def get_data(request: Request):
 | Detail | Value |
 |--------|-------|
 | Pre-installed version | 0.115.0 |
-| app.yaml command | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]` |
+| app.yaml command | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]` |
 | Auth header | `request.headers.get('x-forwarded-access-token')` via `Request` |
 
 **Databricks tips**:
@@ -241,6 +243,6 @@ class State(rx.State):
 - All frameworks are **pre-installed** — no need to add them to `requirements.txt`
 - Add only additional packages your app needs to `requirements.txt`
 - SDK `Config()` auto-detects credentials from injected environment variables
-- Databricks Apps expects apps to listen on **port 8080** (configure your framework accordingly)
+- Apps must bind to `DATABRICKS_APP_PORT` env var (defaults to 8000). Streamlit is auto-configured by the runtime; for other frameworks, read the env var in code or hardcode 8000 in `app.yaml` command. **Never use 8080**
 - For framework-specific deployment commands, see [4-deployment.md](4-deployment.md)
 - For authorization integration, see [1-authorization.md](1-authorization.md)

--- a/databricks-skills/databricks-app-python/4-deployment.md
+++ b/databricks-skills/databricks-app-python/4-deployment.md
@@ -31,8 +31,8 @@ env:
 | Dash | `["python", "app.py"]` |
 | Streamlit | `["streamlit", "run", "app.py"]` |
 | Gradio | `["python", "app.py"]` |
-| Flask | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8080"]` |
-| FastAPI | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]` |
+| Flask | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8000"]` |
+| FastAPI | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]` |
 | Reflex | `["reflex", "run", "--env", "prod"]` |
 
 ### Step 2: Create and Deploy

--- a/databricks-skills/databricks-app-python/SKILL.md
+++ b/databricks-skills/databricks-app-python/SKILL.md
@@ -38,8 +38,8 @@ Copy this checklist and verify each item:
 | **Dash** | Production dashboards, BI tools, complex interactivity | `["python", "app.py"]` |
 | **Streamlit** | Rapid prototyping, data science apps, internal tools | `["streamlit", "run", "app.py"]` |
 | **Gradio** | ML demos, model interfaces, chat UIs | `["python", "app.py"]` |
-| **Flask** | Custom REST APIs, lightweight apps, webhooks | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8080"]` |
-| **FastAPI** | Async APIs, auto-generated OpenAPI docs | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]` |
+| **Flask** | Custom REST APIs, lightweight apps, webhooks | `["gunicorn", "app:app", "-w", "4", "-b", "0.0.0.0:8000"]` |
+| **FastAPI** | Async APIs, auto-generated OpenAPI docs | `["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]` |
 | **Reflex** | Full-stack Python apps without JavaScript | `["reflex", "run", "--env", "prod"]` |
 
 **Default**: Recommend **Streamlit** for prototypes, **Dash** for production dashboards, **FastAPI** for APIs, **Gradio** for ML demos.
@@ -170,7 +170,7 @@ class EntityIn(BaseModel):
 | **Resource not accessible** | Add resource via UI, verify SP has permissions, use `valueFrom` in app.yaml |
 | **Import error on deploy** | Add missing packages to `requirements.txt` (pre-installed packages don't need listing) |
 | **Lakebase app crashes on start** | `psycopg2`/`asyncpg` are NOT pre-installed — MUST add to `requirements.txt` |
-| **Port conflict** | Databricks Apps expects port 8080; configure your framework accordingly |
+| **Port conflict** | Apps must bind to `DATABRICKS_APP_PORT` env var (defaults to 8000). Never use 8080. Streamlit is auto-configured; for others, read the env var in code or use 8000 in app.yaml command |
 | **Streamlit: set_page_config error** | `st.set_page_config()` must be the first Streamlit command |
 | **Dash: unstyled layout** | Add `dash-bootstrap-components`; use `dbc.themes.BOOTSTRAP` |
 | **Slow queries** | Use Lakebase for transactional/low-latency; SQL warehouse for analytical queries |


### PR DESCRIPTION
## Summary

- Fix incorrect port `8080` references across `databricks-app-python` skill files. Per the [official Databricks docs](https://docs.databricks.com/aws/en/dev-tools/databricks-apps/system-env#default-environment-variables), apps must bind to the `DATABRICKS_APP_PORT` environment variable which defaults to **8000**.
- Using 8080 causes deployed apps to show "App Not Available" because the gateway routes traffic to `DATABRICKS_APP_PORT` (8000).
- Verified by deploying test apps on a live workspace: port 8000 works, port 8080 does not.

## Changes

| File | What changed |
|------|-------------|
| `SKILL.md` | Flask/FastAPI commands `8080`→`8000`; port conflict row now references `DATABRICKS_APP_PORT` |
| `3-frameworks.md` | Flask/FastAPI/Gradio commands `8080`→`8000`; Gradio code example reads `DATABRICKS_APP_PORT`; Dash/Gradio port override notes updated; common section references `DATABRICKS_APP_PORT` |
| `4-deployment.md` | Flask/FastAPI commands `8080`→`8000` |

## Test plan

- [x] Deployed FastAPI app with port 8000 on live workspace — works
- [x] Deployed FastAPI app with port 8080 on live workspace — "App Not Available"
- [x] Confirmed `DATABRICKS_APP_PORT` defaults to 8000 per official docs