### PR TITLE
Add SET MANAGED migration patterns for external and foreign tables

### DIFF
--- a/databricks-skills/databricks-managed-tables/SKILL.md
+++ b/databricks-skills/databricks-managed-tables/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: databricks-managed-tables
-description: "Unity Catalog managed tables with predictive optimization. Covers managed vs external tables, predictive optimization setup, and automatic maintenance. Use when creating tables, choosing managed vs external, or enabling auto-optimization."
+description: "Unity Catalog managed tables with predictive optimization. Covers managed vs external tables, SET MANAGED migration (external and foreign to managed), predictive optimization setup, and automatic maintenance. Use when creating tables, migrating to managed, or enabling auto-optimization."
 ---
 
 # Databricks Managed Tables & Predictive Optimization
@@ -10,6 +10,8 @@ The single most impactful optimization on Databricks: use **Unity Catalog manage
 ## When to Use
 
 - Creating new Delta tables (always prefer managed)
+- Migrating external tables to managed via `ALTER TABLE ... SET MANAGED`
+- Migrating foreign tables (HMS/Glue federation) to managed via `SET MANAGED {MOVE|COPY}`
 - Enabling predictive optimization on existing managed tables
 - Understanding the trade-offs between managed and external tables
 - Setting up zero-maintenance table lifecycle
@@ -142,6 +144,39 @@ System table columns:
 | `usage_quantity` | DBUs consumed |
 | `usage_unit` | Always `DBU` |
 | `start_time` / `end_time` | Operation window |
+
+## Migrating to Managed Tables
+
+### External to Managed: `SET MANAGED` (Recommended)
+
+```sql
+-- Recommended: in-place conversion with minimal downtime (DBR 17.0+)
+ALTER TABLE catalog.schema.my_external_table SET MANAGED;
+
+-- Verify
+DESCRIBE EXTENDED catalog.schema.my_external_table;
+-- Type: MANAGED
+```
+
+`SET MANAGED` copies data in the background, then briefly blocks writes to switch over. Supports rollback within 14 days via `UNSET MANAGED`.
+
+### Foreign to Managed: `SET MANAGED {MOVE|COPY}` (DBR 17.3+)
+
+For tables federated from HMS or AWS Glue:
+
+```sql
+-- MOVE: converts and disables access from external catalog
+ALTER TABLE catalog.schema.my_foreign_table SET MANAGED MOVE;
+
+-- COPY: converts but keeps source table accessible in external catalog
+ALTER TABLE catalog.schema.my_foreign_table SET MANAGED COPY;
+```
+
+See [migration-patterns.md](migration-patterns.md) for full details, batch scripts, conversion times, rollback procedures, and error handling.
+
+## Reference Files
+
+- [migration-patterns.md](migration-patterns.md) - SET MANAGED migration patterns (external + foreign), batch conversion, rollback, and troubleshooting
 
 ## Common Issues
 

