### PR TITLE
updated zerobus-ingest client files with latest sdk syntax recommendations

### DIFF
--- a/databricks-skills/databricks-zerobus-ingest/2-python-client.md
+++ b/databricks-skills/databricks-zerobus-ingest/2-python-client.md
@@ -11,12 +11,14 @@ Python SDK patterns for Zerobus Ingest: synchronous and asynchronous APIs, JSON 
 from zerobus.sdk.sync import ZerobusSdk
 
 # Asynchronous API (equivalent capabilities)
-from zerobus.sdk.asyncio import ZerobusSdk as AsyncZerobusSdk
+from zerobus.sdk.aio import ZerobusSdk as AsyncZerobusSdk
 
 # Shared types (used by both sync and async)
 from zerobus.sdk.shared import (
     RecordType,
-    IngestRecordResponse,
+    AckCallback,
+    ZerobusException,
+    NonRetriableException,
     StreamConfigurationOptions,
     TableProperties,
 )
@@ -49,8 +51,8 @@ stream = sdk.create_stream(client_id, client_secret, table_props, options)
 try:
     for i in range(100):
         record = {"device_name": f"sensor-{i}", "temp": 22, "humidity": 55}
-        ack = stream.ingest_record(record)
-        ack.wait_for_ack()  # Block until durably written
+        offset = stream.ingest_record_offset(record)
+        stream.wait_for_offset(offset)  # Block until durably written
 finally:
     stream.close()
 ``` -->
@@ -90,8 +92,8 @@ try:
             temp=22,
             humidity=55,
         )
-        ack = stream.ingest_record(record)
-        ack.wait_for_ack()
+        offset = stream.ingest_record_offset(record)
+        stream.wait_for_offset(offset)
 finally:
     stream.close()
 ```
@@ -100,17 +102,21 @@ finally:
 
 ## ACK Callback (Asynchronous Acknowledgment)
 
-Instead of blocking on each ACK, register a callback for background durability confirmation:
+Instead of blocking on each ACK, register an `AckCallback` subclass for background durability confirmation:
 
 ```python
-from zerobus.sdk.shared import IngestRecordResponse, StreamConfigurationOptions, RecordType
+from zerobus.sdk.shared import AckCallback, StreamConfigurationOptions, RecordType
 
-def on_ack(response: IngestRecordResponse) -> None:
-    print(f"Durable up to offset: {response.durability_ack_up_to_offset}")
+class MyAckHandler(AckCallback):
+    def on_ack(self, offset: int) -> None:
+        print(f"Durable up to offset: {offset}")
+
+    def on_error(self, offset: int, message: str) -> None:
+        print(f"Error at offset {offset}: {message}")
 
 options = StreamConfigurationOptions(
     record_type=RecordType.JSON,
-    ack_callback=on_ack,
+    ack_callback=MyAckHandler(),
 )
 
 # Create stream with callback
@@ -119,7 +125,7 @@ stream = sdk.create_stream(client_id, client_secret, table_props, options)
 try:
     for i in range(1000):
         record = {"device_name": f"sensor-{i}", "temp": 22, "humidity": 55}
-        stream.ingest_record(record)  # Non-blocking, ACKs arrive via callback
+        stream.ingest_record_nowait(record)  # Fire-and-forget, ACKs arrive via callback
     stream.flush()  # Ensure all buffered records are sent
 finally:
     stream.close()
@@ -135,12 +141,12 @@ A production-ready wrapper with retry logic, reconnection, and both JSON and Pro
 import os
 import time
 import logging
-from typing import Optional, Callable
+from typing import Optional
 
 from zerobus.sdk.sync import ZerobusSdk
 from zerobus.sdk.shared import (
     RecordType,
-    IngestRecordResponse,
+    AckCallback,
     StreamConfigurationOptions,
     TableProperties,
 )
@@ -159,7 +165,7 @@ class ZerobusClient:
         client_id: str,
         client_secret: str,
         record_type: RecordType = RecordType.JSON,
-        ack_callback: Optional[Callable[[IngestRecordResponse], None]] = None,
+        ack_callback: Optional[AckCallback] = None,
         proto_descriptor=None,
     ):
         self.server_endpoint = server_endpoint
@@ -199,8 +205,8 @@ class ZerobusClient:
             try:
                 if self.stream is None:
                     self.init_stream()
-                ack = self.stream.ingest_record(payload)
-                ack.wait_for_ack()
+                offset = self.stream.ingest_record_offset(payload)
+                self.stream.wait_for_offset(offset)
                 return True
             except Exception as e:
                 err = str(e).lower()
@@ -275,7 +281,7 @@ The SDK provides an equivalent async API for use with `asyncio`:
 
 ```python
 import asyncio
