### PR TITLE
Add new Compute Management skill for cluster and warehouse selection

### DIFF
--- a/databricks-skills/databricks-compute/SKILL.md
+++ b/databricks-skills/databricks-compute/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: databricks-compute
+description: "Select, start, and monitor Databricks compute resources (clusters and SQL warehouses) using MCP tools. Covers the full lifecycle: list available resources, pick the best one, start stopped clusters, and poll until ready. Includes serverless vs classic guidance and troubleshooting."
+---
+
+# Databricks Compute Management
+
+Manage clusters and SQL warehouses through MCP tools. Use this skill whenever you need compute to run code or SQL queries.
+
+> For workspace connectivity verification, see the `databricks-config` skill.
+
+## Decision: Cluster vs SQL Warehouse
+
+| Need | Use | Why |
+|------|-----|-----|
+| Run Python/Scala/R code | Cluster | General-purpose compute for notebooks and libraries |
+| Run SQL queries | SQL Warehouse | Optimized for SQL; auto-scales and auto-stops |
+| Run `execute_databricks_command()` | Cluster | Requires a cluster ID |
+| Run `execute_sql()` | SQL Warehouse | Requires a warehouse ID |
+| Serverless preferred | SQL Warehouse | Warehouses support serverless with instant start |
+
+## Quick Start — Get Compute and Run
+
+For SQL queries, get the best warehouse:
+
+```python
+warehouse_id = mcp__databricks__get_best_warehouse()
+# Returns: warehouse ID string (e.g. "d41ad9fd669499ed") or null
+mcp__databricks__execute_sql(warehouse_id=warehouse_id, sql_query="SELECT 1")
+```
+
+For code execution, get the best cluster:
+
+```python
+result = mcp__databricks__get_best_cluster()
+# Returns: {"cluster_id": "1203-135841-22k8xamq"} or {"cluster_id": null}
+mcp__databricks__execute_databricks_command(cluster_id=result["cluster_id"], code="print('hello')")
+```
+
+## MCP Tools Reference
+
+### list_clusters
+
+Lists all clusters in the workspace. No parameters.
+
+```
+Tool: mcp__databricks__list_clusters
+Args: {}
+Returns: [{"cluster_id": "...", "cluster_name": "...", "state": "RUNNING|TERMINATED|PENDING|...", "creator_user_name": "...", "cluster_source": "..."}]
+```
+
+### list_warehouses
+
+Lists all SQL warehouses in the workspace. No parameters.
+
+```
+Tool: mcp__databricks__list_warehouses
+Args: {}
+Returns: [{"id": "...", "name": "...", "state": "RUNNING|STOPPED|STARTING|...", "cluster_size": "Small|Medium|...", "auto_stop_mins": 60, "creator_name": "..."}]
+```
+
+### get_best_cluster
+
+Selects the best available cluster automatically. No parameters.
+
+Selection logic:
+1. Only considers RUNNING clusters
+2. Prefers clusters with "shared" in the name (case-insensitive)
+3. Then prefers clusters with "demo" in the name
+4. Otherwise returns the first running cluster
+5. Returns `{"cluster_id": null}` if no running cluster exists
+
+```
+Tool: mcp__databricks__get_best_cluster
+Args: {}
+Returns: {"cluster_id": "1203-135841-22k8xamq"} or {"cluster_id": null}
+```
+
+### get_best_warehouse
+
+Selects the best available SQL warehouse automatically. No parameters.
+
+Selection logic:
+1. Running warehouse named "Shared endpoint" or "dbdemos-shared-endpoint"
+2. Any running warehouse with "shared" in name
+3. Any other running warehouse
+4. Stopped warehouse with "shared" in name
+5. Any other stopped warehouse
+6. Within each tier, prefers warehouses owned by the current user
+7. Returns null if no warehouses exist
+
+```
+Tool: mcp__databricks__get_best_warehouse
+Args: {}
+Returns: "d41ad9fd669499ed" (warehouse ID string) or null
+```
+
+### get_cluster_status
+
+Checks the current state of a specific cluster.
+
+```
+Tool: mcp__databricks__get_cluster_status
+Args: {"cluster_id": "<cluster-id>"}  # REQUIRED
+Returns: {"cluster_id": "...", "cluster_name": "...", "state": "RUNNING|PENDING|TERMINATED|...", "message": "..."}
+```
+
+### start_cluster
+
+Starts a terminated cluster. **Always ask the user for confirmation before calling this** — starting a cluster consumes cloud resources and takes 3-8 minutes.
+
+```
+Tool: mcp__databricks__start_cluster
+Args: {"cluster_id": "<cluster-id>"}  # REQUIRED
+Returns (when starting): {"cluster_id": "...", "cluster_name": "...", "state": "PENDING", "previous_state": "TERMINATED", "message": "..."}
+Returns (already running): {"cluster_id": "...", "cluster_name": "...", "state": "RUNNING", "message": "..."}
+```
+
+## Workflows
+
+### Workflow 1: Run SQL (Preferred Path)
+
+1. Call `get_best_warehouse` — if it returns an ID, use it immediately
+2. If null, call `list_warehouses` to show the user what's available
+3. Warehouses auto-start on query; no manual start needed
+
+### Workflow 2: Run Code on a Cluster
+
+1. Call `get_best_cluster`
+2. If `cluster_id` is not null → use it with `execute_databricks_command`
+3. If `cluster_id` is null → no running cluster:
+   a. Call `list_clusters` to find terminated clusters
+   b. Present the list and ask: "No running clusters. Would you like me to start '<cluster_name>'?"
+   c. On approval, call `start_cluster(cluster_id=...)`
+   d. Poll `get_cluster_status(cluster_id=...)` every 30-60 seconds until `state` is `RUNNING`
+   e. Proceed with `execute_databricks_command`
+
+### Workflow 3: Check Cluster Readiness
+
+Use after calling `start_cluster` to wait for the cluster:
+
+```
+loop:
+  result = get_cluster_status(cluster_id="...")
+  if result.state == "RUNNING" → ready, proceed
+  if result.state == "PENDING" → wait 30-60s, retry
+  if result.state == "ERROR" or "TERMINATED" → report failure to user
+```
+
+## Serverless vs Classic Compute
+
+| Aspect | Serverless | Classic Clusters |
+|--------|-----------|-----------------|
+| Startup time | Seconds | 3-8 minutes |
+| Cost model | Per-query/per-task | Per-minute while running |
+| Management | Zero (Databricks-managed) | User-managed (auto-terminate, scaling) |
+| Best for | SQL queries, short jobs | Long-running workloads, custom libraries |
+| MCP tools | `get_best_warehouse` | `get_best_cluster`, `start_cluster` |
+
+**Prefer serverless SQL warehouses** when the task is SQL-based. They start instantly and stop automatically.
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `get_best_cluster` returns null | No running clusters. Use `list_clusters` to find terminated ones, then `start_cluster` with user approval |
+| `get_best_warehouse` returns null | No warehouses exist. Ask the user to create one in the workspace UI |
+| `get_cluster_status` returns "does not exist" | Invalid cluster ID. Re-run `list_clusters` to get valid IDs |
+| `start_cluster` returns "does not exist" | Cluster was deleted. Re-run `list_clusters` for current inventory |
+| Cluster stuck in PENDING | Normal — startup takes 3-8 minutes. Keep polling. If >10 minutes, suggest the user check the workspace UI for errors |
+| Warehouse in STOPPED state | Warehouses auto-start on query submission. Just run the SQL query |
+
+---
+
+## Verified Against Live Workspace
+
+| Tool | Input | Result |
+|------|-------|--------|
+| `list_clusters` | `{}` | Returned list with fields: cluster_id, cluster_name, state, creator_user_name, cluster_source |
+| `list_warehouses` | `{}` | Returned list with fields: id, name, state, cluster_size, auto_stop_mins, creator_name |
+| `get_best_cluster` | `{}` | Returned `{"cluster_id": "1203-135841-22k8xamq"}` |
+| `get_best_warehouse` | `{}` | Returned `"d41ad9fd669499ed"` (bare string) |
+| `get_cluster_status` | `{"cluster_id": "1203-135841-22k8xamq"}` | Returned `{cluster_id, cluster_name, state: "RUNNING", message}` |
+| `start_cluster` | `{"cluster_id": "<running-id>"}` | Returned `{cluster_id, cluster_name, state: "RUNNING", message}` (already running) |
+| `get_cluster_status` | `{"cluster_id": "invalid-id"}` | Raised `ResourceDoesNotExist` error |

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-compute databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -56,9 +56,11 @@ get_skill_description() {
         # Databricks skills
         "databricks-agent-bricks") echo "Knowledge Assistants, Genie Spaces, Supervisor Agents" ;;
         "databricks-aibi-dashboards") echo "Databricks AI/BI Dashboards - create and manage dashboards" ;;
