### PR TITLE
Expand Unity Catalog skill with governance, tags, security, sharing docs

### DIFF
--- a/databricks-skills/databricks-unity-catalog/1-objects-and-governance.md
+++ b/databricks-skills/databricks-unity-catalog/1-objects-and-governance.md
@@ -1,0 +1,311 @@
+# Unity Catalog Objects & Governance
+
+Manage the UC namespace hierarchy (catalogs, schemas, volumes, functions) and permissions.
+
+## Namespace Hierarchy
+
+```
+metastore
+└── catalog
+    └── schema
+        ├── table / view / materialized view
+        ├── volume (managed or external)
+        └── function
+```
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `manage_uc_objects` | CRUD for catalogs, schemas, volumes, functions |
+| `manage_uc_grants` | Grant, revoke, and inspect permissions |
+
+---
+
+## Catalog Operations
+
+### Create a Catalog
+
+```python
+manage_uc_objects(
+    object_type="catalog",
+    action="create",
+    name="analytics",
+    comment="Production analytics catalog"
+)
+```
+
+With managed storage location (isolates data from metastore default):
+
+```python
+manage_uc_objects(
+    object_type="catalog",
+    action="create",
+    name="analytics",
+    comment="Production analytics catalog",
+    storage_root="s3://my-bucket/analytics/"
+)
+```
+
+### List / Get / Update / Delete
+
+```python
+# List all catalogs
+manage_uc_objects(object_type="catalog", action="list")
+
+# Get details
+manage_uc_objects(object_type="catalog", action="get", full_name="analytics")
+
+# Update comment or owner
+manage_uc_objects(
+    object_type="catalog",
+    action="update",
+    full_name="analytics",
+    comment="Updated description",
+    owner="data-engineering@company.com"
+)
+
+# Delete (force=True to delete non-empty catalogs)
+manage_uc_objects(object_type="catalog", action="delete", full_name="analytics", force=True)
+```
+
+### Catalog Isolation Mode
+
+```python
+# OPEN: all workspace users can see the catalog
+# ISOLATED: only explicitly bound workspaces can access
+manage_uc_objects(
+    object_type="catalog",
+    action="update",
+    full_name="analytics",
+    isolation_mode="ISOLATED"
+)
+```
+
+---
+
+## Schema Operations
+
+```python
+# Create schema
+manage_uc_objects(
+    object_type="schema",
+    action="create",
+    name="gold",
+    catalog_name="analytics",
+    comment="Gold-layer aggregated tables"
+)
+
+# List schemas in a catalog
+manage_uc_objects(object_type="schema", action="list", catalog_name="analytics")
+
+# Delete schema
+manage_uc_objects(object_type="schema", action="delete", full_name="analytics.gold", force=True)
+```
+
+---
+
+## Volume Operations
+
+```python
+# Create managed volume (data stored in catalog's managed location)
+manage_uc_objects(
+    object_type="volume",
+    action="create",
+    name="raw_files",
+    catalog_name="analytics",
+    schema_name="bronze",
+    volume_type="MANAGED",
+    comment="Raw ingestion files"
+)
+
+# Create external volume (data stays in your cloud storage)
+manage_uc_objects(
+    object_type="volume",
+    action="create",
+    name="landing_zone",
+    catalog_name="analytics",
+    schema_name="bronze",
+    volume_type="EXTERNAL",
+    storage_location="s3://my-bucket/landing/",
+    comment="External landing zone"
+)
+
+# List volumes in a schema
+manage_uc_objects(
+    object_type="volume",
+    action="list",
+    catalog_name="analytics",
+    schema_name="bronze"
+)
+```
+
+For file operations on volumes (upload, download, list files), see [6-volumes.md](6-volumes.md).
+
+---
+
+## Function Operations
+
+```python
+# List functions in a schema
+manage_uc_objects(
+    object_type="function",
+    action="list",
+    catalog_name="analytics",
+    schema_name="gold"
+)
+
+# Get function details
+manage_uc_objects(
+    object_type="function",
+    action="get",
+    full_name="analytics.gold.calculate_revenue"
+)
+
+# Delete function
+manage_uc_objects(
+    object_type="function",
+    action="delete",
+    full_name="analytics.gold.calculate_revenue"
+)
+```
+
+To **create** functions, use `execute_sql` or `manage_uc_security_policies` (for security functions):
+
+```sql
+CREATE FUNCTION analytics.gold.calculate_revenue(quantity INT, price DECIMAL(10,2))
+RETURNS DECIMAL(10,2)
+RETURN quantity * price;
+```
+
+---
+
+## Permissions (Grants)
+
+### Grant Privileges
+
+```python
+# Grant catalog-level access
+manage_uc_grants(
+    action="grant",
+    securable_type="catalog",
+    full_name="analytics",
+    principal="data-analysts",
+    privileges=["USE_CATALOG"]
+)
+
+# Grant schema-level read access
+manage_uc_grants(
+    action="grant",
+    securable_type="schema",
+    full_name="analytics.gold",
+    principal="data-analysts",
+    privileges=["USE_SCHEMA", "SELECT"]
+)
+
+# Grant table-level write access
+manage_uc_grants(
+    action="grant",
+    securable_type="table",
+    full_name="analytics.gold.revenue",
+    principal="data-engineering",
+    privileges=["SELECT", "MODIFY"]
+)
+
+# Grant volume access
+manage_uc_grants(
+    action="grant",
+    securable_type="volume",
+    full_name="analytics.bronze.raw_files",
+    principal="data-engineering",
+    privileges=["READ_VOLUME", "WRITE_VOLUME"]
+)
+```
+
+### Common Privilege Combinations
+
+| Role | Catalog | Schema | Tables | Volumes |
+|------|---------|--------|--------|---------|
+| **Reader** | `USE_CATALOG` | `USE_SCHEMA` | `SELECT` | `READ_VOLUME` |
+| **Writer** | `USE_CATALOG` | `USE_SCHEMA` | `SELECT`, `MODIFY` | `READ_VOLUME`, `WRITE_VOLUME` |
+| **Creator** | `USE_CATALOG` | `USE_SCHEMA`, `CREATE_TABLE`, `CREATE_VOLUME` | — | — |
+| **Admin** | `ALL_PRIVILEGES` | — | — | — |
+
+### Inspect and Revoke
+
+```python
+# Get current grants on an object
+manage_uc_grants(
+    action="get",
+    securable_type="catalog",
+    full_name="analytics"
+)
+
+# Get effective grants (includes inherited permissions)
+manage_uc_grants(
+    action="get_effective",
+    securable_type="table",
+    full_name="analytics.gold.revenue"
+)
+
+# Revoke privileges
+manage_uc_grants(
+    action="revoke",
+    securable_type="schema",
+    full_name="analytics.gold",
+    principal="former-team",
+    privileges=["SELECT", "USE_SCHEMA"]
+)
+```
+
+---
+
+## Common Patterns
+
+### Bootstrap a New Project
+
+```python
+# 1. Create catalog
+manage_uc_objects(object_type="catalog", action="create", name="my_project",
+                  comment="My project data")
+
+# 2. Create medallion schemas
+for layer in ["bronze", "silver", "gold"]:
+    manage_uc_objects(object_type="schema", action="create",
+                      name=layer, catalog_name="my_project",
+                      comment=f"{layer.title()} layer")
+
+# 3. Create a volume for raw file ingestion
+manage_uc_objects(object_type="volume", action="create",
+                  name="raw_files", catalog_name="my_project",
+                  schema_name="bronze", volume_type="MANAGED")
+
+# 4. Grant access to the team
+manage_uc_grants(action="grant", securable_type="catalog",
+                 full_name="my_project", principal="my-team",
+                 privileges=["USE_CATALOG", "CREATE_SCHEMA"])
+```
+
+### Audit Who Has Access
+
+```python
+# Check grants on a sensitive table
+grants = manage_uc_grants(
+    action="get",
+    securable_type="table",
+    full_name="analytics.gold.customer_pii"
+)
+# Review grants["assignments"] for unexpected principals
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"User does not have USE_CATALOG"** | Grant `USE_CATALOG` on the catalog AND `USE_SCHEMA` on the schema — both are required for access |
+| **Cannot create objects** | Need `CREATE_TABLE`/`CREATE_VOLUME` on the schema, plus `USE_SCHEMA` and `USE_CATALOG` |
+| **"Catalog not found"** | Check `isolation_mode` — ISOLATED catalogs are only visible to bound workspaces |
+| **Cannot delete non-empty catalog** | Use `force=True` or delete child schemas first |
+| **External volume creation fails** | Ensure a storage credential and external location exist for the cloud path |

--- a/databricks-skills/databricks-unity-catalog/2-tags-and-classification.md
+++ b/databricks-skills/databricks-unity-catalog/2-tags-and-classification.md
@@ -1,0 +1,205 @@
+# Tags & Classification
+
+Tag Unity Catalog objects and columns for governance, data discovery, and compliance tracking.
+
+## MCP Tool
+
+| Tool | Purpose |
+|------|---------|
+| `manage_uc_tags` | Set/unset tags, set comments, query tags from system tables |
+
+---
+
+## Setting Tags
+
+Tags are key-value pairs attached to catalogs, schemas, tables, or columns.
+
+### Tag a Table
+
+```python
+manage_uc_tags(
+    action="set_tags",
+    object_type="table",
+    full_name="analytics.gold.customers",
+    tags={"pii": "true", "classification": "confidential", "owner_team": "data-eng"}
+)
+```
+
+### Tag a Column
+
+```python
+manage_uc_tags(
+    action="set_tags",
+    object_type="column",
+    full_name="analytics.gold.customers",
+    column_name="email",
+    tags={"pii": "true", "data_type": "email_address"}
+)
+```
+
+### Tag a Catalog or Schema
+
+```python
+manage_uc_tags(
+    action="set_tags",
+    object_type="catalog",
+    full_name="analytics",
+    tags={"environment": "production", "cost_center": "CC-1234"}
+)
+```
+
+---
+
+## Removing Tags
+
+```python
+manage_uc_tags(
+    action="unset_tags",
+    object_type="table",
+    full_name="analytics.gold.customers",
+    tag_names=["classification", "owner_team"]
+)
+```
+
+---
+
+## Setting Comments
+
+```python
+manage_uc_tags(
+    action="set_comment",
+    object_type="table",
+    full_name="analytics.gold.customers",
+    comment_text="Master customer table. Updated daily via SDP pipeline."
+)
+
+# Comment on a column
+manage_uc_tags(
+    action="set_comment",
+    object_type="column",
+    full_name="analytics.gold.customers",
+    column_name="customer_id",
+    comment_text="Unique customer identifier. FK to orders.customer_id."
+)
+```
+
+---
+
+## Querying Tags
+
+### Find All Tagged Tables
+
+```python
+manage_uc_tags(
+    action="query_table_tags",
+    catalog_filter="analytics"
+)
+# Returns rows from system.information_schema.table_tags
+```
+
+### Find PII Tables
+
+```python
+manage_uc_tags(
+    action="query_table_tags",
+    tag_name_filter="pii",
+    tag_value_filter="true"
+)
+```
+
+### Find Tagged Columns
+
+```python
+manage_uc_tags(
+    action="query_column_tags",
+    catalog_filter="analytics",
+    tag_name_filter="pii"
+)
+```
+
+### Filter by Table
+
+```python
+manage_uc_tags(
+    action="query_column_tags",
+    catalog_filter="analytics",
+    table_name_filter="customers"
+)
+```
+
+---
+
+## Common Tagging Patterns
+
+### PII Classification
+
+```python
+pii_columns = {
+    "analytics.gold.customers": ["email", "phone", "ssn", "address"],
+    "analytics.gold.employees": ["email", "salary", "ssn"],
+}
+
+for table, columns in pii_columns.items():
+    manage_uc_tags(action="set_tags", object_type="table",
+                   full_name=table, tags={"contains_pii": "true"})
+    for col in columns:
+        manage_uc_tags(action="set_tags", object_type="column",
+                       full_name=table, column_name=col,
+                       tags={"pii": "true"})
+```
+
+### Data Domain Tagging
+
+```python
+manage_uc_tags(action="set_tags", object_type="schema",
+               full_name="analytics.gold",
+               tags={"domain": "analytics", "sla": "99.9%", "refresh": "daily"})
+```
+
+### Cost Attribution
+
+```python
+manage_uc_tags(action="set_tags", object_type="catalog",
+               full_name="ml_features",
+               tags={"cost_center": "ML-OPS", "budget_owner": "ml-team@company.com"})
+```
+
+---
+
+## Using Tags with System Tables
+
+Tags stored via the MCP tool are queryable through `system.information_schema`:
+
+```sql
+-- Find all PII tables across all catalogs
+SELECT catalog_name, schema_name, table_name, tag_value
+FROM system.information_schema.table_tags
+WHERE tag_name = 'pii' AND tag_value = 'true';
+
+-- Find all PII columns
+SELECT catalog_name, schema_name, table_name, column_name, tag_value
+FROM system.information_schema.column_tags
+WHERE tag_name = 'pii';
+
+-- Cross-reference: tables tagged PII but missing column masks
+SELECT t.catalog_name, t.schema_name, t.table_name
+FROM system.information_schema.table_tags t
+LEFT JOIN system.information_schema.column_tags c
+  ON t.catalog_name = c.catalog_name
+  AND t.schema_name = c.schema_name
+  AND t.table_name = c.table_name
+  AND c.tag_name = 'masked'
+WHERE t.tag_name = 'pii' AND t.tag_value = 'true'
+  AND c.tag_name IS NULL;
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **Tag query returns empty** | Tags are per-catalog; ensure `catalog_filter` matches. System tables require `system.information_schema` access |
+| **"Cannot set tag"** | Need `APPLY_TAG` privilege on the object, plus `USE_CATALOG` and `USE_SCHEMA` |
+| **Tag not visible in UI** | Tags set via API/MCP appear in Catalog Explorer under the object's "Tags" tab. Allow a few seconds for propagation |
+| **Too many tags** | Maximum 50 tags per object. Use structured naming conventions (e.g., `domain:`, `compliance:`) |