-from zerobus.sdk.asyncio import ZerobusSdk as AsyncZerobusSdk
+from zerobus.sdk.aio import ZerobusSdk as AsyncZerobusSdk
 from zerobus.sdk.shared import RecordType, StreamConfigurationOptions, TableProperties
 
 
@@ -289,8 +295,8 @@ async def ingest_async():
     try:
         for i in range(100):
             record = {"device_name": f"sensor-{i}", "temp": 22, "humidity": 55}
-            ack = await stream.ingest_record(record)
-            await ack.wait_for_ack()
+            offset = await stream.ingest_record_offset(record)
+            await stream.wait_for_offset(offset)
     finally:
         await stream.close()
 
@@ -304,7 +310,7 @@ asyncio.run(ingest_async())
 
 ## Batch Pattern
 
-For higher throughput, send records without blocking on each ACK and flush at the end:
+For higher throughput, use `ingest_record_nowait` (fire-and-forget) or batch methods, and flush at the end:
 
 ```python
 with ZerobusClient(
@@ -314,10 +320,39 @@ with ZerobusClient(
     client_id=os.environ["DATABRICKS_CLIENT_ID"],
     client_secret=os.environ["DATABRICKS_CLIENT_SECRET"],
     record_type=RecordType.JSON,
-    ack_callback=lambda resp: None,  # Discard individual ACKs
 ) as client:
     for i in range(10_000):
         record = {"device_name": f"sensor-{i}", "temp": 22, "humidity": 55}
-        client.stream.ingest_record(record)  # Non-blocking
+        client.stream.ingest_record_nowait(record)  # Fire-and-forget
     # flush() and close() called automatically by context manager
 ```
+
+For true batch ingestion, use the batch variants:
+
+```python
+records = [
+    {"device_name": f"sensor-{i}", "temp": 22, "humidity": 55}
+    for i in range(10_000)
+]
+# Fire-and-forget batch
+stream.ingest_records_nowait(records)
+stream.flush()
+
+# Or with offset tracking
+offset = stream.ingest_records_offset(records)
+stream.wait_for_offset(offset)
+```
+
+---
+
+## Ingestion Method Comparison
+
+| Method | Returns | Blocks? | Best For |
+|--------|---------|---------|----------|
+| `ingest_record_offset(record)` | offset | No (enqueues) | Single record with durability tracking |
+| `ingest_record_nowait(record)` | None | No | Max single-record throughput |
+| `ingest_records_offset(records)` | last offset | No (enqueues) | Batch with durability tracking |
+| `ingest_records_nowait(records)` | None | No | Max batch throughput |
+| `wait_for_offset(offset)` | None | Yes (until ACK) | Durability confirmation |
+| `flush()` | None | Yes (until sent) | Ensure all buffered records are sent |
+| `ingest_record(record)` | RecordAcknowledgment | No | **Deprecated** — use `ingest_record_offset` |

