### PR TITLE
Add new Terraform skill for Databricks infrastructure-as-code

### DIFF
--- a/databricks-skills/databricks-terraform/1-provider-and-auth.md
+++ b/databricks-skills/databricks-terraform/1-provider-and-auth.md
@@ -1,0 +1,207 @@
+# Provider Configuration & Authentication
+
+## Provider Block
+
+```hcl
+terraform {
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = "~> 1.110"
+    }
+  }
+}
+```
+
+Always pin the provider version to avoid unexpected breaking changes.
+
+---
+
+## Authentication Patterns
+
+### Personal Access Token (Simplest)
+
+```hcl
+provider "databricks" {
+  host  = var.databricks_host
+  token = var.databricks_token
+}
+```
+
+```hcl
+variable "databricks_host" {
+  description = "Databricks workspace URL (e.g., https://adb-1234567890.1.azuredatabricks.net)"
+  type        = string
+}
+
+variable "databricks_token" {
+  description = "Databricks personal access token"
+  type        = string
+  sensitive   = true
+}
+```
+
+### Environment Variables
+
+```bash
+export DATABRICKS_HOST="https://my-workspace.cloud.databricks.com"
+export DATABRICKS_TOKEN="dapi..."
+```
+
+```hcl
+provider "databricks" {}
+```
+
+### Databricks CLI Profile
+
+```hcl
+provider "databricks" {
+  profile = "my-profile"
+}
+```
+
+Uses `~/.databrickscfg` profile configuration.
+
+---
+
+## AWS Authentication
+
+### Service Principal (OAuth M2M) — Recommended for CI/CD
+
+```hcl
+provider "databricks" {
+  host          = var.databricks_host
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+```
+
+### AWS IAM Role (Account-Level)
+
+```hcl
+provider "databricks" {
+  host       = "https://accounts.cloud.databricks.com"
+  account_id = var.databricks_account_id
+}
+```
+
+---
+
+## Azure Authentication
+
+### Service Principal with Client Secret
+
+```hcl
+provider "databricks" {
+  host                        = var.databricks_host
+  azure_tenant_id             = var.azure_tenant_id
+  azure_client_id             = var.azure_client_id
+  azure_client_secret         = var.azure_client_secret
+}
+```
+
+### Azure CLI
+
+```hcl
+provider "databricks" {
+  host = var.databricks_host
+}
+```
+
+Requires `az login` before running Terraform.
+
+### Managed Identity (for Azure VMs / Azure DevOps)
+
+```hcl
+provider "databricks" {
+  host                    = var.databricks_host
+  azure_use_msi           = true
+  azure_client_id         = var.msi_client_id  # Optional for user-assigned MI
+}
+```
+
+---
+
+## GCP Authentication
+
+### Service Account
+
+```hcl
+provider "databricks" {
+  host                  = var.databricks_host
+  google_service_account = var.google_service_account
+}
+```
+
+### Google Default Credentials
+
+```hcl
+provider "databricks" {
+  host = var.databricks_host
+}
+```
+
+Requires `gcloud auth application-default login`.
+
+---
+
+## Multi-Provider Configuration
+
+Use aliases when managing resources across workspaces or account + workspace levels.
+
+### Account + Workspace
+
+```hcl
+provider "databricks" {
+  alias      = "account"
+  host       = "https://accounts.cloud.databricks.com"
+  account_id = var.databricks_account_id
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+
+provider "databricks" {
+  alias         = "workspace"
+  host          = var.workspace_host
+  client_id     = var.client_id
+  client_secret = var.client_secret
+}
+
+resource "databricks_group" "admins" {
+  provider     = databricks.account
+  display_name = "workspace-admins"
+}
+
+resource "databricks_cluster" "shared" {
+  provider     = databricks.workspace
+  cluster_name = "shared"
+  # ...
+}
+```
+
+### Multiple Workspaces
+
+```hcl
+provider "databricks" {
+  alias = "dev"
+  host  = var.dev_workspace_host
+  token = var.dev_token
+}
+
+provider "databricks" {
+  alias = "prod"
+  host  = var.prod_workspace_host
+  token = var.prod_token
+}
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"Unauthorized"** | Verify `host` URL includes `https://` and has no trailing slash |
+| **Token expired** | Regenerate PAT; for CI/CD prefer service principal with OAuth |
+| **Azure auth fails** | Ensure service principal has "Contributor" role on the workspace resource |
+| **Account vs workspace confusion** | Account-level resources (groups, metastores) need account-level auth; workspace resources need workspace-level auth |