--- a/databricks-skills/databricks-unity-catalog/3-security-policies.md
+++ b/databricks-skills/databricks-unity-catalog/3-security-policies.md
@@ -1,0 +1,189 @@
+# Row Filters & Column Masks
+
+Apply fine-grained access control to tables using SQL functions as row filters and column masks.
+
+## MCP Tool
+
+| Tool | Purpose |
+|------|---------|
+| `manage_uc_security_policies` | Create security functions, apply/remove row filters and column masks |
+
+---
+
+## How It Works
+
+- **Row filter**: A SQL function that returns `BOOLEAN`. Rows where the function returns `FALSE` are hidden from the user.
+- **Column mask**: A SQL function that returns the same type as the column. The function can redact, hash, or transform values based on the user's identity.
+
+Both use `IS_ACCOUNT_GROUP_MEMBER()` or `CURRENT_USER()` to make access decisions at query time.
+
+---
+
+## Row Filters
+
+### Step 1: Create a Filter Function
+
+```python
+manage_uc_security_policies(
+    action="create_security_function",
+    function_name="analytics.gold.region_filter",
+    parameter_name="region_val",
+    parameter_type="STRING",
+    return_type="BOOLEAN",
+    function_body="RETURN IF(IS_ACCOUNT_GROUP_MEMBER('global-admins'), TRUE, region_val = 'US')",
+    function_comment="Non-admins can only see US region data"
+)
+```
+
+### Step 2: Apply to a Table
+
+```python
+manage_uc_security_policies(
+    action="set_row_filter",
+    table_name="analytics.gold.orders",
+    filter_function="analytics.gold.region_filter",
+    filter_columns=["region"]
+)
+```
+
+Now when a non-admin queries `analytics.gold.orders`, they only see rows where `region = 'US'`.
+
+### Remove a Row Filter
+
+```python
+manage_uc_security_policies(
+    action="drop_row_filter",
+    table_name="analytics.gold.orders"
+)
+```
+
+---
+
+## Column Masks
+
+### Mask an Email Column
+
+```python
+# Create mask function
+manage_uc_security_policies(
+    action="create_security_function",
+    function_name="analytics.gold.mask_email",
+    parameter_name="email_val",
+    parameter_type="STRING",
+    return_type="STRING",
+    function_body="RETURN IF(IS_ACCOUNT_GROUP_MEMBER('pii-readers'), email_val, CONCAT(LEFT(email_val, 2), '***@***.com'))",
+    function_comment="Show full email only to PII readers group"
+)
+
+# Apply to column
+manage_uc_security_policies(
+    action="set_column_mask",
+    table_name="analytics.gold.customers",
+    column_name="email",
+    mask_function="analytics.gold.mask_email"
+)
+```
+
+Result: non-PII users see `st***@***.com` instead of `steven.tan@company.com`.
+
+### Mask a Numeric Column (e.g., Salary)
+
+```python
+manage_uc_security_policies(
+    action="create_security_function",
+    function_name="hr.secure.mask_salary",
+    parameter_name="salary_val",
+    parameter_type="DECIMAL(10,2)",
+    return_type="DECIMAL(10,2)",
+    function_body="RETURN IF(IS_ACCOUNT_GROUP_MEMBER('hr-admins'), salary_val, NULL)",
+    function_comment="Only HR admins can see salary values"
+)
+
+manage_uc_security_policies(
+    action="set_column_mask",
+    table_name="hr.employees.staff",
+    column_name="salary",
+    mask_function="hr.secure.mask_salary"
+)
+```
+
+### Remove a Column Mask
+
+```python
+manage_uc_security_policies(
+    action="drop_column_mask",
+    table_name="analytics.gold.customers",
+    column_name="email"
+)
+```
+
+---
+
+## Common Patterns
+
+### Multi-Column Masking
+
+Apply masks to several PII columns on the same table:
+
+```python
+pii_masks = [
+    ("email", "STRING", "CONCAT(LEFT(val, 2), '***@***.com')"),
+    ("phone", "STRING", "CONCAT('***-***-', RIGHT(val, 4))"),
+    ("ssn", "STRING", "'***-**-****'"),
+]
+
+for col, dtype, mask_expr in pii_masks:
+    func_name = f"analytics.gold.mask_{col}"
+    manage_uc_security_policies(
+        action="create_security_function",
+        function_name=func_name,
+        parameter_name="val",
+        parameter_type=dtype,
+        return_type=dtype,
+        function_body=f"RETURN IF(IS_ACCOUNT_GROUP_MEMBER('pii-readers'), val, {mask_expr})"
+    )
+    manage_uc_security_policies(
+        action="set_column_mask",
+        table_name="analytics.gold.customers",
+        column_name=col,
+        mask_function=func_name
+    )
+```
+
+### Row Filter by User's Department
+
+```python
+manage_uc_security_policies(
+    action="create_security_function",
+    function_name="analytics.gold.dept_filter",
+    parameter_name="dept_val",
+    parameter_type="STRING",
+    return_type="BOOLEAN",
+    function_body="""RETURN
+      IS_ACCOUNT_GROUP_MEMBER('global-admins')
+      OR IS_ACCOUNT_GROUP_MEMBER(CONCAT('dept-', LOWER(dept_val)))""",
+    function_comment="Users only see rows for their department group"
+)
+```
+
+---
+
+## Important Notes
+
+- Row filters and column masks are enforced at **query time** — they apply to all SQL, BI tools, and notebooks
+- Functions must be in the **same catalog** as the table (or in a catalog the user has access to)
+- `IS_ACCOUNT_GROUP_MEMBER()` checks account-level groups, not workspace-local groups
+- Only **metastore admins** and **account admins** bypass row filters and column masks. Table owners and users with `ALL_PRIVILEGES` do NOT automatically bypass them
+- Performance impact is minimal for simple functions; avoid expensive joins in filter/mask functions
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"Function not found"** | Function must exist before applying. Use `create_security_function` first |
+| **Filter not working for admins** | Users with `ALL_PRIVILEGES` or table ownership bypass filters/masks by design |
+| **Type mismatch** | Column mask `return_type` must exactly match the column's data type |
+| **Cannot apply to view** | Row filters and column masks only work on tables, not views. Use view-level logic instead |
+| **"Cannot create function"** | Need `CREATE_FUNCTION` privilege on the schema |

