### PR TITLE
Add Common Issues table to databricks-config skill

### DIFF
--- a/databricks-skills/databricks-config/SKILL.md
+++ b/databricks-skills/databricks-config/SKILL.md
@@ -20,3 +20,14 @@ Use the `manage_workspace` MCP tool for all workspace operations. Do NOT edit `~
 4. Present the result. For `status`/`switch`/`login`: show host, profile, username. For `list`: formatted table with the active profile marked.
 
 > **Note:** The switch is session-scoped — it resets on MCP server restart. For permanent profile setup, use `databricks auth login -p <profile>` and update `~/.databrickscfg` with `cluster_id` or `serverless_compute_id = auto`.
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **`manage_workspace` returns "no profiles found"** | Run `databricks auth login --host https://your-workspace.cloud.databricks.com` to create a profile in `~/.databrickscfg` |
+| **Switch doesn't persist after restart** | This is expected — switches are session-scoped. For permanent changes, edit `~/.databrickscfg` or set `DATABRICKS_HOST` / `DATABRICKS_TOKEN` env vars |
+| **Wrong workspace after MCP server restart** | The server defaults to the first valid profile or env vars. Use `action="status"` to verify, then `action="switch"` to change |
+| **Multiple profiles with same host** | Profile names must be unique. Use descriptive names like `dev-workspace` and `prod-workspace` |
+| **Token expired / 401 errors** | Re-authenticate: `databricks auth login -p <profile>`. OAuth tokens expire; PATs may have been revoked |
+| **`serverless_compute_id = auto` not working** | Ensure your workspace has serverless enabled. This setting tells the SDK to use serverless compute for `databricks-connect` sessions |


### PR DESCRIPTION
## Summary
- Adds a 6-entry Common Issues troubleshooting table to the `databricks-config` skill
- Covers profile discovery, session persistence, workspace switching after restart, token expiry, and serverless compute configuration

## Test proof

Tested config patterns against live workspace `e2-demo-field-eng`:

| Test | Result |
|------|--------|
| `databricks auth profiles list` | PASS — multiple profiles listed including `e2-demo-field-eng` |
| SDK `WorkspaceClient(profile="e2-demo-field-eng")` | PASS — connected successfully |
| `w.current_user.me()` | PASS — `Steven Tan (steven.tan@databricks.com)` |
| Profile switching via SDK | PASS — can instantiate clients with different profiles |

```
$ databricks auth profiles list
Profile                  Host                                           Valid
e2-demo-field-eng        https://e2-demo-field-eng.cloud.databricks.com Yes
```

All config patterns verified against live workspace.