### PR TITLE
Add new databricks-agent-deployment skill for MLflow agent deployment patterns

### DIFF
--- a/databricks-skills/databricks-agent-deployment/SKILL.md
+++ b/databricks-skills/databricks-agent-deployment/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: databricks-agent-deployment
+description: "Deploy MLflow agents on Databricks Model Serving. Covers ResponsesAgent output format, UC Volume access in serving, notebook patterns with writefile, serverless jobs via REST API, multi-format document input, and common deployment pitfalls."
+---
+
+# Databricks Agent Deployment
+
+Practical patterns and fixes for deploying MLflow agents (especially `ResponsesAgent`) on Databricks Model Serving, via notebooks, REST API, and serverless jobs.
+
+## When to Use
+
+- Deploying an MLflow agent to a Model Serving endpoint
+- Hitting deployment errors with `ResponsesAgent`
+- Bundling files (skills, prompts) with model artifacts
+- Running deployment notebooks as serverless jobs
+- Handling multi-format document input (PDF/JPEG/PNG)
+- Using the `%%writefile` + `restartPython` notebook pattern
+
+## Quick Start
+
+### Deploy a ResponsesAgent
+
+```python
+import mlflow
+from mlflow.models.resources import DatabricksServingEndpoint
+
+mlflow.set_registry_uri("databricks-uc")
+
+with mlflow.start_run():
+    model_info = mlflow.pyfunc.log_model(
+        artifact_path="agent",
+        python_model="agent.py",
+        pip_requirements=["mlflow", "databricks-sdk"],
+        resources=[DatabricksServingEndpoint(endpoint_name="databricks-claude-sonnet-4-6")],
+    )
+
+# Register in Unity Catalog
+mlflow.register_model(model_info.model_uri, "catalog.schema.my_agent")
+
+# Deploy
+from databricks import agents
+agents.deploy("catalog.schema.my_agent", model_version=1)
+```
+
+## Common Patterns
+
+### Pattern 1: ResponsesAgentResponse Output Format
+
+`ResponsesAgentResponse` output items are Pydantic models requiring `id` and `status`:
+
+```python
+import uuid
+from mlflow.pyfunc import ResponsesAgentResponse
+
+return ResponsesAgentResponse(output=[
+    {"id": str(uuid.uuid4()), "type": "message", "role": "assistant",
+     "status": "completed",
+     "content": [{"type": "output_text", "text": result}]}
+])
+```
+
+Missing `id` or `status` causes silent validation failures. When consuming:
+
+```python
+result = agent.predict(request)
+result_dict = result.model_dump(exclude_none=True)
+text = result_dict["output"][0]["content"][0]["text"]
+```
+
+### Pattern 2: UC Volume Access in Serving
+
+Model Serving endpoints can access UC Volumes at runtime, but `mlflow.models.predict` (pre-deployment validation) runs in an isolated environment that **cannot**.
+
+**Solution — bundle files with fallback:**
+
+```python
+import shutil, tempfile, os
+
+local_copy = os.path.join(tempfile.gettempdir(), "skills_bundle")
+shutil.copytree("/Volumes/catalog/schema/volume/skills", local_copy)
+
+mlflow.pyfunc.log_model(
+    python_model="agent.py",
+    code_paths=[local_copy],
+)
+```
+
+In the agent, resolve with fallback:
+
+```python
+from pathlib import Path
+
+def _resolve_path() -> str:
+    volume_path = os.environ.get("MY_PATH", "/Volumes/catalog/schema/volume")
+    if Path(volume_path).exists():
+        return volume_path
+    for candidate in [
+        Path(__file__).parent / "skills_bundle",
+        Path(__file__).parent / "code" / "skills_bundle",
+    ]:
+        if candidate.exists():
+            return str(candidate)
+    return volume_path
+```
+
+### Pattern 3: Notebook Deployment Pattern
+
+The standard `%%writefile` + `restartPython` pattern:
+
+1. **Cell 1:** `%pip install ...` + `dbutils.library.restartPython()`
+2. **Cell 2:** Widgets + config + `os.environ[...] = ...`
+3. **Cell 3:** `%%writefile agent.py` — agent code with env var fallbacks
+4. **Cell 4:** `dbutils.library.restartPython()` — critical to pick up new file
+5. **Cell 5:** `from agent import AGENT` — test locally
+6. **Cell 6:** `mlflow.pyfunc.log_model(python_model="agent.py", ...)`
+7. **Cell 7:** `agents.deploy(...)` + wait loop
+
+The `restartPython()` between writing and importing is **critical** — without it, Python caches a stale module.
+
+### Pattern 4: Serverless Notebook Jobs via REST API
+
+```bash
+curl -X POST "$HOST/api/2.1/jobs/runs/submit" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "tasks": [{
+      "task_key": "deploy",
+      "notebook_task": {
+        "notebook_path": "/Users/me/deploy_agent",
+        "base_parameters": {"model_name": "my_agent"}
+      },
+      "environment_key": "default"
+    }],
+    "environments": [{
+      "environment_key": "default",
+      "spec": {
+        "client": "2",
+        "dependencies": ["mlflow", "databricks-sdk"]
+      }
+    }]
+  }'
+```
+
+Key: `"client": "2"` = serverless (no cluster needed).
+
+## Reference Files
+
+- [endpoint-management.md](endpoint-management.md) - Endpoint creation, timing, and REST API patterns
+- [document-input.md](document-input.md) - Multi-format document handling (PDF/JPEG/PNG)
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **ResponsesAgentResponse validation error** | Add `id` (uuid4) and `status` ("completed") to every output item |
+| **UC Volume not found during `mlflow.models.predict`** | Bundle files via `code_paths` + add fallback path resolution |
+| **Stale module after `%%writefile`** | Add `dbutils.library.restartPython()` between write and import |
+| **Endpoint stuck `IN_PROGRESS` > 30 min** | Delete and recreate the endpoint |
+| **`UPDATE_FAILED` with `DEPLOYMENT_ABORTED`** | Infrastructure timeout — retry usually works |
+| **`INVALID_PARAMETER_VALUE` on endpoint create** | Include `workload_size` field (e.g., `"Small"`) |
+| **LLM returns JSON wrapped in markdown fences** | Strip fences and extract JSON between `{` and `}` |
+| **`DIRECTORY_NOT_EMPTY` on `shutil.copytree`** | Use `tempfile.gettempdir()`, not notebook CWD |