--- a/databricks-skills/databricks-unity-catalog/4-sharing-and-federation.md
+++ b/databricks-skills/databricks-unity-catalog/4-sharing-and-federation.md
@@ -1,0 +1,299 @@
+# Delta Sharing & Lakehouse Federation
+
+Share data securely across organizations and connect to external data sources.
+
+## MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `manage_uc_sharing` | Create/manage shares, recipients, and providers for Delta Sharing |
+| `manage_uc_connections` | Create/manage Lakehouse Federation connections to external databases |
+| `manage_uc_storage` | Create/manage storage credentials and external locations |
+
+---
+
+## Delta Sharing
+
+Delta Sharing enables secure, read-only sharing of data across Databricks workspaces and to non-Databricks consumers.
+
+### Concepts
+
+- **Share**: A named collection of tables to share
+- **Recipient**: An entity (person, org, workspace) that receives shared data
+- **Provider**: An entity that shares data (your workspace)
+
+### Create a Share
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="create",
+    name="partner_data_share",
+    comment="Quarterly metrics shared with partners"
+)
+```
+
+### Add a Table to a Share
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="add_table",
+    name="partner_data_share",
+    table_name="analytics.gold.quarterly_metrics",
+    shared_as="quarterly_metrics"
+)
+```
+
+### Add a Table with Partition Filter
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="add_table",
+    name="partner_data_share",
+    table_name="analytics.gold.orders",
+    shared_as="orders",
+    partition_spec="region = 'US'"
+)
+```
+
+### Remove a Table from a Share
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="remove_table",
+    name="partner_data_share",
+    table_name="analytics.gold.quarterly_metrics"
+)
+```
+
+### Create a Recipient
+
+```python
+# Databricks-to-Databricks sharing (uses sharing_id)
+manage_uc_sharing(
+    resource_type="recipient",
+    action="create",
+    name="partner_acme",
+    authentication_type="DATABRICKS",
+    sharing_id="<sharing_identifier_from_partner>",
+    comment="Acme Corp data team"
+)
+
+# Open sharing (generates activation link for non-Databricks consumers)
+manage_uc_sharing(
+    resource_type="recipient",
+    action="create",
+    name="external_partner",
+    authentication_type="TOKEN",
+    comment="External partner using open Delta Sharing"
+)
+```
+
+### Grant a Share to a Recipient
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="grant_to_recipient",
+    share_name="partner_data_share",
+    recipient_name="partner_acme"
+)
+```
+
+### Revoke a Share from a Recipient
+
+```python
+manage_uc_sharing(
+    resource_type="share",
+    action="revoke_from_recipient",
+    share_name="partner_data_share",
+    recipient_name="partner_acme"
+)
+```
+
+### List and Inspect
+
+```python
+# List all shares
+manage_uc_sharing(resource_type="share", action="list")
+
+# Get share details (shows included tables)
+manage_uc_sharing(resource_type="share", action="get", name="partner_data_share")
+
+# List recipients
+manage_uc_sharing(resource_type="recipient", action="list")
+
+# List providers (shares you've received)
+manage_uc_sharing(resource_type="provider", action="list")
+
+# List shares from a specific provider
+manage_uc_sharing(resource_type="provider", action="list_shares", name="databricks-partner")
+```
+
+---
+
+## Storage Credentials & External Locations
+
+Required for external tables, external volumes, and Lakehouse Federation.
+
+### Storage Credentials
+
+```python
+# List existing credentials
+manage_uc_storage(resource_type="credential", action="list")
+
+# Get credential details
+manage_uc_storage(resource_type="credential", action="get", name="my-s3-credential")
+
+# Create an AWS IAM role credential
+manage_uc_storage(
+    resource_type="credential",
+    action="create",
+    name="my-s3-credential",
+    aws_iam_role_arn="arn:aws:iam::123456789012:role/unity-catalog-access",
+    comment="Access to analytics S3 bucket"
+)
+
+# Validate a credential
+manage_uc_storage(
+    resource_type="credential",
+    action="validate",
+    name="my-s3-credential"
+)
+```
+
+### External Locations
+
+```python
+# Create external location
+manage_uc_storage(
+    resource_type="external_location",
+    action="create",
+    name="analytics-landing",
+    url="s3://my-bucket/landing/",
+    credential_name="my-s3-credential",
+    comment="Landing zone for raw data files"
+)
+
+# List external locations
+manage_uc_storage(resource_type="external_location", action="list")
+```
+
+---
+
+## Lakehouse Federation
+
+Connect to external databases (PostgreSQL, MySQL, SQL Server, Snowflake, BigQuery) and query them through Unity Catalog.
+
+### Create a Connection
+
+```python
+# PostgreSQL connection
+manage_uc_connections(
+    action="create",
+    name="postgres_erp",
+    connection_type="POSTGRESQL",
+    options={
+        "host": "erp-db.company.com",
+        "port": "5432",
+        "user": "readonly_user",
+        "password": "<password>"
+    },
+    comment="ERP PostgreSQL database"
+)
+
+# MySQL connection
+manage_uc_connections(
+    action="create",
+    name="mysql_legacy",
+    connection_type="MYSQL",
+    options={
+        "host": "legacy-db.company.com",
+        "port": "3306",
+        "user": "reader",
+        "password": "<password>"
+    }
+)
+```
+
+### Create a Foreign Catalog
+
+After creating a connection, create a foreign catalog to browse and query the external database:
+
+```python
+manage_uc_connections(
+    action="create_foreign_catalog",
+    connection_name="postgres_erp",
+    catalog_name="erp_catalog",
+    catalog_options={"database": "erp_production"}
+)
+```
+
+Now you can query external tables as if they were native UC tables:
+
+```sql
+SELECT * FROM erp_catalog.public.orders LIMIT 10;
+```
+
+### List and Manage Connections
+
+```python
+# List all connections
+manage_uc_connections(action="list")
+
+# Get connection details
+manage_uc_connections(action="get", name="postgres_erp")
+
+# Update connection
+manage_uc_connections(
+    action="update",
+    name="postgres_erp",
+    options={"host": "new-erp-db.company.com"},
+    comment="Updated to new host"
+)
+
+# Delete connection
+manage_uc_connections(action="delete", name="postgres_erp")
+```
+
+---
+
+## Common Patterns
+
+### Share Region-Specific Data
+
+```python
+# Share only US data with a US partner
+manage_uc_sharing(
+    resource_type="share",
+    action="add_table",
+    name="us_partner_share",
+    table_name="analytics.gold.revenue",
+    partition_spec="region = 'US'"
+)
+```
+
+### Federated Query Across Sources
+
+```sql
+-- Join Databricks table with federated PostgreSQL table
+SELECT d.customer_id, d.total_spend, e.erp_status
+FROM analytics.gold.customers d
+JOIN erp_catalog.public.customer_status e
+  ON d.customer_id = e.customer_id;
+```
+
+---
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **"Share not found"** | Shares are metastore-level objects. Ensure you're connected to the right workspace/metastore |
+| **Recipient can't access shared data** | Verify: (1) share is granted to recipient via `grant_to_recipient`, (2) activation link was used (for TOKEN auth), (3) table is added to the share |
+| **Federation query slow** | Predicate pushdown works for simple filters. Complex joins are pulled into Spark — add filters early |
+| **"Connection failed"** | Check: (1) network connectivity (firewall/VPC), (2) credentials in `options`, (3) host/port |
+| **Cannot create foreign catalog** | Need `CREATE_CATALOG` and `CREATE_FOREIGN_CATALOG` privileges, plus the connection must exist |

--- a/databricks-skills/databricks-unity-catalog/SKILL.md
+++ b/databricks-skills/databricks-unity-catalog/SKILL.md
@@ -1,80 +1,131 @@
 ---
 name: databricks-unity-catalog
-description: "Unity Catalog system tables and volumes. Use when querying system tables (audit, lineage, billing) or working with volume file operations (upload, download, list files in /Volumes/)."
+description: "Unity Catalog governance: manage catalogs/schemas/volumes/functions, grants & permissions, tags & classification, row filters & column masks, Delta Sharing, Lakehouse Federation, system tables, volumes, and data profiling."
 ---
 
 # Unity Catalog
 
-Guidance for Unity Catalog system tables, volumes, and governance.
+Comprehensive guidance for Unity Catalog — Databricks' unified governance layer for data, AI, and analytics assets.
 
 ## When to Use This Skill
 
 Use this skill when:
+- **Creating or managing** catalogs, schemas, volumes, or functions
+- **Granting or revoking** permissions on any UC object
+- **Tagging** tables or columns for governance, PII classification, or data discovery
+- **Applying row filters or column masks** for fine-grained access control
+- **Sharing data** across organizations with Delta Sharing
+- **Connecting to external databases** via Lakehouse Federation
+- **Managing storage credentials** and external locations
 - Working with **volumes** (upload, download, list files in `/Volumes/`)
-- Querying **lineage** (table dependencies, column-level lineage)
-- Analyzing **audit logs** (who accessed what, permission changes)
-- Monitoring **billing and usage** (DBU consumption, cost analysis)
-- Tracking **compute resources** (cluster usage, warehouse metrics)
-- Reviewing **job execution** (run history, success rates, failures)
-- Analyzing **query performance** (slow queries, warehouse utilization)
-- Profiling **data quality** (data profiling, drift detection, metric tables)
+- Querying **system tables** (lineage, audit, billing, compute, jobs, query history)
+- Setting up **data profiling** (monitors, drift detection, ML model monitoring)
+
+## MCP Tools
+
+| Tool | Purpose | Reference |
+|------|---------|-----------|
+| `manage_uc_objects` | CRUD for catalogs, schemas, volumes, functions | [1-objects-and-governance.md](1-objects-and-governance.md) |
+| `manage_uc_grants` | Grant, revoke, inspect permissions | [1-objects-and-governance.md](1-objects-and-governance.md) |
+| `manage_uc_tags` | Set/unset tags, set comments, query tags | [2-tags-and-classification.md](2-tags-and-classification.md) |
+| `manage_uc_security_policies` | Row filters, column masks, security functions | [3-security-policies.md](3-security-policies.md) |
+| `manage_uc_sharing` | Delta Sharing: shares, recipients, providers | [4-sharing-and-federation.md](4-sharing-and-federation.md) |
+| `manage_uc_connections` | Lakehouse Federation connections | [4-sharing-and-federation.md](4-sharing-and-federation.md) |
+| `manage_uc_storage` | Storage credentials and external locations | [4-sharing-and-federation.md](4-sharing-and-federation.md) |
+| `manage_uc_monitors` | Data profiling monitors | [7-data-profiling.md](7-data-profiling.md) |
+| `list_volume_files` / `upload_to_volume` / `download_from_volume` | Volume file operations | [6-volumes.md](6-volumes.md) |
+| `execute_sql` | Query system tables and run DDL | [5-system-tables.md](5-system-tables.md) |
 
 ## Reference Files
 
 | Topic | File | Description |
 |-------|------|-------------|
+| Objects & Governance | [1-objects-and-governance.md](1-objects-and-governance.md) | Catalog/schema/volume/function CRUD, permissions, common patterns |
+| Tags & Classification | [2-tags-and-classification.md](2-tags-and-classification.md) | Tagging tables/columns, PII classification, querying tags |
+| Security Policies | [3-security-policies.md](3-security-policies.md) | Row filters, column masks, security functions |
+| Sharing & Federation | [4-sharing-and-federation.md](4-sharing-and-federation.md) | Delta Sharing, storage credentials, external locations, Lakehouse Federation |
 | System Tables | [5-system-tables.md](5-system-tables.md) | Lineage, audit, billing, compute, jobs, query history |
 | Volumes | [6-volumes.md](6-volumes.md) | Volume file operations, permissions, best practices |
-| Data Profiling | [7-data-profiling.md](7-data-profiling.md) | Data profiling, drift detection, profile metrics |
+| Data Profiling | [7-data-profiling.md](7-data-profiling.md) | Data profiling, drift detection, ML model monitoring |
 
 ## Quick Start
 
-### Volume File Operations (MCP Tools)
+### Create a Catalog and Schema
 
 ```python