--- a/databricks-skills/databricks-managed-tables/migration-patterns.md
+++ b/databricks-skills/databricks-managed-tables/migration-patterns.md
@@ -1,0 +1,201 @@
+# Migration Patterns: Converting to Managed Tables
+
+## When to Use
+
+Use these patterns when migrating existing external or foreign tables to Unity Catalog managed tables to gain predictive optimization, automatic maintenance, and full governance.
+
+## Why Migrate?
+
+External and foreign tables miss out on:
+- **Predictive optimization** — no automatic OPTIMIZE/VACUUM/clustering
+- **Automatic maintenance** — must schedule manual OPTIMIZE and VACUUM jobs
+- **Full DROP semantics** — managed tables clean up data + metadata completely
+- **Simplified governance** — managed storage is fully controlled by Unity Catalog
+
+## External to Managed: `SET MANAGED` (Recommended)
+
+`ALTER TABLE ... SET MANAGED` is the **recommended** way to convert external tables to managed. It is superior to DEEP CLONE or CTAS because it:
+
+- Minimizes reader and writer downtime
+- Handles concurrent writes during conversion
+- Retains full table history
+- Keeps the same table name, settings, permissions, and views
+- Supports rollback via `UNSET MANAGED` within 14 days
+
+**Requires:** Databricks Runtime 17.0+ or Serverless compute. All readers/writers must use name-based access (not path-based).
+
+### Basic Conversion
+
+```sql
+-- For tables WITHOUT UniForm (Iceberg reads) enabled
+ALTER TABLE catalog.schema.my_external_table SET MANAGED;
+
+-- For tables WITH UniForm (Iceberg reads) already enabled (requires DBR 17.2+)
+ALTER TABLE catalog.schema.my_external_table SET MANAGED TRUNCATE UNIFORM HISTORY;
+```
+
+### Verify Conversion
+
+```sql
+DESCRIBE EXTENDED catalog.schema.my_external_table;
+-- Type should now show: MANAGED
+```
+
+### How SET MANAGED Works
+
+1. **Initial data copy (no downtime):** Data and Delta log are copied from external to managed location. Readers and writers continue normally.
+2. **Switch to managed location (brief downtime):** Remaining commits are moved, metadata is updated. Writers are briefly blocked. Readers on DBR 16.1+ experience no downtime.
+
+### Estimated Conversion Times
+
+| Table Size | Recommended Compute | Data Copy Time | Downtime |
+|-----------|-------------------|---------------|----------|
+| ≤100 GB | 32-core / XL warehouse | ~6 min | ~1-2 min |
+| 1 TB | 64-core / 2XL warehouse | ~30 min | ~1-2 min |
+| 10 TB | 256-core / 4XL warehouse | ~1.5 hrs | ~1-5 min |
+
+### Rollback (Within 14 Days)
+
+```sql
+ALTER TABLE catalog.schema.my_managed_table UNSET MANAGED;
+-- Table reverts to EXTERNAL, original data location is restored
+```
+
+After rollback, Databricks deletes data in the managed location after 7 days.
+
+### Post-Conversion Steps
+
+1. **Restart streaming jobs** — any streaming readers/writers must be restarted
+2. **Verify readers/writers** — confirm all consumers work with the managed table
+3. **Predictive optimization** — automatically enabled after conversion (unless manually disabled)
+4. **VACUUM after 14 days** — Databricks auto-deletes external location data via PO; if PO is disabled, run `VACUUM` manually
+
+### Important Precautions
+
+- **Cancel OPTIMIZE jobs** before conversion — cancel any running OPTIMIZE, liquid clustering, compaction, or ZORDER jobs on the table
+- **Don't run multiple SET MANAGED** on the same table concurrently
+- **All access must be name-based** — path-based access (`delta.\`s3://...\``) is not supported and may cause data corruption
+- If interrupted, rerun `SET MANAGED` — it resumes from where it left off
+
+## Foreign to Managed: `SET MANAGED {MOVE | COPY}`
+
+For tables federated from external catalogs (HMS, AWS Glue), use `SET MANAGED` with either `MOVE` or `COPY` mode.
+
+**Requires:** Databricks Runtime 17.3+, Delta Lake format, `OWNER`/`MANAGE` on table + `CREATE` on external location. Currently in Public Preview.
+
+### MOVE Mode (Recommended)
+
+Converts the table and **disables access** from the external catalog:
+
+```sql
+ALTER TABLE catalog.schema.my_foreign_table SET MANAGED MOVE;
+```
+
+- Access through the external catalog or path-based access fails after conversion
+- All readers/writers must use Unity Catalog namespace
+- Supports rollback:
+
+```sql
+-- Rollback: table becomes external, then re-federates as foreign on next sync
+ALTER TABLE catalog.schema.my_managed_table UNSET MANAGED;
+```
+
+**Warning:** You MUST run `UNSET MANAGED` before dropping a moved table. Dropping without `UNSET MANAGED` can cause data loss.
+
+### COPY Mode
+
+Converts the table **without disrupting** the source in the external catalog:
+
+```sql
+ALTER TABLE catalog.schema.my_foreign_table SET MANAGED COPY;
+```
+
+- Creates a separate managed copy — two copies of data exist
+- Source table in external catalog remains accessible
+- Rollback: just drop the managed table; source re-federates on next catalog sync
+- You are responsible for migrating workloads and disabling access to the source
+
+### MOVE vs COPY
+
+| Aspect | MOVE | COPY |
+|--------|------|------|
+| Source table access after conversion | Disabled | Still accessible |
+| Data copies | 1 (moved) | 2 (original + managed) |
+| Rollback method | `UNSET MANAGED` | Drop table |
+| Risk of dual-write conflicts | None | Possible if source not disabled |
+| Recommended for | Production cutover | Gradual migration |
+
+## Batch Migration at Schema/Catalog Level
+
+For converting entire schemas or catalogs, use the discoverx labs project:
+
+```python
+df = (dx.from_tables("prod.*.*")
+    .with_sql("ALTER TABLE {full_table_name} SET MANAGED;")
+    .apply())
+```
+
+Or iterate with the SDK:
+
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+wh_id = "<warehouse-id>"
+
+# Find all external tables in a schema
+tables = w.statement_execution.execute_statement(
+    warehouse_id=wh_id,
+    statement="""
+        SELECT table_catalog, table_schema, table_name
+        FROM system.information_schema.tables
+        WHERE table_catalog = 'my_catalog'
+          AND table_schema = 'my_schema'
+          AND table_type = 'EXTERNAL'
+    """,
+    wait_timeout="30s"
+)
+
+for row in tables.result.data_array:
+    full_name = f"{row[0]}.{row[1]}.{row[2]}"
+    print(f"Converting {full_name}...")
+    w.statement_execution.execute_statement(
+        warehouse_id=wh_id,
+        statement=f"ALTER TABLE {full_name} SET MANAGED",
+        wait_timeout="0s"  # async for large tables
+    )
+```
+
+## Migration Checklist
+
+| Step | Action | Verification |
+|------|--------|-------------|
+| 1 | Identify external/foreign tables | `DESCRIBE TABLE EXTENDED` → `Type: EXTERNAL` or `FOREIGN` |
+| 2 | Check table size | `DESCRIBE DETAIL` → `sizeInBytes` |
+| 3 | Cancel running OPTIMIZE/ZORDER jobs | Verify no active maintenance jobs |
+| 4 | Verify all access is name-based | No `delta.\`path\`` access patterns |
+| 5 | Run `ALTER TABLE ... SET MANAGED` | Command completes without error |
+| 6 | Verify conversion | `DESCRIBE EXTENDED` → `Type: MANAGED` |
+| 7 | Restart streaming jobs | Stop and restart all streaming readers/writers |
+| 8 | Verify predictive optimization | `SHOW TBLPROPERTIES` or check PO system table |
+| 9 | Validate consumers | Run key queries, confirm dashboards/jobs work |
+| 10 | VACUUM after 14 days | Run `VACUUM` if PO is disabled (PO handles it automatically otherwise) |
+
+## Common Conversion Errors
+
+| Error | Cause | Solution |
+|-------|-------|---------|
+| `DELTA_TRUNCATED_TRANSACTION_LOG` | Table has `columnMapping` feature with specific protocol versions | Check `DESCRIBE DETAIL` for protocol versions |
+| `DELTA_ALTER_TABLE_SET_MANAGED_INTERNAL_ERROR` | Cluster shut down during conversion | Retry the `SET MANAGED` command |
+| `FILE_VALIDATION_FAILED` | Files missing from source location | Check Spark driver logs, verify source files exist, retry |
+| `DELTA_TXN_LOG_FAILED_INTEGRITY` | Corrupted external table | Verify table health with `DESCRIBE DETAIL` first |
+
+## Best Practices
+
+1. **Use `SET MANAGED` over DEEP CLONE** — it's the official recommended approach with minimal downtime
+2. **Always use managed tables for new tables** — no reason to use external unless sharing storage with non-Databricks tools
+3. **Enable PO at the schema level** so all new tables inherit it automatically
+4. **Cancel OPTIMIZE jobs** before running `SET MANAGED`
+5. **Keep the 14-day rollback window** — don't drop external locations immediately
+6. **Restart streaming jobs** after conversion — this is required, not optional
+7. **For foreign tables, prefer MOVE** for clean cutover; use COPY for gradual migration

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -69,7 +69,7 @@ get_skill_description() {
         "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
-        "databricks-managed-tables") echo "Managed tables and predictive optimization" ;;
+        "databricks-managed-tables") echo "Managed tables, predictive optimization, SET MANAGED migration (external + foreign)" ;;
         "databricks-metric-views") echo "Unity Catalog Metric Views - governed business metrics in YAML" ;;
         "databricks-model-serving") echo "Model Serving - deploy MLflow models and AI agents" ;;
         "databricks-parsing") echo "Document parsing with ai_parse_document and custom RAG pipelines" ;;