--- a/databricks-skills/databricks-zerobus-ingest/3-multilanguage-clients.md
+++ b/databricks-skills/databricks-zerobus-ingest/3-multilanguage-clients.md
@@ -51,7 +51,8 @@ public class ZerobusProducer {
                     .setTemp(22)
                     .setHumidity(55)
                     .build();
-                stream.ingestRecord(record).join();
+                long offset = stream.ingestRecordOffset(record);
+                stream.waitForOffset(offset);
             }
         } finally {
             stream.close();
@@ -126,12 +127,12 @@ func main() {
         record := fmt.Sprintf(
             `{"device_name": "sensor-%d", "temp": 22, "humidity": 55}`, i,
         )
-        ack, err := stream.IngestRecord(record)
+        offset, err := stream.IngestRecordOffset(record)
         if err != nil {
             log.Printf("Ingest failed for record %d: %v", i, err)
             continue
         }
-        ack.Await()
+        stream.WaitForOffset(offset)
     }
 
     stream.Flush()
@@ -187,7 +188,8 @@ const stream = await sdk.createStream(
 try {
   for (let i = 0; i < 100; i++) {
     const record = { device_name: `sensor-${i}`, temp: 22, humidity: 55 };
-    await stream.ingestRecord(record);
+    const offset = await stream.ingestRecordOffset(record);
+    await stream.waitForOffset(offset);
   }
   await stream.flush();
 } finally {
@@ -207,7 +209,8 @@ async function ingestWithRetry(
 ): Promise<boolean> {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      await stream.ingestRecord(record);
+      const offset = await stream.ingestRecordOffset(record);
+      await stream.waitForOffset(offset);
       return true;
     } catch (error) {
       console.warn(`Attempt ${attempt + 1}/${maxRetries} failed:`, error);
@@ -268,8 +271,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             r#"{{"device_name": "sensor-{}", "temp": 22, "humidity": 55}}"#,
             i
         );
-        let ack = stream.ingest_record(record.into_bytes()).await?;
-        ack.await?;
+        let offset = stream.ingest_record_offset(record.into_bytes()).await?;
+        stream.wait_for_offset(offset).await?;
     }
 
     stream.close().await?;
@@ -296,8 +299,8 @@ let mut stream = sdk
 
 // Ingest serialized protobuf bytes
 let record_bytes = my_proto_message.encode_to_vec();
-let ack = stream.ingest_record(record_bytes).await?;
-ack.await?;
+let offset = stream.ingest_record_offset(record_bytes).await?;
+stream.wait_for_offset(offset).await?;
 ```
 
 ---
@@ -310,5 +313,5 @@ ack.await?;
 | Package | `databricks-zerobus-ingest-sdk` | `com.databricks:zerobus-ingest-sdk` | `github.com/databricks/zerobus-sdk-go` | `@databricks/zerobus-ingest-sdk` | `databricks-zerobus-ingest-sdk` |
 | Default serialization | JSON | Protobuf | JSON | JSON | JSON |
 | Async API | Yes (separate module) | CompletableFuture | Goroutines | Native async/await | Tokio async/await |
-| ACK pattern | `ack.wait_for_ack()` or callback | `.join()` | `ack.Await()` | Implicit in `await` | `ack.await?` |
+| ACK pattern | `wait_for_offset(offset)` or `AckCallback` | `waitForOffset(offset)` | `WaitForOffset(offset)` | `await waitForOffset(offset)` | `wait_for_offset(offset).await?` |
 | Proto generation | `python -m zerobus.tools.generate_proto` | JAR CLI tool | External `protoc` | External `protoc` | External `protoc` |

--- a/databricks-skills/databricks-zerobus-ingest/5-operations-and-limits.md
+++ b/databricks-skills/databricks-zerobus-ingest/5-operations-and-limits.md
@@ -12,40 +12,44 @@ Every ingested record returns a durability acknowledgment. An ACK indicates that
 
 | Strategy | When to Use | Trade-off |
 |----------|-------------|-----------|
-| **Sync block per record** | Low-volume, strict ordering | Simplest; lower throughput |
-| **ACK callback** | High-volume producers | Higher throughput; more complex |
-| **Periodic flush** | Batch-oriented workloads | Best throughput; eventual consistency |
+| **`ingest_record_offset` + `wait_for_offset`** | Low-volume, strict ordering | Simplest; lower throughput |
+| **`ingest_record_nowait` + `AckCallback`** | High-volume producers | Higher throughput; more complex |
+| **`ingest_record_nowait` + periodic `flush`** | Batch-oriented workloads | Best throughput; eventual consistency |
 
 ### Sync Block (Python)
 
 ```python
-ack = stream.ingest_record(record)
-ack.wait_for_ack()  # Blocks until durable
+offset = stream.ingest_record_offset(record)
+stream.wait_for_offset(offset)  # Blocks until durable
 ```
 
 ### ACK Callback (Python)
 
 ```python
-from zerobus.sdk.shared import IngestRecordResponse
+from zerobus.sdk.shared import AckCallback
 
-last_acked_offset = 0
+class MyAckHandler(AckCallback):
+    def __init__(self):
+        self.last_acked_offset = 0
 
-def on_ack(response: IngestRecordResponse) -> None:
-    global last_acked_offset
-    last_acked_offset = response.durability_ack_up_to_offset
+    def on_ack(self, offset: int) -> None:
+        self.last_acked_offset = offset
+
+    def on_error(self, offset: int, message: str) -> None:
+        print(f"Error at offset {offset}: {message}")
 
 options = StreamConfigurationOptions(
     record_type=RecordType.JSON,
-    ack_callback=on_ack,
+    ack_callback=MyAckHandler(),
 )
 ```
 
 ### Flush-Based
 
 ```python
-# Send many records without blocking
+# Send many records without blocking (fire-and-forget)
 for record in batch:
-    stream.ingest_record(record)
+    stream.ingest_record_nowait(record)
 
 # Flush ensures all buffered records are sent
 stream.flush()
@@ -89,8 +93,8 @@ def ingest_with_retry(stream_factory, record, max_retries=5):
 
     for attempt in range(max_retries):
         try:
-            ack = stream.ingest_record(record)
-            ack.wait_for_ack()
+            offset = stream.ingest_record_offset(record)
+            stream.wait_for_offset(offset)
             return stream  # Return the (possibly new) stream
         except Exception as e:
             err = str(e).lower()

--- a/databricks-skills/databricks-zerobus-ingest/SKILL.md
+++ b/databricks-skills/databricks-zerobus-ingest/SKILL.md
@@ -95,8 +95,8 @@ table_props = TableProperties(table_name)
 stream = sdk.create_stream(client_id, client_secret, table_props, options)
 try:
     record = {"device_name": "sensor-1", "temp": 22, "humidity": 55}
-    ack = stream.ingest_record(record)
-    ack.wait_for_ack()
+    offset = stream.ingest_record_offset(record)
+    stream.wait_for_offset(offset)
 finally:
     stream.close()
 ```
@@ -193,7 +193,7 @@ The timestamp generation must use microseconds for Databricks.
 - **gRPC + Protobuf**: Zerobus uses gRPC as its transport protocol. Any application that can communicate via gRPC and construct Protobuf messages can produce to Zerobus.
 - **JSON or Protobuf serialization**: JSON for quick starts; Protobuf for type safety, forward compatibility, and performance.
 - **At-least-once delivery**: The connector provides at-least-once guarantees. Design consumers to handle duplicates.
-- **Durability ACKs**: Each ingested record returns an ACK confirming durable write. ACKs indicate all records up to that offset have been durably written.
+- **Durability ACKs**: Each ingested record returns an offset. Use `wait_for_offset(offset)` to confirm durable write. ACKs indicate all records up to that offset have been durably written.
 - **No table management**: Zerobus does not create or alter tables. You must pre-create your target table and manage schema evolution yourself.
 - **Single-AZ durability**: The service runs in a single availability zone. Plan for potential zone outages.
 


### PR DESCRIPTION
Zerobus SDK was recently updated to use `stream.ingest_record_offset()` / `stream.wait_for_offset()` instead of `stream.ingest_record()` / `stream.wait_for_ack()`. Modified Zerobus skill to prioritize the new pattern.