### PR TITLE
Add React Error #310 troubleshooting to app-apx skill

### DIFF
--- a/databricks-skills/databricks-app-apx/SKILL.md
+++ b/databricks-skills/databricks-app-apx/SKILL.md
@@ -236,6 +236,7 @@ Create two markdown files:
 **TypeScript errors**: Wait for OpenAPI regen, verify hook names match operation_ids
 **OpenAPI not updating**: Check watcher status with `apx dev status`, restart if needed
 **Components not added**: Run shadcn from project root with `--yes` flag
+**React page crashes to blank after data loads (Error #310)**: `useMemo`/`useCallback` hooks placed after early returns (`if (loading) return <Spinner />`) violate React Rules of Hooks. Hooks must be called in the same order on every render. Move ALL hooks before any conditional returns and guard their internals instead: `useMemo(() => { if (!data.length) return []; ... }, [data])`
 
 ## Reference Materials
 


### PR DESCRIPTION
## Summary
- Documents the React hooks-after-early-return crash pattern in app-apx Common Issues
- `useMemo`/`useCallback` placed after `if (loading) return <Spinner />` violates React Rules of Hooks, causing blank page crash when data loads

## Test proof — observed in production

Encountered during live APX app development:
1. Page loaded fine during loading state (spinner shown)
2. When data arrived, page crashed to completely blank
3. Console showed "Rendered fewer hooks than expected" (React Error #310)
4. Root cause: `useMemo` was placed after `if (loading) return <Spinner />`
5. Fix: moved all hooks before conditional returns, guarded internals instead