-# List files in a volume
-list_volume_files(volume_path="/Volumes/catalog/schema/volume/folder/")
+manage_uc_objects(object_type="catalog", action="create",
+                  name="analytics", comment="Production analytics")
 
-# Upload file to volume
-upload_to_volume(
-    local_path="/tmp/data.csv",
-    volume_path="/Volumes/catalog/schema/volume/data.csv"
-)
-
-# Download file from volume
-download_from_volume(
-    volume_path="/Volumes/catalog/schema/volume/data.csv",
-    local_path="/tmp/downloaded.csv"
-)
-
-# Create directory
-create_volume_directory(volume_path="/Volumes/catalog/schema/volume/new_folder")
+manage_uc_objects(object_type="schema", action="create",
+                  name="gold", catalog_name="analytics",
+                  comment="Gold-layer aggregated tables")
 ```
 
-### Enable System Tables Access
+### Grant Access
 
-```sql
--- Grant access to system tables
-GRANT USE CATALOG ON CATALOG system TO `data_engineers`;
-GRANT USE SCHEMA ON SCHEMA system.access TO `data_engineers`;
-GRANT SELECT ON SCHEMA system.access TO `data_engineers`;
+```python
+manage_uc_grants(action="grant", securable_type="catalog",
+                 full_name="analytics", principal="data-team",
+                 privileges=["USE_CATALOG"])
+
+manage_uc_grants(action="grant", securable_type="schema",
+                 full_name="analytics.gold", principal="data-team",
+                 privileges=["USE_SCHEMA", "SELECT"])
 ```
 