--- a/databricks-skills/databricks-terraform/2-core-resources.md
+++ b/databricks-skills/databricks-terraform/2-core-resources.md
@@ -1,0 +1,350 @@
+# Core Resources
+
+Common Databricks resources managed via Terraform.
+
+## Clusters
+
+### All-Purpose Cluster
+
+```hcl
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
+resource "databricks_cluster" "shared" {
+  cluster_name            = "shared-analytics"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 30
+
+  autoscale {
+    min_workers = 1
+    max_workers = 4
+  }
+
+  spark_conf = {
+    "spark.databricks.io.cache.enabled" = "true"
+  }
+
+  custom_tags = {
+    "Team"        = "data-engineering"
+    "Environment" = "production"
+  }
+}
+```
+
+### Single-Node Cluster (ML / Development)
+
+```hcl
+resource "databricks_cluster" "single_node" {
+  cluster_name            = "ml-single-node"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = "i3.xlarge"
+  autotermination_minutes = 60
+  num_workers             = 0
+
+  spark_conf = {
+    "spark.databricks.cluster.profile" = "singleNode"
+    "spark.master"                     = "local[*]"
+  }
+}
+```
+
+---
+
+## Jobs
+
+### Notebook Job with Schedule
+
+```hcl
+resource "databricks_job" "daily_etl" {
+  name = "daily-etl"
+
+  task {
+    task_key = "ingest"
+
+    notebook_task {
+      notebook_path = "/Repos/team/etl/ingest"
+      base_parameters = {
+        "env" = "production"
+      }
+    }
+
+    new_cluster {
+      spark_version = data.databricks_spark_version.latest_lts.id
+      node_type_id  = data.databricks_node_type.smallest.id
+      num_workers   = 4
+    }
+  }
+
+  schedule {
+    quartz_cron_expression = "0 0 6 * * ?"
+    timezone_id            = "UTC"
+  }
+
+  email_notifications {
+    on_failure = ["team@company.com"]
+  }
+}
+```
+
+### Multi-Task Job with Dependencies
+
+```hcl
+resource "databricks_job" "pipeline" {
+  name = "data-pipeline"
+
+  task {
+    task_key = "bronze"
+    notebook_task {
+      notebook_path = "/Repos/team/pipeline/bronze"
+    }
+    existing_cluster_id = databricks_cluster.shared.id
+  }
+
+  task {
+    task_key = "silver"
+    depends_on {
+      task_key = "bronze"
+    }
+    notebook_task {
+      notebook_path = "/Repos/team/pipeline/silver"
+    }
+    existing_cluster_id = databricks_cluster.shared.id
+  }
+
+  task {
+    task_key = "gold"
+    depends_on {
+      task_key = "silver"
+    }
+    notebook_task {
+      notebook_path = "/Repos/team/pipeline/gold"
+    }
+    existing_cluster_id = databricks_cluster.shared.id
+  }
+}
+```
+
+### Python Script Job (Serverless)
+
+```hcl
+resource "databricks_job" "serverless_etl" {
+  name = "serverless-etl"
+
+  task {
+    task_key = "run"
+
+    python_wheel_task {
+      package_name = "my_etl"
+      entry_point  = "main"
+    }
+
+    environment_key = "default"
+  }
+
+  environment {
+    environment_key = "default"
+
+    spec {
+      client = "1"
+      dependencies = [
+        "my_etl==1.0.0"
+      ]
+    }
+  }
+}
+```
+
+---
+
+## SQL Warehouses
+
+```hcl
+resource "databricks_sql_endpoint" "analytics" {
+  name             = "analytics-warehouse"
+  cluster_size     = "Small"
+  max_num_clusters = 2
+  auto_stop_mins   = 15
+
+  warehouse_type = "PRO"
+
+  tags {
+    custom_tags {
+      key   = "Team"
+      value = "analytics"
+    }
+  }
+}
+```
+
+### Serverless SQL Warehouse
+
+```hcl
+resource "databricks_sql_endpoint" "serverless" {
+  name                = "serverless-warehouse"
+  cluster_size        = "Small"
+  max_num_clusters    = 1
+  auto_stop_mins      = 10
+  enable_serverless_compute = true
+}
+```
+
+---
+
+## DLT / SDP Pipelines
+
+```hcl
+resource "databricks_pipeline" "etl" {
+  name    = "etl-pipeline"
+  catalog = "analytics"
+  schema  = "silver"
+
+  library {
+    notebook {
+      path = "/Repos/team/pipelines/etl"
+    }
+  }
+
+  continuous  = false
+  development = false
+
+  cluster {
+    label       = "default"
+    num_workers = 4
+  }
+}
+```
+
+---
+
+## Model Serving
+
+```hcl
+resource "databricks_model_serving" "llm_endpoint" {
+  name = "llm-endpoint"
+
+  config {
+    served_entities {
+      entity_name    = "catalog.schema.my_model"
+      entity_version = "1"
+      workload_size  = "Small"
+      scale_to_zero_enabled = true
+    }
+
+    auto_capture_config {
+      catalog_name     = "analytics"
+      schema_name      = "inference_logs"
+      table_name_prefix = "llm_endpoint"
+      enabled          = true
+    }
+  }
+}
+```
+
+---
+
+## Secrets
+
+```hcl
+resource "databricks_secret_scope" "app" {
+  name = "app-secrets"
+}
+
+resource "databricks_secret" "api_key" {
+  scope        = databricks_secret_scope.app.name
+  key          = "api-key"
+  string_value = var.api_key
+}
+```
+
+---
+
+## Instance Pools
+
+```hcl
+resource "databricks_instance_pool" "shared" {
+  instance_pool_name = "shared-pool"
+  node_type_id       = data.databricks_node_type.smallest.id
+
+  min_idle_instances                  = 0
+  max_capacity                        = 20
+  idle_instance_autotermination_minutes = 10
+
+  preloaded_spark_versions = [
+    data.databricks_spark_version.latest_lts.id
+  ]
+}
+
+resource "databricks_cluster" "pooled" {
+  cluster_name            = "pooled-cluster"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  instance_pool_id        = databricks_instance_pool.shared.id
+  autotermination_minutes = 30
+  num_workers             = 2
+}
+```
+
+---
+
+## Cluster Policies
+
+```hcl
+resource "databricks_cluster_policy" "team_policy" {
+  name = "data-engineering-policy"
+
+  definition = jsonencode({
+    "autotermination_minutes" : {
+      "type" : "range",
+      "minValue" : 10,
+      "maxValue" : 120,
+      "defaultValue" : 30
+    },
+    "num_workers" : {
+      "type" : "range",
+      "minValue" : 1,
+      "maxValue" : 10
+    },
+    "node_type_id" : {
+      "type" : "allowlist",
+      "values" : ["i3.xlarge", "i3.2xlarge"]
+    },
+    "custom_tags.Team" : {
+      "type" : "fixed",
+      "value" : "data-engineering"
+    }
+  })
+}
+```
+
+---
+
+## Notebooks
+
+```hcl
+resource "databricks_notebook" "etl" {
+  path     = "/Repos/team/etl/ingest"
+  language = "PYTHON"
+  content_base64 = base64encode(<<-EOT
+    # Databricks notebook source
+    df = spark.read.format("json").load("/Volumes/catalog/schema/volume/data/")
+    df.write.mode("overwrite").saveAsTable("catalog.schema.bronze_events")
+  EOT
+  )
+}
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **Cluster creation fails with "node type not found"** | Use `databricks_node_type` data source instead of hardcoding |
+| **Job fails with "notebook not found"** | Ensure notebook path exists; use `depends_on` if creating notebook in same config |
+| **SQL warehouse stuck creating** | Check workspace quotas; serverless warehouses may need admin enablement |
+| **Pipeline fails to start** | Verify catalog/schema exist and user has permissions |

--- a/databricks-skills/databricks-terraform/3-unity-catalog.md
+++ b/databricks-skills/databricks-terraform/3-unity-catalog.md
@@ -1,0 +1,336 @@
+# Unity Catalog Resources
+
+Manage the full Unity Catalog hierarchy and governance via Terraform.
+
+## Namespace Hierarchy
+
+```
+metastore (account-level)
+└── catalog
+    └── schema
+        ├── table / view / materialized view
+        ├── volume (managed or external)
+        └── function
+```
+
+---
+
+## Metastore (Account-Level)
+
+```hcl
+resource "databricks_metastore" "primary" {
+  provider      = databricks.account
+  name          = "primary-metastore"
+  region        = "us-west-2"
+  storage_root  = "s3://my-metastore-bucket/metastore"
+  force_destroy = true
+}
+
+resource "databricks_metastore_assignment" "default" {
+  provider     = databricks.account
+  metastore_id = databricks_metastore.primary.id
+  workspace_id = var.workspace_id
+}
+```
+
+---
+
+## Catalogs
+
+```hcl
+resource "databricks_catalog" "analytics" {
+  name           = "analytics"
+  comment        = "Production analytics catalog"
+  isolation_mode = "OPEN"
+}
+
+resource "databricks_catalog" "sandbox" {
+  name    = "sandbox"
+  comment = "Development sandbox"
+  properties = {
+    "environment" = "dev"
+  }
+}
+```
+
+### Foreign Catalog (Lakehouse Federation)
+
+```hcl
+resource "databricks_catalog" "postgres_erp" {
+  name            = "erp"
+  comment         = "Federated PostgreSQL ERP database"
+  connection_name = databricks_connection.postgres.name
+
+  options = {
+    "database" = "erp_production"
+  }
+}
+```
+
+---
+
+## Schemas
+
+```hcl
+resource "databricks_schema" "bronze" {
+  catalog_name = databricks_catalog.analytics.name
+  name         = "bronze"
+  comment      = "Raw ingestion layer"
+}
+
+resource "databricks_schema" "silver" {
+  catalog_name = databricks_catalog.analytics.name
+  name         = "silver"
+  comment      = "Cleaned and conformed data"
+}
+
+resource "databricks_schema" "gold" {
+  catalog_name = databricks_catalog.analytics.name
+  name         = "gold"
+  comment      = "Business-level aggregations"
+}
+```
+
+### Medallion Pattern Module
+
+```hcl
+variable "catalog_name" {
+  type = string
+}
+
+variable "layers" {
+  type    = list(string)
+  default = ["bronze", "silver", "gold"]
+}
+
+resource "databricks_schema" "layer" {
+  for_each     = toset(var.layers)
+  catalog_name = var.catalog_name
+  name         = each.value
+  comment      = "${title(each.value)} data layer"
+}
+```
+
+---
+
+## Volumes
+
+```hcl
+resource "databricks_volume" "raw_files" {
+  catalog_name = databricks_catalog.analytics.name
+  schema_name  = databricks_schema.bronze.name
+  name         = "raw_files"
+  volume_type  = "MANAGED"
+  comment      = "Raw ingestion files"
+}
+
+resource "databricks_volume" "landing_zone" {
+  catalog_name     = databricks_catalog.analytics.name
+  schema_name      = databricks_schema.bronze.name
+  name             = "landing_zone"
+  volume_type      = "EXTERNAL"
+  storage_location = "s3://my-bucket/landing/"
+  comment          = "External landing zone"
+}
+```
+
+---
+
+## Storage Credentials & External Locations
+
+```hcl
+resource "databricks_storage_credential" "s3_access" {
+  name = "s3-analytics-credential"
+
+  aws_iam_role {
+    role_arn = var.iam_role_arn
+  }
+
+  comment = "Access to analytics S3 bucket"
+}
+
+resource "databricks_external_location" "landing" {
+  name            = "analytics-landing"
+  url             = "s3://my-bucket/landing/"
+  credential_name = databricks_storage_credential.s3_access.name
+  comment         = "Landing zone for raw data"
+}
+```
+
+---
+
+## Grants
+
+Grants use a single `databricks_grants` resource per securable object.
+
+```hcl
+resource "databricks_grants" "catalog" {
+  catalog = databricks_catalog.analytics.name
+
+  grant {
+    principal  = "data-engineering"
+    privileges = ["USE_CATALOG", "CREATE_SCHEMA"]
+  }
+
+  grant {
+    principal  = "data-analysts"
+    privileges = ["USE_CATALOG"]
+  }
+}
+
+resource "databricks_grants" "schema" {
+  schema = "${databricks_catalog.analytics.name}.${databricks_schema.gold.name}"
+
+  grant {
+    principal  = "data-analysts"
+    privileges = ["USE_SCHEMA", "SELECT"]
+  }
+
+  grant {
+    principal  = "data-engineering"
+    privileges = ["USE_SCHEMA", "SELECT", "MODIFY", "CREATE_TABLE", "CREATE_VOLUME"]
+  }
+}
+
+resource "databricks_grants" "volume" {
+  volume = "${databricks_catalog.analytics.name}.${databricks_schema.bronze.name}.${databricks_volume.raw_files.name}"
+
+  grant {
+    principal  = "data-engineering"
+    privileges = ["READ_VOLUME", "WRITE_VOLUME"]
+  }
+}
+```
+
+### Grant on External Location
+
+```hcl
+resource "databricks_grants" "ext_location" {
+  external_location = databricks_external_location.landing.id
+
+  grant {
+    principal  = "data-engineering"
+    privileges = ["CREATE_EXTERNAL_TABLE", "CREATE_EXTERNAL_VOLUME", "READ_FILES", "WRITE_FILES"]
+  }
+}
+```
+
+---
+
+## Connections (Lakehouse Federation)
+
+```hcl
+resource "databricks_connection" "postgres" {
+  name            = "postgres-erp"
+  connection_type = "POSTGRESQL"
+  comment         = "ERP PostgreSQL database"
+
+  options = {
+    "host"     = var.postgres_host
+    "port"     = "5432"
+    "user"     = var.postgres_user
+    "password" = var.postgres_password
+  }
+}
+```
+
+---
+
+## Delta Sharing
+
+```hcl
+resource "databricks_share" "partner_data" {
+  name = "partner-data-share"
+
+  object {
+    name                        = "analytics.gold.quarterly_metrics"
+    data_object_type            = "TABLE"
+    shared_as                   = "quarterly_metrics"
+  }
+}
+
+resource "databricks_recipient" "partner" {
+  name                = "acme-corp"
+  authentication_type = "TOKEN"
+  comment             = "Acme Corp data team"
+}
+
+resource "databricks_grants" "share_grant" {
+  share = databricks_share.partner_data.name
+
+  grant {
+    principal  = databricks_recipient.partner.name
+    privileges = ["SELECT"]
+  }
+}
+```
+
+---
+
+## Complete Unity Catalog Setup
+
+```hcl
+locals {
+  catalog_name = "analytics"
+  layers       = ["bronze", "silver", "gold"]
+  teams = {
+    "data-engineering" = {
+      catalog_privs = ["USE_CATALOG", "CREATE_SCHEMA"]
+      schema_privs  = ["USE_SCHEMA", "SELECT", "MODIFY", "CREATE_TABLE"]
+    }
+    "data-analysts" = {
+      catalog_privs = ["USE_CATALOG"]
+      schema_privs  = ["USE_SCHEMA", "SELECT"]
+    }
+  }
+}
+
+resource "databricks_catalog" "main" {
+  name    = local.catalog_name
+  comment = "Main analytics catalog"
+}
+
+resource "databricks_schema" "layers" {
+  for_each     = toset(local.layers)
+  catalog_name = databricks_catalog.main.name
+  name         = each.value
+  comment      = "${title(each.value)} data layer"
+}
+
+resource "databricks_grants" "catalog_grants" {
+  catalog = databricks_catalog.main.name
+
+  dynamic "grant" {
+    for_each = local.teams
+    content {
+      principal  = grant.key
+      privileges = grant.value.catalog_privs
+    }
+  }
+}
+
+resource "databricks_grants" "schema_grants" {
+  for_each = databricks_schema.layers
+  schema   = "${databricks_catalog.main.name}.${each.value.name}"
+
+  dynamic "grant" {
+    for_each = local.teams
+    content {
+      principal  = grant.key
+      privileges = grant.value.schema_privs
+    }
+  }
+}
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"Catalog not found" on schema creation** | Ensure catalog resource is referenced (implicit dependency) or use `depends_on` |
+| **Grants conflict** | Only one `databricks_grants` resource per securable object; combine all grants in one block |
+| **External volume fails** | Storage credential and external location must exist first |
+| **Metastore operations fail** | Metastore resources require account-level provider (`provider = databricks.account`) |
+| **Import existing UC objects** | Use `terraform import databricks_catalog.name "catalog_name"` |

