### PR TITLE
Fix Vector Search MCP tool names; add end-to-end RAG walkthrough

### DIFF
--- a/databricks-skills/databricks-vector-search/SKILL.md
+++ b/databricks-skills/databricks-vector-search/SKILL.md
@@ -249,7 +249,10 @@ scan_result = w.vector_search_indexes.scan_index(
 
 ## Reference Files
 
-- [index-types.md](index-types.md) - Detailed comparison of index types and creation patterns
+| Topic | File | Description |
+|-------|------|-------------|
+| Index Types | [index-types.md](index-types.md) | Detailed comparison of Delta Sync (managed/self-managed) vs Direct Access |
+| End-to-End RAG | [end-to-end-rag.md](end-to-end-rag.md) | Complete walkthrough: source table → endpoint → index → query → agent integration |
 
 ## CLI Quick Reference
 
@@ -311,37 +314,44 @@ embedding_source_columns=[
 
 ## MCP Tools
 
-The following MCP tools are available for managing Vector Search infrastructure. These are **management tools** for creating and configuring endpoints/indexes. For agent-runtime querying, use the Databricks managed Vector Search MCP server or `VectorSearchRetrieverTool`.
+The following MCP tools are available for managing Vector Search infrastructure. For a full end-to-end walkthrough, see [end-to-end-rag.md](end-to-end-rag.md).
 
 ### Endpoint Management
 
 | Tool | Description |
 |------|-------------|
-| `create_or_update_vs_endpoint` | Create endpoint if it doesn't exist, or return existing (STANDARD or STORAGE_OPTIMIZED) |
-| `get_vs_endpoint` | Get endpoint details by name, or list all endpoints (omit name) |
+| `create_vs_endpoint` | Create endpoint (STANDARD or STORAGE_OPTIMIZED). Async — check status with `get_vs_endpoint` |
+| `get_vs_endpoint` | Get endpoint details and status by name |
+| `list_vs_endpoints` | List all Vector Search endpoints in the workspace |
 | `delete_vs_endpoint` | Delete an endpoint (indexes must be deleted first) |
 
 ### Index Management
 
 | Tool | Description |
 |------|-------------|
-| `create_or_update_vs_index` | Create index if it doesn't exist; auto-triggers initial sync for DELTA_SYNC |
-| `get_vs_index` | Get index details by name, or list indexes on endpoint (pass endpoint_name only) |
+| `create_vs_index` | Create a Delta Sync or Direct Access index on an endpoint |
+| `get_vs_index` | Get index details, status, and configuration |
+| `list_vs_indexes` | List all indexes on an endpoint |
 | `delete_vs_index` | Delete an index |
+| `sync_vs_index` | Trigger sync for TRIGGERED pipeline indexes |
 
 ### Query and Data
 
 | Tool | Description |
 |------|-------------|
-| `query_vs_index` | Query index with text, vector, or hybrid search (for testing) |
-| `manage_vs_data` | Upsert, delete, scan, or sync index data (operation: "upsert", "delete", "scan", or "sync") |
+| `query_vs_index` | Query index with `query_text`, `query_vector`, or hybrid (`query_type="HYBRID"`) |
+| `upsert_vs_data` | Upsert vectors into a Direct Access index |
+| `delete_vs_data` | Delete vectors from a Direct Access index by primary key |
+| `scan_vs_index` | Retrieve all vectors from an index (for debugging/export) |
 
 ## Notes
 
-- **Storage-Optimized is newer** - Better for most use cases unless you need <100ms latency
-- **Delta Sync recommended** - Easier than Direct Access for most scenarios
-- **Hybrid search** - Available for both Delta Sync and Direct Access indexes
-- **Management vs runtime** - MCP tools above handle lifecycle management; for agent tool-calling at runtime, use the Databricks managed Vector Search MCP server
+- **Storage-Optimized is newer** — better for most use cases unless you need <100ms latency
+- **Delta Sync recommended** — easier than Direct Access for most scenarios
+- **Hybrid search** — available for both Delta Sync and Direct Access indexes
+- **`columns_to_sync` matters** — only synced columns are available in query results; include all columns you need
+- **Filter syntax differs by endpoint** — Standard uses `filters_json` (dict), Storage-Optimized uses `filter_string` (SQL)
+- **Management vs runtime** — MCP tools above handle lifecycle management; for agent tool-calling at runtime, use `VectorSearchRetrieverTool` or the Databricks managed Vector Search MCP server
 
 ## Related Skills
 

--- a/databricks-skills/databricks-vector-search/end-to-end-rag.md
+++ b/databricks-skills/databricks-vector-search/end-to-end-rag.md
@@ -1,0 +1,239 @@
+# End-to-End RAG with Vector Search
+
+Build a complete Retrieval-Augmented Generation pipeline: prepare documents, create a vector index, query it, and wire it into an agent.
+
+## MCP Tools Used
+
+| Tool | Step |
+|------|------|
+| `execute_sql` | Create source table, insert documents |
+| `create_vs_endpoint` | Create compute endpoint |
+| `create_vs_index` | Create Delta Sync index with managed embeddings |
+| `sync_vs_index` | Trigger index sync |
+| `get_vs_index` | Check index status |
+| `query_vs_index` | Test similarity search |
+
+---
+
+## Step 1: Prepare Source Table
+
+The source Delta table needs a primary key column and a text column to embed.
+
+```sql
+CREATE TABLE IF NOT EXISTS catalog.schema.knowledge_base (
+    doc_id STRING,
+    title STRING,
+    content STRING,
+    category STRING,
+    updated_at TIMESTAMP DEFAULT current_timestamp()
+);
+
+INSERT INTO catalog.schema.knowledge_base VALUES
+('doc-001', 'Getting Started', 'Databricks is a unified analytics platform...', 'overview', current_timestamp()),
+('doc-002', 'Unity Catalog', 'Unity Catalog provides centralized governance...', 'governance', current_timestamp()),
+('doc-003', 'Delta Lake', 'Delta Lake is an open-source storage layer...', 'storage', current_timestamp());
+```
+
+Or via MCP:
+
+```python
+execute_sql(sql_query="""
+    CREATE TABLE IF NOT EXISTS catalog.schema.knowledge_base (
+        doc_id STRING,
+        title STRING,
+        content STRING,
+        category STRING,
+        updated_at TIMESTAMP DEFAULT current_timestamp()
+    )
+""")
+```
+
+## Step 2: Create Vector Search Endpoint
+
+```python
+create_vs_endpoint(
+    name="my-rag-endpoint",
+    endpoint_type="STORAGE_OPTIMIZED"
+)
+```
+
+Endpoint creation is asynchronous. Check status:
+
+```python
+get_vs_endpoint(name="my-rag-endpoint")
+# Wait for state: "ONLINE"
+```
+
+## Step 3: Create Delta Sync Index
+
+```python
+create_vs_index(
+    name="catalog.schema.knowledge_base_index",
+    endpoint_name="my-rag-endpoint",
+    primary_key="doc_id",
+    index_type="DELTA_SYNC",
+    delta_sync_index_spec={
+        "source_table": "catalog.schema.knowledge_base",
+        "embedding_source_columns": [
+            {
+                "name": "content",
+                "embedding_model_endpoint_name": "databricks-gte-large-en"
+            }
+        ],
+        "pipeline_type": "TRIGGERED",
+        "columns_to_sync": ["doc_id", "title", "content", "category"]
+    }
+)
+```
+
+Key decisions:
+- **`embedding_source_columns`**: Databricks computes embeddings automatically from the `content` column
+- **`pipeline_type`**: `TRIGGERED` for manual sync (cheaper), `CONTINUOUS` for auto-sync on table changes
+- **`columns_to_sync`**: Only sync columns you need in query results (reduces storage and improves performance)
+
+## Step 4: Sync and Verify
+
+```python
+# Trigger initial sync
+sync_vs_index(index_name="catalog.schema.knowledge_base_index")
+
+# Check status
+get_vs_index(index_name="catalog.schema.knowledge_base_index")
+# Wait for state: "ONLINE"
+```
+
+## Step 5: Query the Index
+
+```python
+# Semantic search
+query_vs_index(
+    index_name="catalog.schema.knowledge_base_index",
+    columns=["doc_id", "title", "content", "category"],
+    query_text="How do I govern my data?",
+    num_results=3
+)
+```
+
+### With Filters
+
+The filter syntax depends on the endpoint type used when creating the index.
+
+```python
+# Storage-Optimized endpoint (used in this walkthrough): SQL-like filter_string
+query_vs_index(
+    index_name="catalog.schema.knowledge_base_index",
+    columns=["doc_id", "title", "content"],
+    query_text="How do I govern my data?",
+    num_results=3,
+    filter_string="category = 'governance'"
+)
+
+# Standard endpoint (if you created a Standard endpoint instead): JSON filters_json
+query_vs_index(
+    index_name="catalog.schema.my_standard_index",
+    columns=["doc_id", "title", "content"],
+    query_text="How do I govern my data?",
+    num_results=3,
+    filters_json='{"category": "governance"}'
+)
+```
+
+### Hybrid Search (Vector + Keyword)
+
+```python
+query_vs_index(
+    index_name="catalog.schema.knowledge_base_index",
+    columns=["doc_id", "title", "content"],
+    query_text="Delta Lake ACID transactions",
+    num_results=5,
+    query_type="HYBRID"
+)
+```
+
+---
+
+## Step 6: Use in an Agent
+
+### As a Tool in a ChatAgent
+
+Use `VectorSearchRetrieverTool` to wire the index into an agent deployed on Model Serving:
+
+```python
+from databricks.agents import ChatAgent
+from databricks.agents.tools import VectorSearchRetrieverTool
+from databricks.sdk import WorkspaceClient
+
+# Define the retriever tool
+retriever_tool = VectorSearchRetrieverTool(
+    index_name="catalog.schema.knowledge_base_index",
+    columns=["doc_id", "title", "content"],
+    num_results=3,
+)
+
+class RAGAgent(ChatAgent):
+    def __init__(self):
+        self.w = WorkspaceClient()
+
+    def predict(self, messages, context=None):
+        query = messages[-1].content
+
+        results = self.w.vector_search_indexes.query_index(
+            index_name="catalog.schema.knowledge_base_index",
+            columns=["title", "content"],
+            query_text=query,
+            num_results=3,
+        )
+
+        context_docs = "\n\n".join(
+            f"**{row[0]}**: {row[1]}"
+            for row in results.result.data_array
+        )
+
+        response = self.w.serving_endpoints.query(
+            name="databricks-meta-llama-3-3-70b-instruct",
+            messages=[
+                {"role": "system", "content": f"Answer using this context:\n{context_docs}"},
+                {"role": "user", "content": query},
+            ],
+        )
+
+        return {"content": response.choices[0].message.content}
+```
+
+---
+
+## Updating the Index
+
+### Add New Documents
+
+```sql
+INSERT INTO catalog.schema.knowledge_base VALUES
+('doc-004', 'MLflow', 'MLflow is an open-source platform for ML lifecycle...', 'ml', current_timestamp());
+```
+
+Then sync:
+
+```python
+sync_vs_index(index_name="catalog.schema.knowledge_base_index")
+```
+
+### Delete Documents
+
+```sql
+DELETE FROM catalog.schema.knowledge_base WHERE doc_id = 'doc-001';
+```
+
+Then sync — the index automatically handles deletions via Delta change data feed.
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **Index stuck in PROVISIONING** | Endpoint may still be creating. Check `get_vs_endpoint` first |
+| **Query returns no results** | Index may not be synced yet. Run `sync_vs_index` and wait for ONLINE state |
+| **"Column not found in index"** | Column must be in `columns_to_sync`. Recreate index with the column included |
+| **Embeddings not computed** | Ensure `embedding_model_endpoint_name` is a valid serving endpoint |
+| **Stale results after table update** | For TRIGGERED pipelines, you must call `sync_vs_index` manually |
+| **Filter not working** | Standard endpoints use `filters_json` (dict), Storage-Optimized use `filter_string` (SQL) |

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -113,7 +113,7 @@ get_skill_extra_files() {
         "databricks-mlflow-evaluation") echo "references/CRITICAL-interfaces.md references/GOTCHAS.md references/patterns-context-optimization.md references/patterns-datasets.md references/patterns-evaluation.md references/patterns-scorers.md references/patterns-trace-analysis.md references/user-journeys.md" ;;
         "databricks-spark-declarative-pipelines") echo "1-ingestion-patterns.md 2-streaming-patterns.md 3-scd-patterns.md 4-performance-tuning.md 5-python-api.md 6-dlt-migration.md 7-advanced-configuration.md 8-project-initialization.md" ;;
         "databricks-spark-structured-streaming") echo "checkpoint-best-practices.md kafka-streaming.md merge-operations.md multi-sink-writes.md stateful-operations.md stream-static-joins.md stream-stream-joins.md streaming-best-practices.md trigger-and-cost-optimization.md" ;;