-### Common Queries
+### Tag a Table for PII
+
+```python
+manage_uc_tags(action="set_tags", object_type="table",
+               full_name="analytics.gold.customers",
+               tags={"pii": "true", "classification": "confidential"})
+```
+
+### Apply a Column Mask
+
+```python
+manage_uc_security_policies(
+    action="create_security_function",
+    function_name="analytics.gold.mask_email",
+    parameter_name="email_val", parameter_type="STRING",
+    return_type="STRING",
+    function_body="RETURN IF(IS_ACCOUNT_GROUP_MEMBER('pii-readers'), email_val, CONCAT(LEFT(email_val, 2), '***@***.com'))"
+)
+
+manage_uc_security_policies(
+    action="set_column_mask",
+    table_name="analytics.gold.customers",
+    column_name="email",
+    mask_function="analytics.gold.mask_email"
+)
+```
+
+### Volume File Operations
+
+```python
+list_volume_files(volume_path="/Volumes/analytics/bronze/raw_files/")
+
+upload_to_volume(local_path="/tmp/data.csv",
+                 volume_path="/Volumes/analytics/bronze/raw_files/data.csv")
+
+download_from_volume(volume_path="/Volumes/analytics/bronze/raw_files/data.csv",
+                     local_path="/tmp/downloaded.csv")
+```
+
+### Query System Tables
 
 ```sql
--- Table lineage: What tables feed into this table?
+-- Table lineage: what feeds this table?
 SELECT source_table_full_name, source_column_name
 FROM system.access.table_lineage
 WHERE target_table_full_name = 'catalog.schema.table'
   AND event_date >= current_date() - 7;
 
--- Audit: Recent permission changes
+-- Audit: recent permission changes
 SELECT event_time, user_identity.email, action_name, request_params
 FROM system.access.audit
 WHERE action_name LIKE '%GRANT%' OR action_name LIKE '%REVOKE%'
-ORDER BY event_time DESC
-LIMIT 100;
+ORDER BY event_time DESC LIMIT 100;
 
 -- Billing: DBU usage by workspace
 SELECT workspace_id, sku_name, SUM(usage_quantity) AS total_dbus
@@ -83,37 +134,36 @@ WHERE usage_date >= current_date() - 30
 GROUP BY workspace_id, sku_name;
 ```
 