--- a/databricks-skills/databricks-terraform/4-best-practices.md
+++ b/databricks-skills/databricks-terraform/4-best-practices.md
@@ -1,0 +1,369 @@
+# Best Practices
+
+Project structure, modules, state management, and CI/CD patterns for Databricks Terraform.
+
+## Project Structure
+
+### Single Workspace
+
+```
+databricks-infra/
+├── main.tf              # Provider config, data sources
+├── variables.tf         # Input variables
+├── outputs.tf           # Output values
+├── terraform.tfvars     # Variable values (gitignored)
+├── clusters.tf          # Cluster resources
+├── jobs.tf              # Job resources
+├── unity-catalog.tf     # UC hierarchy and grants
+├── warehouses.tf        # SQL warehouses
+└── backend.tf           # Remote state config
+```
+
+### Multi-Environment
+
+```
+databricks-infra/
+├── modules/
+│   ├── catalog/         # Reusable UC catalog module
+│   │   ├── main.tf
+│   │   ├── variables.tf
+│   │   └── outputs.tf
+│   ├── cluster/         # Reusable cluster module
+│   └── job/             # Reusable job module
+├── environments/
+│   ├── dev/
+│   │   ├── main.tf      # Module calls with dev values
+│   │   ├── variables.tf
+│   │   ├── terraform.tfvars
+│   │   └── backend.tf
+│   ├── staging/
+│   └── prod/
+└── README.md
+```
+
+---
+
+## Reusable Modules
+
+### Catalog Module
+
+```hcl
+# modules/catalog/variables.tf
+variable "catalog_name" { type = string }
+variable "layers" {
+  type    = list(string)
+  default = ["bronze", "silver", "gold"]
+}
+variable "teams" {
+  type = map(object({
+    catalog_privileges = list(string)
+    schema_privileges  = list(string)
+  }))
+}
+
+# modules/catalog/main.tf
+resource "databricks_catalog" "this" {
+  name    = var.catalog_name
+  comment = "Managed by Terraform"
+}
+
+resource "databricks_schema" "layers" {
+  for_each     = toset(var.layers)
+  catalog_name = databricks_catalog.this.name
+  name         = each.value
+}
+
+resource "databricks_grants" "catalog" {
+  catalog = databricks_catalog.this.name
+
+  dynamic "grant" {
+    for_each = var.teams
+    content {
+      principal  = grant.key
+      privileges = grant.value.catalog_privileges
+    }
+  }
+}
+
+# modules/catalog/outputs.tf
+output "catalog_name" { value = databricks_catalog.this.name }
+output "schema_names" { value = { for k, v in databricks_schema.layers : k => v.name } }
+```
+
+### Usage
+
+```hcl
+module "analytics" {
+  source       = "../../modules/catalog"
+  catalog_name = "analytics"
+
+  teams = {
+    "data-engineering" = {
+      catalog_privileges = ["USE_CATALOG", "CREATE_SCHEMA"]
+      schema_privileges  = ["USE_SCHEMA", "SELECT", "MODIFY", "CREATE_TABLE"]
+    }
+    "data-analysts" = {
+      catalog_privileges = ["USE_CATALOG"]
+      schema_privileges  = ["USE_SCHEMA", "SELECT"]
+    }
+  }
+}
+```
+
+---
+
+## Remote State
+
+### AWS S3
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "my-terraform-state"
+    key            = "databricks/prod/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "terraform-locks"
+    encrypt        = true
+  }
+}
+```
+
+### Azure Blob Storage
+
+```hcl
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "terraform-state-rg"
+    storage_account_name = "tfstateaccount"
+    container_name       = "tfstate"
+    key                  = "databricks/prod/terraform.tfstate"
+  }
+}
+```
+
+### GCS
+
+```hcl
+terraform {
+  backend "gcs" {
+    bucket = "my-terraform-state"
+    prefix = "databricks/prod"
+  }
+}
+```
+
+---
+
+## Variable Management
+
+### Separate Sensitive Variables
+
+```hcl
+# variables.tf
+variable "databricks_host" { type = string }
+variable "databricks_token" {
+  type      = string
+  sensitive = true
+}
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+```
+
+```hcl
+# terraform.tfvars (gitignored)
+databricks_host  = "https://my-workspace.cloud.databricks.com"
+databricks_token = "dapi..."
+environment      = "production"
+```
+
+### Use Locals for Derived Values
+
+```hcl
+locals {
+  name_prefix = "${var.project}-${var.environment}"
+  common_tags = {
+    "Project"     = var.project
+    "Environment" = var.environment
+    "ManagedBy"   = "terraform"
+  }
+}
+
+resource "databricks_cluster" "shared" {
+  cluster_name = "${local.name_prefix}-shared"
+  custom_tags  = local.common_tags
+  # ...
+}
+```
+
+---
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+name: Terraform Databricks
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9"
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Plan
+        run: terraform plan -out=tfplan
+        if: github.event_name == 'pull_request'
+
+      - name: Terraform Apply
+        run: terraform apply -auto-approve tfplan
+        if: github.ref == 'refs/heads/main'
+```
+
+### Azure DevOps
+
+```yaml
+trigger:
+  branches:
+    include: [main]
+
+pool:
+  vmImage: "ubuntu-latest"
+
+steps:
+  - task: TerraformInstaller@0
+    inputs:
+      terraformVersion: "1.9"
+
+  - script: |
+      terraform init
+      terraform plan -out=tfplan
+    env:
+      DATABRICKS_HOST: $(DATABRICKS_HOST)
+      DATABRICKS_TOKEN: $(DATABRICKS_TOKEN)
+
+  - script: terraform apply -auto-approve tfplan
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+    env:
+      DATABRICKS_HOST: $(DATABRICKS_HOST)
+      DATABRICKS_TOKEN: $(DATABRICKS_TOKEN)
+```
+
+---
+
+## Lifecycle Management
+
+### Prevent Accidental Destruction
+
+```hcl
+resource "databricks_catalog" "production" {
+  name = "production"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+```
+
+### Ignore External Changes
+
+```hcl
+resource "databricks_cluster" "shared" {
+  cluster_name = "shared"
+  # ...
+
+  lifecycle {
+    ignore_changes = [
+      spark_conf,
+      custom_tags,
+    ]
+  }
+}
+```
+
+### Import Existing Resources
+
+```bash
+# Import existing catalog
+terraform import databricks_catalog.analytics "analytics"
+
+# Import existing cluster
+terraform import databricks_cluster.shared "<cluster-id>"
+
+# Import existing job
+terraform import databricks_job.etl "<job-id>"
+
+# Import grants
+terraform import 'databricks_grants.catalog' "catalog/analytics"
+```
+
+---
+
+## Common Patterns
+
+### Environment-Specific Sizing
+
+```hcl
+variable "environment" { type = string }
+
+locals {
+  cluster_config = {
+    dev  = { min_workers = 1, max_workers = 2, node_type = "i3.xlarge" }
+    prod = { min_workers = 2, max_workers = 10, node_type = "i3.2xlarge" }
+  }
+  config = local.cluster_config[var.environment]
+}
+
+resource "databricks_cluster" "main" {
+  node_type_id = local.config.node_type
+  autoscale {
+    min_workers = local.config.min_workers
+    max_workers = local.config.max_workers
+  }
+}
+```
+
+### Conditional Resources
+
+```hcl
+variable "enable_monitoring" {
+  type    = bool
+  default = false
+}
+
+resource "databricks_sql_endpoint" "monitoring" {
+  count        = var.enable_monitoring ? 1 : 0
+  name         = "monitoring-warehouse"
+  cluster_size = "Small"
+}
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **State lock stuck** | Force unlock: `terraform force-unlock <lock-id>` |
+| **Drift after manual changes** | Run `terraform plan` to detect; `terraform import` to reconcile |
+| **Circular dependencies** | Use `depends_on` explicitly or restructure resource references |
+| **Slow plan with many resources** | Use `-target` for focused operations; split into smaller state files |
+| **Secrets in state file** | Always use encrypted remote state; never commit `.tfstate` to git |
+| **Provider version conflicts** | Pin version with `version = "~> 1.110"` and run `terraform init -upgrade` |

--- a/databricks-skills/databricks-terraform/SKILL.md
+++ b/databricks-skills/databricks-terraform/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: databricks-terraform
+description: "Generate, validate, and manage Databricks infrastructure using the Databricks Terraform Provider. Use when provisioning workspaces, Unity Catalog objects, clusters, jobs, pipelines, model serving, SQL warehouses, or any Databricks resource via Terraform."
+---
+
+# Databricks Terraform
+
+Infrastructure-as-code for Databricks using the [Databricks Terraform Provider](https://registry.terraform.io/providers/databricks/databricks/latest/docs).
+
+## When to Use This Skill
+
+Use this skill when:
+- Generating `.tf` files for Databricks resources (clusters, jobs, UC objects, pipelines, etc.)
+- Setting up **provider authentication** (PAT, service principal, Azure/AWS/GCP)
+- Scaffolding a **Unity Catalog hierarchy** (metastore → catalog → schema → tables/volumes)
+- Creating reusable **Terraform modules** for Databricks
+- Debugging `terraform plan` or `terraform apply` errors
+- Configuring **remote state** backends (S3, Azure Blob, GCS)
+
+## Reference Files
+
+| Topic | File | Description |
+|-------|------|-------------|
+| Provider & Auth | [1-provider-and-auth.md](1-provider-and-auth.md) | Provider configuration, authentication patterns for AWS/Azure/GCP |
+| Core Resources | [2-core-resources.md](2-core-resources.md) | Clusters, jobs, SQL warehouses, notebooks, secrets |
+| Unity Catalog | [3-unity-catalog.md](3-unity-catalog.md) | Catalogs, schemas, volumes, grants, external locations |
+| Best Practices | [4-best-practices.md](4-best-practices.md) | Project structure, modules, state management, CI/CD |
+
+## Quick Start
+
+### Minimal Provider Setup (AWS)
+
+```hcl
+terraform {
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = "~> 1.110"
+    }
+  }
+}
+
+provider "databricks" {
+  host  = var.databricks_host
+  token = var.databricks_token
+}
+```
+
+### Create a Cluster
+
+```hcl
+data "databricks_spark_version" "latest_lts" {
+  long_term_support = true
+}
+
+data "databricks_node_type" "smallest" {
+  local_disk = true
+}
+
+resource "databricks_cluster" "shared" {
+  cluster_name            = "shared-analytics"
+  spark_version           = data.databricks_spark_version.latest_lts.id
+  node_type_id            = data.databricks_node_type.smallest.id
+  autotermination_minutes = 30
+  num_workers             = 2
+
+  spark_conf = {
+    "spark.databricks.io.cache.enabled" = "true"
+  }
+}
+```
+
+### Create a Unity Catalog Hierarchy
+
+```hcl
+resource "databricks_catalog" "analytics" {
+  name    = "analytics"
+  comment = "Production analytics catalog"
+}
+
+resource "databricks_schema" "gold" {
+  catalog_name = databricks_catalog.analytics.name
+  name         = "gold"
+  comment      = "Gold-layer aggregated tables"
+}
+
+resource "databricks_volume" "raw_files" {
+  catalog_name     = databricks_catalog.analytics.name
+  schema_name      = databricks_schema.gold.name
+  name             = "raw_files"
+  volume_type      = "MANAGED"
+  comment          = "Raw ingestion files"
+}
+
+resource "databricks_grants" "catalog_grants" {
+  catalog = databricks_catalog.analytics.name
+
+  grant {
+    principal  = "data-analysts"
+    privileges = ["USE_CATALOG"]
+  }
+}
+
+resource "databricks_grants" "schema_grants" {
+  schema = "${databricks_catalog.analytics.name}.${databricks_schema.gold.name}"
+
+  grant {
+    principal  = "data-analysts"
+    privileges = ["USE_SCHEMA", "SELECT"]
+  }
+}
+```
+
+### Create a Job
+
+```hcl
+resource "databricks_job" "etl_pipeline" {
+  name = "daily-etl-pipeline"
+
+  task {
+    task_key = "ingest"
+
+    notebook_task {
+      notebook_path = "/Repos/team/etl/ingest"
+    }
+
+    new_cluster {
+      spark_version = data.databricks_spark_version.latest_lts.id
+      node_type_id  = data.databricks_node_type.smallest.id
+      num_workers   = 4
+    }
+  }
+
+  task {
+    task_key = "transform"
+    depends_on {
+      task_key = "ingest"
+    }
+
+    notebook_task {
+      notebook_path = "/Repos/team/etl/transform"
+    }
+
+    new_cluster {
+      spark_version = data.databricks_spark_version.latest_lts.id
+      node_type_id  = data.databricks_node_type.smallest.id
+      num_workers   = 8
+    }
+  }
+
+  schedule {
+    quartz_cron_expression = "0 0 6 * * ?"
+    timezone_id            = "UTC"
+  }
+}
+```
+
+## Common Resources
+
+| Resource | Purpose |
+|----------|---------|
+| `databricks_cluster` | All-purpose and job clusters |
+| `databricks_job` | Scheduled and triggered jobs |
+| `databricks_sql_endpoint` | SQL warehouses |
+| `databricks_notebook` | Workspace notebooks |
+| `databricks_catalog` | Unity Catalog catalogs |
+| `databricks_schema` | Unity Catalog schemas |
+| `databricks_volume` | Unity Catalog volumes |
+| `databricks_grants` | Permissions on UC objects |
+| `databricks_external_location` | External storage locations |
+| `databricks_storage_credential` | Cloud storage credentials |
+| `databricks_model_serving` | Model serving endpoints |
+| `databricks_pipeline` | DLT/SDP pipelines |
+| `databricks_secret_scope` | Secret scopes |
+| `databricks_secret` | Secrets within scopes |
+| `databricks_cluster_policy` | Cluster policies |
+| `databricks_instance_pool` | Instance pools |
+| `databricks_token` | Personal access tokens |
+| `databricks_group` | Account/workspace groups |
+| `databricks_service_principal` | Service principals |
+
+## Common Data Sources
+
+| Data Source | Purpose |
+|-------------|---------|
+| `databricks_spark_version` | Look up Spark/DBR versions |
+| `databricks_node_type` | Find instance types by criteria |
+| `databricks_current_user` | Current authenticated user |
+| `databricks_catalogs` | List existing catalogs |
+| `databricks_schemas` | List schemas in a catalog |
+| `databricks_tables` | List tables in a schema |
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"Provider produced inconsistent result"** | Pin provider version with `version = "~> 1.110"` to avoid breaking changes |
+| **"Unauthorized" on plan/apply** | Check `host` and `token` variables; ensure token has workspace admin access |
+| **Cluster creation fails** | Use `databricks_node_type` data source instead of hardcoding instance types |
+| **Grants fail with "not found"** | Ensure parent resources (catalog, schema) are created first with `depends_on` or implicit references |
+| **State drift after manual changes** | Run `terraform import` to reconcile, or use `lifecycle { ignore_changes }` |
+| **Slow plan with many resources** | Use `-target` for focused applies; split into modules |
+
+## Related Skills
+
+- **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** — UC concepts that Terraform resources map to
+- **[databricks-jobs](../databricks-jobs/SKILL.md)** — job configurations that `databricks_job` implements
+- **[databricks-asset-bundles](../databricks-asset-bundles/SKILL.md)** — alternative IaC approach using Databricks-native bundles
+- **[databricks-config](../databricks-config/SKILL.md)** — authentication setup used by the Terraform provider
+
+## Resources
+
+- [Terraform Registry — Databricks Provider](https://registry.terraform.io/providers/databricks/databricks/latest/docs)
+- [Databricks Terraform Docs](https://docs.databricks.com/en/dev-tools/terraform/index.html)
+- [Automate Unity Catalog with Terraform](https://docs.databricks.com/en/dev-tools/terraform/automate-uc.html)
+- [GitHub — terraform-provider-databricks](https://github.com/databricks/terraform-provider-databricks)

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-terraform databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -66,6 +66,7 @@ get_skill_description() {
         "databricks-iceberg") echo "Apache Iceberg - managed tables, UniForm, IRC, Snowflake interop, migration" ;;
         "databricks-jobs") echo "Databricks Lakeflow Jobs - workflow orchestration" ;;
         "databricks-python-sdk") echo "Databricks Python SDK, Connect, and REST API" ;;
+        "databricks-terraform") echo "Databricks Terraform provider - IaC for workspaces, UC, clusters, jobs" ;;
         "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
@@ -105,6 +106,7 @@ get_skill_extra_files() {
         "databricks-app-python") echo "dash.md streamlit.md README.md" ;;
         "databricks-jobs") echo "task-types.md triggers-schedules.md notifications-monitoring.md examples.md" ;;
         "databricks-python-sdk") echo "doc-index.md examples/1-authentication.py examples/2-clusters-and-jobs.py examples/3-sql-and-warehouses.py examples/4-unity-catalog.py examples/5-serving-and-vector-search.py" ;;
+        "databricks-terraform") echo "1-provider-and-auth.md 2-core-resources.md 3-unity-catalog.md 4-best-practices.md" ;;
         "databricks-unity-catalog") echo "5-system-tables.md" ;;
         "databricks-lakebase-autoscale") echo "projects.md branches.md computes.md connection-patterns.md reverse-etl.md" ;;
         "databricks-lakebase-provisioned") echo "connection-patterns.md reverse-etl.md" ;;


### PR DESCRIPTION
## Summary

Addresses #145 — community-requested Terraform skill.

New skill with **SKILL.md + 4 reference files**:
- `1-provider-and-auth.md` — PAT, service principal, Azure/AWS/GCP auth, multi-provider config
- `2-core-resources.md` — clusters, jobs, SQL warehouses, DLT pipelines, model serving, secrets, instance pools, cluster policies
- `3-unity-catalog.md` — catalogs, schemas, volumes, grants, storage credentials, external locations, connections, Delta Sharing
- `4-best-practices.md` — project structure, reusable modules, remote state (S3/Azure Blob/GCS), CI/CD, lifecycle management

Provider version verified at v1.110.0 (Feb 2026). install_skills.sh updated to register the new skill.

## Test plan
- [x] HCL syntax verified
- [x] Provider version confirmed current
- [x] install_skills.sh registers skill + extra files
- [x] No MCP tools involved (Terraform is CLI-based)