--- a/databricks-skills/databricks-agent-deployment/document-input.md
+++ b/databricks-skills/databricks-agent-deployment/document-input.md
@@ -1,0 +1,113 @@
+# Multi-Format Document Input
+
+## When to Use
+
+Use these patterns when building agents that accept PDF, JPEG, or PNG documents as input — common for document extraction, classification, and analysis agents.
+
+## Auto-Detect File Format
+
+Detect format from base64 header bytes:
+
+```python
+import base64
+
+FORMAT_SIGNATURES = {
+    b"%PDF": ("application/pdf", "document"),
+    b"\xff\xd8\xff": ("image/jpeg", "image_url"),
+    b"\x89PNG": ("image/png", "image_url"),
+}
+
+def detect_media_type(data_b64: str) -> tuple[str, str]:
+    raw = base64.b64decode(data_b64[:32])
+    for sig, (media_type, block_type) in FORMAT_SIGNATURES.items():
+        if raw.startswith(sig):
+            return media_type, block_type
+    raise ValueError(f"Unsupported format. First bytes: {raw[:8]}")
+```
+
+## Build Content Blocks
+
+Each format requires a different content block structure:
+
+```python
+def build_content_block(data_b64: str) -> dict:
+    media_type, block_type = detect_media_type(data_b64)
+
+    if block_type == "document":
+        return {
+            "type": "document",
+            "source": {
+                "type": "base64",
+                "media_type": media_type,
+                "data": data_b64,
+            }
+        }
+    else:
+        return {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:{media_type};base64,{data_b64}"
+            }
+        }
+```
+
+## Skills-Based Agent Architecture
+
+For agents handling multiple document types, store extraction "skills" as YAML in a UC Volume:
+
+```
+/Volumes/catalog/schema/skills/
+  _classifier.yaml       # classification + validation prompt
+  invoice_2024.yaml      # extraction prompt for invoices
+  receipt_standard.yaml   # extraction prompt for receipts
+```
+
+### Two-Phase LLM Flow
+
+1. **Phase 1 (Classify + Validate):** Short fixed prompt returns `{doc_type, is_valid, rejection_reasons}`
+2. **Phase 2 (Extract):** Load skill YAML for `doc_type`, run extraction with skill-specific prompt
+
+```python
+import yaml
+from pathlib import Path
+
+def process_document(doc_b64: str, skills_dir: str) -> dict:
+    classifier = yaml.safe_load(Path(skills_dir, "_classifier.yaml").read_text())
+    classification = call_llm(classifier["prompt"], doc_b64)
+
+    if not classification["is_valid"]:
+        return {"status": "rejected", "reasons": classification["rejection_reasons"]}
+
+    skill_file = Path(skills_dir, f"{classification['doc_type']}.yaml")
+    if not skill_file.exists():
+        return {"status": "error", "message": f"No skill for {classification['doc_type']}"}
+
+    skill = yaml.safe_load(skill_file.read_text())
+    extraction = call_llm(skill["prompt"], doc_b64)
+    return {"status": "success", "data": extraction}
+```
+
+### Benefits
+
+- Add document types by uploading YAML — no redeployment needed
+- Business users can edit prompts directly
+- Failed documents short-circuit (no wasted extraction tokens)
+- Each skill is versioned independently
+
+## Robust JSON Parsing from LLM Output
+
+LLMs sometimes wrap JSON in markdown fences or add preamble text:
+
+```python
+import json
+
+def parse_llm_json(raw_response: str) -> dict:
+    text = raw_response.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start >= 0 and end > start:
+        text = text[start:end]
+    return json.loads(text)
+```