-## MCP Tool Integration
+## Common Permission Combinations
 
-Use `mcp__databricks__execute_sql` for system table queries:
-
-```python
-# Query lineage
-mcp__databricks__execute_sql(
-    sql_query="""
-        SELECT source_table_full_name, target_table_full_name
-        FROM system.access.table_lineage
-        WHERE event_date >= current_date() - 7
-    """,
-    catalog="system"
-)
-```
+| Role | Catalog | Schema | Tables | Volumes |
+|------|---------|--------|--------|---------|
+| **Reader** | `USE_CATALOG` | `USE_SCHEMA` | `SELECT` | `READ_VOLUME` |
+| **Writer** | `USE_CATALOG` | `USE_SCHEMA` | `SELECT`, `MODIFY` | `READ_VOLUME`, `WRITE_VOLUME` |
+| **Creator** | `USE_CATALOG` | `USE_SCHEMA`, `CREATE_TABLE`, `CREATE_VOLUME` | — | — |
+| **Admin** | `ALL_PRIVILEGES` | — | — | — |
 
 ## Best Practices
 
-1. **Filter by date** - System tables can be large; always use date filters
-2. **Use appropriate retention** - Check your workspace's retention settings
-3. **Grant minimal access** - System tables contain sensitive metadata
-4. **Schedule reports** - Create scheduled queries for regular monitoring
+1. **Filter system tables by date** — they are partitioned by date; always use `event_date >= current_date() - N`
+2. **Grant least privilege** — start with `USE_CATALOG` + `USE_SCHEMA` + `SELECT`, add more as needed
+3. **Tag PII early** — tag tables and columns at creation time; use tags to drive column masks
+4. **Use managed volumes** unless you need external storage control
+5. **Test security functions** — verify row filters and column masks with a non-admin user before production
+6. **Enable system schemas** early in your UC setup for audit and lineage visibility
 
 ## Related Skills
 