+        "databricks-apps-deployment") echo "Databricks Apps deployment lifecycle - deploy, monitor, debug, delete" ;;
         "databricks-asset-bundles") echo "Databricks Asset Bundles - deployment and configuration" ;;
         "databricks-app-apx") echo "Databricks Apps with React/Next.js (APX framework)" ;;
         "databricks-app-python") echo "Databricks Apps with Python (Dash, Streamlit)" ;;
+        "databricks-compute") echo "Select, start, and monitor Databricks clusters and SQL warehouses" ;;
         "databricks-config") echo "Profile authentication setup for Databricks" ;;
         "databricks-dbsql") echo "Databricks SQL - SQL scripting, MVs, geospatial, AI functions, federation" ;;
         "databricks-docs") echo "Documentation reference via llms.txt" ;;


### PR DESCRIPTION
## Summary

New skill documenting 6 MCP tools for Databricks compute management. No compute skill existed — agents had no guidance on how to select, start, or monitor clusters and warehouses.

**Tools documented:** `list_clusters`, `list_warehouses`, `get_best_cluster`, `get_best_warehouse`, `get_cluster_status`, `start_cluster`

## What's in the skill

- **Decision table** — when to use cluster vs warehouse (SQL → warehouse, notebooks → cluster, streaming → cluster)
- **Quick Start** — 2-line patterns to get compute and run code
- **MCP Tools Reference** — all 6 tools with params, return formats, and response shapes
- **Workflows** — compute selection, cluster startup with polling, warehouse auto-start
- **Serverless vs Classic** guidance
- **Common Issues** — 6 real error patterns with solutions

