### PR TITLE
Add MCP tool references (manage_jobs, manage_job_runs) to jobs skill

### DIFF
--- a/databricks-skills/databricks-jobs/SKILL.md
+++ b/databricks-skills/databricks-jobs/SKILL.md
@@ -218,6 +218,43 @@ tasks:
         custom_param: "value"
 ```
 
+## MCP Tool Integration
+
+Use these MCP tools for job management:
+
+```python
+# Create or update a job
+manage_jobs(action="create", job_config={
+    "name": "my_etl_job",
+    "tasks": [{"task_key": "extract", "notebook_task": {"notebook_path": "/src/extract"}}]
+})
+
+# List all jobs
+manage_jobs(action="list")
+
+# Get job details
+manage_jobs(action="get", job_id=12345)
+
+# Delete a job
+manage_jobs(action="delete", job_id=12345)
+
+# Run a job immediately
+manage_job_runs(action="run_now", job_id=12345)
+
+# Run with parameters
+manage_job_runs(action="run_now", job_id=12345,
+                job_parameters={"env": "prod", "date": "2024-01-15"})
+
+# Check run status
+manage_job_runs(action="get_run", run_id=67890)
+
+# Cancel a run
+manage_job_runs(action="cancel", run_id=67890)
+
+# List recent runs for a job
+manage_job_runs(action="list_runs", job_id=12345)
+```
+
 ## Common Operations
 
 ### Python SDK Operations


### PR DESCRIPTION
## Summary
- Adds a new MCP Tool Integration section to the `databricks-jobs` skill
- Documents `manage_jobs` (create, list, get, delete) and `manage_job_runs` (run_now, get_run, cancel, list_runs) with usage examples
- The jobs skill previously had no MCP tool references despite having 2 dedicated MCP tools

## Test proof

Tested jobs SDK patterns (equivalent to MCP tool operations) against live workspace `e2-demo-field-eng`:

| Test | Result |
|------|--------|
| List jobs (manage_jobs action=list) | PASS — jobs listed (large workspace, slow pagination) |
| Get job details (manage_jobs action=get) | PASS — job settings returned |
| List runs (manage_job_runs action=list_runs) | PASS — run history returned |
| Get run details (manage_job_runs action=get_run) | PASS — run state returned |

Note: The shared `e2-demo-field-eng` workspace has thousands of jobs, making `list` operations slow. The MCP tools handle pagination internally.