-- **[databricks-spark-declarative-pipelines](../databricks-spark-declarative-pipelines/SKILL.md)** - for pipelines that write to Unity Catalog tables
-- **[databricks-jobs](../databricks-jobs/SKILL.md)** - for job execution data visible in system tables
-- **[databricks-synthetic-data-gen](../databricks-synthetic-data-gen/SKILL.md)** - for generating data stored in Unity Catalog Volumes
-- **[databricks-aibi-dashboards](../databricks-aibi-dashboards/SKILL.md)** - for building dashboards on top of Unity Catalog data
+- **[databricks-spark-declarative-pipelines](../databricks-spark-declarative-pipelines/SKILL.md)** — pipelines that write to Unity Catalog tables
+- **[databricks-jobs](../databricks-jobs/SKILL.md)** — job execution data visible in system tables
+- **[databricks-synthetic-data-gen](../databricks-synthetic-data-gen/SKILL.md)** — generating data stored in Unity Catalog Volumes
+- **[databricks-aibi-dashboards](../databricks-aibi-dashboards/SKILL.md)** — building dashboards on top of Unity Catalog data
+- **[databricks-vector-search](../databricks-vector-search/SKILL.md)** — vector indexes on Unity Catalog tables
 
 ## Resources
 
+- [Unity Catalog Documentation](https://docs.databricks.com/en/data-governance/unity-catalog/index.html)
 - [Unity Catalog System Tables](https://docs.databricks.com/administration-guide/system-tables/)
-- [Audit Log Reference](https://docs.databricks.com/administration-guide/account-settings/audit-logs.html)
+- [Delta Sharing Documentation](https://docs.databricks.com/en/delta-sharing/index.html)
+- [Lakehouse Federation](https://docs.databricks.com/en/query-federation/index.html)
+- [Row Filters and Column Masks](https://docs.databricks.com/en/data-governance/unity-catalog/row-and-column-filters.html)

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -66,7 +66,7 @@ get_skill_description() {
         "databricks-iceberg") echo "Apache Iceberg - managed tables, UniForm, IRC, Snowflake interop, migration" ;;
         "databricks-jobs") echo "Databricks Lakeflow Jobs - workflow orchestration" ;;
         "databricks-python-sdk") echo "Databricks Python SDK, Connect, and REST API" ;;
-        "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
+        "databricks-unity-catalog") echo "UC governance: objects, grants, tags, security policies, sharing, federation" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
         "databricks-metric-views") echo "Unity Catalog Metric Views - governed business metrics in YAML" ;;
@@ -105,7 +105,7 @@ get_skill_extra_files() {
         "databricks-app-python") echo "dash.md streamlit.md README.md" ;;
         "databricks-jobs") echo "task-types.md triggers-schedules.md notifications-monitoring.md examples.md" ;;
         "databricks-python-sdk") echo "doc-index.md examples/1-authentication.py examples/2-clusters-and-jobs.py examples/3-sql-and-warehouses.py examples/4-unity-catalog.py examples/5-serving-and-vector-search.py" ;;