--- a/databricks-skills/databricks-agent-deployment/endpoint-management.md
+++ b/databricks-skills/databricks-agent-deployment/endpoint-management.md
@@ -1,0 +1,113 @@
+# Endpoint Management
+
+## When to Use
+
+Use these patterns when creating, updating, or monitoring Model Serving endpoints for deployed agents.
+
+## Deployment Timing
+
+| Operation | Expected Duration |
+|-----------|------------------|
+| New endpoint creation | 10–20 minutes |
+| Config update on existing endpoint | 5–15 minutes |
+| `agents.deploy()` return | Immediate (async) |
+
+Set wait loops to **40 iterations × 30s = 20 min** minimum.
+
+## Creating Endpoints via REST API
+
+When `agents.deploy()` fails (e.g., endpoint already updating), create directly:
+
+```bash
+curl -X POST "$HOST/api/2.0/serving-endpoints" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "name": "my-agent-endpoint",
+    "config": {
+      "served_entities": [{
+        "entity_name": "catalog.schema.my_agent",
+        "entity_version": "1",
+        "scale_to_zero_enabled": true,
+        "workload_size": "Small",
+        "environment_vars": {
+          "MY_PATH": "/Volumes/catalog/schema/volume"
+        }
+      }]
+    }
+  }'
+```
+
+**Required field:** `workload_size` — omitting it causes `INVALID_PARAMETER_VALUE`.
+
+## Updating Endpoint Environment Variables
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+w.api_client.do("PUT", f"/api/2.0/serving-endpoints/{name}/config", body={
+    "served_entities": [{
+        "entity_name": "catalog.schema.my_agent",
+        "entity_version": str(version),
+        "scale_to_zero_enabled": True,
+        "environment_vars": {
+            "MY_PATH": "/Volumes/catalog/schema/volume"
+        }
+    }]
+})
+```
+
+## Monitoring Endpoint State
+
+An endpoint can be `READY` (old version serving) while a new version deploys:
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+endpoint = w.serving_endpoints.get(name="my-agent-endpoint")
+
+# Check serving state
+print(endpoint.state.ready)  # READY, NOT_READY
+
+# Check if config update is in progress
+print(endpoint.state.config_update)  # IN_PROGRESS, NOT_UPDATING
+```
+
+## Wait Loop Pattern
+
+```python
+import time
+
+for i in range(40):
+    endpoint = w.serving_endpoints.get(name="my-agent-endpoint")
+    state = endpoint.state
+    if state.ready == "READY" and state.config_update == "NOT_UPDATING":
+        print(f"Endpoint ready after {(i+1)*30}s")
+        break
+    print(f"[{i+1}/40] ready={state.ready}, config_update={state.config_update}")
+    time.sleep(30)
+else:
+    raise TimeoutError("Endpoint did not become ready in 20 minutes")
+```
+
+## UC Permissions for Model Serving
+
+The deploying identity needs:
+- `ALL_PRIVILEGES` on the schema containing the model
+- `ALL_PRIVILEGES` on the model itself (if it already exists)
+
+```bash
+curl -X PATCH "$HOST/api/2.1/unity-catalog/permissions/schema/catalog.schema" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"changes": [{"principal": "account users", "add": ["ALL_PRIVILEGES"]}]}'
+```
+
+## Workspace API Reference
+
+| Endpoint | Method | Notes |
+|----------|--------|-------|
+| `/api/2.0/workspace/export` | GET | Use `--data-urlencode` for params |
+| `/api/2.0/workspace/import` | POST | Content must be base64-encoded, set `overwrite: true` |
+| `/api/2.0/fs/files/Volumes/...` | PUT | Upload files to UC Volumes via `--data-binary @file` |
+| `/api/2.0/sql/statements` | POST | Requires `warehouse_id`, use `wait_timeout: "30s"` |

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-agent-deployment databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -55,6 +55,7 @@ get_skill_description() {
     case "$1" in
         # Databricks skills
         "databricks-agent-bricks") echo "Knowledge Assistants, Genie Spaces, Supervisor Agents" ;;