@@ -109,6 +109,7 @@ get_skill_extra_files() {
         "databricks-unity-catalog") echo "5-system-tables.md" ;;
         "databricks-lakebase-autoscale") echo "projects.md branches.md computes.md connection-patterns.md reverse-etl.md" ;;
         "databricks-lakebase-provisioned") echo "connection-patterns.md reverse-etl.md" ;;
+        "databricks-managed-tables") echo "migration-patterns.md" ;;
         "databricks-metric-views") echo "yaml-reference.md patterns.md" ;;
         "databricks-model-serving") echo "1-classical-ml.md 2-custom-pyfunc.md 3-genai-agents.md 4-tools-integration.md 5-development-testing.md 6-logging-registration.md 7-deployment.md 8-querying-endpoints.md 9-package-requirements.md" ;;
         "databricks-mlflow-evaluation") echo "references/CRITICAL-interfaces.md references/GOTCHAS.md references/patterns-context-optimization.md references/patterns-datasets.md references/patterns-evaluation.md references/patterns-scorers.md references/patterns-trace-analysis.md references/user-journeys.md" ;;


### PR DESCRIPTION
## Summary
- Adds `migration-patterns.md` reference file to `databricks-managed-tables` skill
- Covers the recommended `ALTER TABLE ... SET MANAGED` approach (DBR 17.0+) for external-to-managed conversion
- Adds foreign-to-managed migration via `SET MANAGED {MOVE|COPY}` (DBR 17.3+, Public Preview)
- Includes conversion time estimates, rollback procedures, batch migration scripts, 10-step checklist, and common error handling

