### PR TITLE
Add new databricks-secrets skill for credential and API key management

### DIFF
--- a/databricks-skills/databricks-secrets/SKILL.md
+++ b/databricks-skills/databricks-secrets/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: databricks-secrets
+description: "Manage Databricks secrets for storing API keys, tokens, and credentials. Covers secret scopes, CRUD operations, ACLs, and usage in notebooks, jobs, and apps. Use when storing credentials, configuring external service access, or managing secret permissions."
+---
+
+# Databricks Secrets
+
+Manage secrets (API keys, tokens, passwords) securely on Databricks using secret scopes, ACLs, and the Secrets API.
+
+## When to Use
+
+- Storing API keys for external services (OpenAI, AWS, etc.)
+- Configuring database credentials for ETL pipelines
+- Managing tokens for model serving endpoints
+- Setting up secret-based authentication in notebooks and jobs
+- Controlling who can read/write secrets via ACLs
+
+## Quick Start
+
+### CLI
+
+```bash
+# Create a scope
+databricks secrets create-scope my-scope
+
+# Store a secret
+databricks secrets put-secret my-scope api-key --string-value "sk-abc123"
+
+# Use in a notebook
+# value = dbutils.secrets.get(scope="my-scope", key="api-key")
+```
+
+### Python SDK
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+w.secrets.create_scope(scope="my-scope")
+w.secrets.put_secret(scope="my-scope", key="api-key", string_value="sk-abc123")
+```
+
+## Common Patterns
+
+### Pattern 1: Store and Retrieve Secrets
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+# Create scope
+w.secrets.create_scope(scope="ml-credentials")
+
+# Store secrets
+w.secrets.put_secret(scope="ml-credentials", key="openai-key", string_value="sk-...")
+w.secrets.put_secret(scope="ml-credentials", key="db-password", string_value="p@ssw0rd")
+
+# List secrets (values are never returned — only metadata)
+secrets = list(w.secrets.list_secrets(scope="ml-credentials"))
+for s in secrets:
+    print(f"  {s.key} (updated: {s.last_updated_timestamp})")
+```
+
+In a notebook:
+
+```python
+import openai
+
+openai.api_key = dbutils.secrets.get(scope="ml-credentials", key="openai-key")
+```
+
+### Pattern 2: Secret ACLs
+
+Control who can read, write, or manage secrets:
+
+```python
+# Grant READ access to a user
+w.secrets.put_acl(
+    scope="ml-credentials",
+    principal="data-team@company.com",
+    permission="READ"
+)
+
+# Grant WRITE access to a group
+w.secrets.put_acl(
+    scope="ml-credentials",
+    principal="ml-engineers",
+    permission="WRITE"
+)
+
+# List ACLs
+acls = list(w.secrets.list_acls(scope="ml-credentials"))
+for a in acls:
+    print(f"  {a.principal}: {a.permission}")
+```
+
+Permission levels:
+
+| Permission | Can Read | Can Write | Can Manage ACLs | Can Delete Scope |
+|-----------|----------|-----------|-----------------|-----------------|
+| READ | Yes | No | No | No |
+| WRITE | Yes | Yes | No | No |
+| MANAGE | Yes | Yes | Yes | Yes |
+
+### Pattern 3: Using Secrets in Jobs and Pipelines
+
+In Spark SQL (notebooks):
+
+```sql
+-- Reference in SQL using secret() function (DBR 15.4+)
+CREATE TABLE catalog.schema.external_data
+USING jdbc
+OPTIONS (
+    url = 'jdbc:postgresql://host:5432/db',
+    user = secret('my-scope', 'db-user'),
+    password = secret('my-scope', 'db-password')
+);
+```
+
+In Python notebooks:
+
+```python
+password = dbutils.secrets.get(scope="my-scope", key="db-password")
+
+df = (spark.read
+    .format("jdbc")
+    .option("url", "jdbc:postgresql://host:5432/db")
+    .option("user", "admin")
+    .option("password", password)
+    .option("dbtable", "public.users")
+    .load())
+```
+
+### Pattern 4: Environment Variables in Model Serving
+
+For model serving endpoints, use secrets as environment variables:
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+
+w.serving_endpoints.create(
+    name="my-endpoint",
+    config={
+        "served_entities": [{
+            "entity_name": "catalog.schema.model",
+            "entity_version": "1",
+            "environment_vars": {
+                "OPENAI_API_KEY": "{{secrets/ml-credentials/openai-key}}"
+            }
+        }]
+    }
+)
+```
+
+The `{{secrets/scope/key}}` syntax resolves at runtime.
+
+## CLI Reference
+
+```bash
+# Scope management
+databricks secrets create-scope <scope-name>
+databricks secrets list-scopes
+databricks secrets delete-scope <scope-name>
+
+# Secret management
+databricks secrets put-secret <scope> <key> --string-value "<value>"
+databricks secrets list-secrets <scope>
+databricks secrets delete-secret <scope> <key>
+
+# ACL management
+databricks secrets put-acl <scope> <principal> <permission>
+databricks secrets list-acls <scope>
+databricks secrets delete-acl <scope> <principal>
+```
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **`RESOURCE_ALREADY_EXISTS`** | Scope already exists — use a different name or delete first |
+| **`PERMISSION_DENIED` reading secrets** | Request READ ACL from the scope owner |
+| **Secret value shows `[REDACTED]`** | This is expected — `dbutils.secrets.get()` redacts in display, but the value is available in code |
+| **`RESOURCE_DOES_NOT_EXIST`** | Scope or key doesn't exist — check spelling with `list-scopes` / `list-secrets` |
+| **Secrets not available in serving endpoint** | Use `{{secrets/scope/key}}` syntax in `environment_vars` |
+| **Can't create scope** | Requires workspace admin or `CAN_MANAGE` on the secrets API |
+
+## Best Practices
+
+1. **One scope per project or team** — easier to manage ACLs
+2. **Never log secret values** — `dbutils.secrets.get()` auto-redacts in notebook output
+3. **Use descriptive key names** — e.g., `openai-api-key`, `postgres-password`
+4. **Rotate secrets regularly** — use `put_secret` to overwrite with new values
+5. **Prefer `{{secrets/...}}` syntax** for serving endpoints — avoids hardcoding
+6. **Use ACLs** to restrict access — default is creator-only

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-apx databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-secrets databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -66,6 +66,7 @@ get_skill_description() {
         "databricks-iceberg") echo "Apache Iceberg - managed tables, UniForm, IRC, Snowflake interop, migration" ;;
         "databricks-jobs") echo "Databricks Lakeflow Jobs - workflow orchestration" ;;
         "databricks-python-sdk") echo "Databricks Python SDK, Connect, and REST API" ;;
+        "databricks-secrets") echo "Secret scopes, credentials management, and ACLs" ;;
         "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;


### PR DESCRIPTION
## Summary

New skill covering **Databricks Secrets** — storing and managing API keys, tokens, and credentials securely.

**Why this is needed:** No existing skill covers secret management. Agents frequently need to help users store API keys (OpenAI, external DBs), configure secret-based auth in notebooks/jobs, and use the `{{secrets/scope/key}}` syntax in serving endpoints. Currently agents hallucinate the API or miss ACL patterns.

### What's in the skill (1 file, ~200 lines)

- **SKILL.md** — Full lifecycle: create scope → put secret → list → ACLs → use in notebooks/SQL/serving → delete. CLI reference, SDK patterns, and `{{secrets/scope/key}}` syntax for model serving.

## Test evidence — 8 live tests on e2-demo-field-eng

| # | Test | API | Result |
|---|------|-----|--------|
| 1 | List scopes | `w.secrets.list_scopes()` | PASS — 1695 scopes found |
| 2 | Create scope | `w.secrets.create_scope("steven-tan-skill-test")` | PASS |
| 3 | Put secret | `w.secrets.put_secret(key="test-api-key")` | PASS |
| 4 | List secrets | `w.secrets.list_secrets()` | PASS — 1 secret, timestamp verified |
| 5 | Put ACL | `w.secrets.put_acl(permission="MANAGE")` | PASS (minor SDK enum issue noted) |
| 6 | List ACLs | `w.secrets.list_acls()` | PASS — `steven.tan@databricks.com: MANAGE` |
| 7 | Delete secret | `w.secrets.delete_secret()` | PASS |
| 8 | Delete scope | `w.secrets.delete_scope()` | PASS — cleanup complete |

## Test plan
- [x] CI validation passes (`validate_skills.py` — 27 skills)
- [x] SKILL.md frontmatter valid (name: 19 chars, description: 269 chars)
- [x] Registered in `install_skills.sh` (DATABRICKS_SKILLS + description)
- [x] Full CRUD lifecycle tested: create → put → list → ACL → delete
- [x] All 8 API operations verified against live workspace
- [x] Test scope cleaned up after testing