-        "databricks-unity-catalog") echo "5-system-tables.md" ;;
+        "databricks-unity-catalog") echo "1-objects-and-governance.md 2-tags-and-classification.md 3-security-policies.md 4-sharing-and-federation.md 5-system-tables.md 6-volumes.md 7-data-profiling.md" ;;
         "databricks-lakebase-autoscale") echo "projects.md branches.md computes.md connection-patterns.md reverse-etl.md" ;;
         "databricks-lakebase-provisioned") echo "connection-patterns.md reverse-etl.md" ;;
         "databricks-metric-views") echo "yaml-reference.md patterns.md" ;;


### PR DESCRIPTION
## Summary
Addresses #103 — the UC skill was limited to system tables and volumes. Adds 4 new reference files documenting **7 MCP tools** that were previously undocumented:

- **1-objects-and-governance.md** — `manage_uc_objects`, `manage_uc_grants` (catalog/schema/volume/function CRUD, permissions)
- **2-tags-and-classification.md** — `manage_uc_tags` (PII classification, data discovery, compliance tagging)
- **3-security-policies.md** — `manage_uc_security_policies` (row filters, column masks, security functions)
- **4-sharing-and-federation.md** — `manage_uc_sharing`, `manage_uc_connections`, `manage_uc_storage` (Delta Sharing, Lakehouse Federation, storage credentials)

SKILL.md expanded from 120 → 170+ lines with MCP tool table, governance quick start, and permission combinations reference. Also registers previously unregistered `6-volumes.md` and `7-data-profiling.md`.

## Test proof — 7 MCP tools verified on e2-demo-field-eng

| # | Tool | Action | Result |
|---|------|--------|--------|
| 1 | `manage_uc_objects` | List catalogs | PASS — returned catalog list |
| 2 | `manage_uc_grants` | Get grants on catalog | PASS — returned privilege assignments |
| 3 | `manage_uc_tags` | List tags on table | PASS — returned tag key-value pairs |
| 4 | `manage_uc_security_policies` | List security functions | PASS — returned function definitions |
| 5 | `manage_uc_storage` | List storage credentials | PASS — returned credential list |
| 6 | `manage_uc_sharing` | List shares | PASS — returned share definitions |
| 7 | `manage_uc_connections` | List connections | PASS — returned foreign connections |

All MCP tool parameter names verified against tool JSON schemas.