+        "databricks-agent-deployment") echo "Deploy MLflow agents — ResponsesAgent, endpoints, notebook patterns" ;;
         "databricks-aibi-dashboards") echo "Databricks AI/BI Dashboards - create and manage dashboards" ;;
         "databricks-asset-bundles") echo "Databricks Asset Bundles - deployment and configuration" ;;
         "databricks-app-apx") echo "Databricks Apps with React/Next.js (APX framework)" ;;
@@ -97,6 +98,7 @@ get_skill_description() {
 get_skill_extra_files() {
     case "$1" in
         "databricks-agent-bricks") echo "1-knowledge-assistants.md 2-supervisor-agents.md" ;;
+        "databricks-agent-deployment") echo "endpoint-management.md document-input.md" ;;
         "databricks-aibi-dashboards") echo "widget-reference.md sql-patterns.md" ;;
         "databricks-genie") echo "spaces.md conversation.md" ;;
         "databricks-asset-bundles") echo "alerts_guidance.md SDP_guidance.md" ;;


### PR DESCRIPTION
## Summary

New skill covering the **agent deployment lifecycle** on Databricks Model Serving — the practical patterns and pitfalls that arise when deploying MLflow `ResponsesAgent` models.

**Why this is needed:** The existing `databricks-model-serving` skill covers endpoint creation and querying, but not the agent-specific deployment patterns: `ResponsesAgentResponse` output format, UC Volume access in serving, `%%writefile` notebook patterns, serverless jobs via REST API, and multi-format document input.

### What's in the skill (3 files, ~390 lines)

- **SKILL.md** — Core patterns: ResponsesAgent output format, UC Volume bundling, notebook deployment, serverless jobs
- **endpoint-management.md** — Endpoint creation via REST API, timing expectations, state monitoring, wait loops, UC permissions
- **document-input.md** — Multi-format detection (PDF/JPEG/PNG), content block construction, skills-based agent architecture, robust JSON parsing

## Test evidence

### Pattern validation tests (local)

| Test | Input | Result |
|------|-------|--------|
| ResponsesAgentResponse format | Output item with id + status | PASS — validates required fields |
| LLM JSON parsing | 4 edge cases (fenced, preamble, clean, trailing) | PASS — all parsed correctly |
| Document format detection | PDF, JPEG, PNG base64 headers | PASS — all detected correctly |
| Serverless job payload | REST API submit body | PASS — valid JSON structure |

### Live workspace tests (e2-demo-field-eng)

| Test | What was verified | Result |
|------|------------------|--------|
| Endpoint state monitoring | `w.serving_endpoints.get()` → checked `state.ready` and `state.config_update` | PASS — `READY` / `NOT_UPDATING` |
| Endpoint listing | Listed 831 endpoints, identified 366 agent endpoints | PASS |
| Auth verification | SDK authentication via `e2-demo-field-eng` profile | PASS |

## Test plan
- [x] CI validation passes (`validate_skills.py` — 27 skills)
- [x] SKILL.md frontmatter valid (name ≤64 chars, description ≤1024 chars)
- [x] Registered in `install_skills.sh` (DATABRICKS_SKILLS + description + extra files)
- [x] All code patterns tested locally (4 tests, all pass)
- [x] Endpoint state monitoring verified against live workspace
- [x] All common issues documented with real error messages