## Dependencies
- Builds on #240 (base managed-tables skill)

## Test proof — live workspace verification on e2-demo-field-eng

| # | Test | SQL | Result |
|---|------|-----|--------|
| 1 | Discover external tables | `SELECT ... FROM system.information_schema.tables WHERE table_type = 'EXTERNAL'` | PASS — found external tables (e.g., `careem_poc.bronze_sql.bronze_2_2b_external`) |
| 2 | Discover managed tables | `SELECT ... FROM system.information_schema.tables WHERE table_type = 'MANAGED'` | PASS — found managed tables |
| 3 | Batch migration query pattern | `SELECT table_catalog, table_schema, table_name FROM system.information_schema.tables WHERE table_type = 'EXTERNAL'` | PASS — returns rows suitable for batch `SET MANAGED` loop |

### Key output samples

```
External tables found:
  → ['careem_poc', 'bronze_sql', 'bronze_2_2b_external', 'EXTERNAL']
  → ['sde', 'gt_test', 'databricks_orc_positional_argument', 'EXTERNAL']

Managed tables found:
  → ['main', 'ashwinpo_swa', '...', 'MANAGED']
  → ['main', 'default', 'rss_news_articles', 'MANAGED']
```

### Documentation verification

SET MANAGED syntax and behavior verified against official Databricks docs:
- [Convert external to managed](https://docs.databricks.com/aws/en/tables/convert-external-managed) — `ALTER TABLE ... SET MANAGED`, rollback via `UNSET MANAGED`, conversion times
- [Convert foreign to managed](https://docs.databricks.com/aws/en/tables/convert-foreign-managed) — `SET MANAGED {MOVE|COPY}`, DBR 17.3+ requirement

> Note: `ALTER TABLE ... SET MANAGED` was not executed in tests because it requires an external table owned by the test user and is a destructive operation on shared workspaces. The syntax, prerequisites, and behavior are documented directly from the official docs (last updated Mar 4, 2026).