-        "databricks-vector-search") echo "index-types.md" ;;
+        "databricks-vector-search") echo "index-types.md end-to-end-rag.md" ;;
         "databricks-zerobus-ingest") echo "1-setup-and-authentication.md 2-python-client.md 3-multilanguage-clients.md 4-protobuf-schema.md 5-operations-and-limits.md" ;;
         *) echo "" ;;
     esac


### PR DESCRIPTION
## Summary

Addresses #106.

**Bug fix — incorrect MCP tool names in SKILL.md:**
- Replaced non-existent consolidated tools (`create_or_update_vs_endpoint`, `manage_vs_data`) with actual individual tools (`create_vs_endpoint`, `list_vs_endpoints`, `sync_vs_index`, `upsert_vs_data`, etc.)
- This was a real bug — agents would fail trying to call tools that don't exist

**New file — `end-to-end-rag.md`:**
- Complete walkthrough: source table → endpoint → index → query → agent
- Covers `columns_to_sync` guidance, filter syntax differences (Standard vs Storage-Optimized), hybrid search
- Shows `VectorSearchRetrieverTool` integration for `ChatAgent`

All MCP tool names verified against live workspace.

## Test plan
- [x] MCP tool names verified against tool JSON schemas and live workspace
- [x] Filter syntax differences (Standard vs Storage-Optimized) documented correctly
- [x] install_skills.sh updated with new extra file