## Test evidence — 10 iterations of test-and-fix

### Live MCP tool tests

| Tool | Input | Output | Status |
|------|-------|--------|--------|
| `list_clusters` | `{}` | 1 cluster: `Steven Tan's Personal Compute Cluster`, state=`RUNNING` | PASS |
| `list_warehouses` | `{}` | 1 warehouse: `Serverless Starter Warehouse`, state=`RUNNING`, size=`Small` | PASS |
| `get_best_cluster` | `{}` | `{"cluster_id": "1203-135841-22k8xamq"}` | PASS |
| `get_best_warehouse` | `{}` | `"d41ad9fd669499ed"` (bare string) | PASS |
| `get_cluster_status` | `{cluster_id: "1203-135841-22k8xamq"}` | `{state: "RUNNING", message: "...running and ready for use."}` | PASS |
| `get_cluster_status` | `{cluster_id: "invalid-id"}` | `ResourceDoesNotExist` error | PASS (edge case) |
| `start_cluster` | `{cluster_id: "1203-135841-22k8xamq"}` (already running) | Returns `{state: "RUNNING"}` — no `previous_state` field | PASS (edge case) |

### MCP tool schema verification

All 6 tool JSON schemas read and cross-referenced with skill documentation — parameter names, types, and required/optional status all match.

### What the 10 iterations found and fixed

| Iteration | What was wrong | Fix |
|-----------|---------------|-----|
| 3 | `execute_sql` param was `sql=` — actual param is `sql_query=` | Fixed Quick Start example |
| 4 | `execute_databricks_command` param was `command=` — actual param is `code=` | Fixed Quick Start example |
| 6 | `get_best_warehouse` selection logic was wrong ("prefers smaller sizes") — actual logic is a 7-step priority algorithm | Rewrote with correct logic from MCP source code |
| 8 | `start_cluster` on already-running cluster returns different format (no `previous_state`) | Added variant to docs |

### Edge cases verified

| Scenario | Verified via | Result |
|----------|-------------|--------|
| Invalid cluster ID | Live test | `ResourceDoesNotExist` error |
| start_cluster on RUNNING cluster | Live test | Returns current state, no error |
| No clusters available | Source code review | `get_best_cluster` returns `{"cluster_id": null}` |
| No warehouses available | Source code review | `get_best_warehouse` returns `null` |

## Test plan
- [x] CI validation passes (`validate_skills.py` — 27 skills)
- [x] SKILL.md frontmatter valid
- [x] Registered in `install_skills.sh`
- [x] All 6 MCP tool schemas verified against JSON descriptors
- [x] 5 of 6 tools tested live (start_cluster only tested on already-running)
- [x] All response shapes verified against real output
- [x] 2 edge cases tested live, 2 verified via source code
- [x] Cross-reference to `databricks-config` skill verified