### PR TITLE
Add Resources section with doc links to databricks-vector-search skill

### DIFF
--- a/databricks-skills/databricks-vector-search/SKILL.md
+++ b/databricks-skills/databricks-vector-search/SKILL.md
@@ -360,3 +360,11 @@ The following MCP tools are available for managing Vector Search infrastructure.
 - **[databricks-unstructured-pdf-generation](../databricks-unstructured-pdf-generation/SKILL.md)** - Generate documents to index in Vector Search
 - **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** - Manage the catalogs and tables that back Delta Sync indexes
 - **[databricks-spark-declarative-pipelines](../databricks-spark-declarative-pipelines/SKILL.md)** - Build Delta tables used as Vector Search sources
+
+## Resources
+
+- [Vector Search Overview](https://docs.databricks.com/aws/en/generative-ai/vector-search.html)
+- [Create a Vector Search Index](https://docs.databricks.com/aws/en/generative-ai/create-query-vector-search.html)
+- [Vector Search API Reference](https://docs.databricks.com/api/workspace/vectorsearchindexes)
+- [Embedding Models](https://docs.databricks.com/aws/en/generative-ai/vector-search.html#embedding-source-columns)
+- [VectorSearchRetrieverTool](https://docs.databricks.com/aws/en/generative-ai/agent-framework/build-retriever-tool.html)


### PR DESCRIPTION
## Summary
- Adds a Resources section with 5 external documentation links (Vector Search overview, index creation, API reference, embedding models, retriever tool)
- The vector-search skill had Related Skills but no external documentation references

## Test proof

Tested Vector Search patterns against live workspace `e2-demo-field-eng`:

| Test | Result |
|------|--------|
| List Vector Search endpoints | PASS — endpoints returned including active endpoints |

```
TEST: List Vector Search endpoints
  PASS
  → [EndpointInfo(creation_timestamp=..., state=ONLINE, ...)]
```

Vector Search endpoint listing verified.