### PR TITLE
Fix Claude global MCP config path: ~/.claude/mcp.json → ~/.claude.json

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -893,7 +893,7 @@ write_mcp_configs() {
     for tool in $TOOLS; do
         case $tool in
             claude)
-                [ "$SCOPE" = "global" ] && write_mcp_json "$HOME/.claude/mcp.json" || write_mcp_json "$base_dir/.mcp.json"
+                [ "$SCOPE" = "global" ] && write_mcp_json "$HOME/.claude.json" || write_mcp_json "$base_dir/.mcp.json"
                 ok "Claude MCP config"
                 ;;
             cursor)


### PR DESCRIPTION
## Summary
- Fixes the Claude global MCP config path in `install.sh`
- Was writing to `~/.claude/mcp.json` but Claude Code expects `~/.claude.json` per [official docs](https://code.claude.com/docs/en/mcp#local-scope)
- Project-level path (`.mcp.json`) is unaffected

Fixes #203

## Test proof

Verified the fix by inspecting the installer logic:

```bash
# Before (line 896):
[ "$SCOPE" = "global" ] && write_mcp_json "$HOME/.claude/mcp.json" || write_mcp_json "$base_dir/.mcp.json"

# After:
[ "$SCOPE" = "global" ] && write_mcp_json "$HOME/.claude.json" || write_mcp_json "$base_dir/.mcp.json"
```

| Test | Result |
|------|--------|
| No other references to `~/.claude/mcp.json` in `install.sh` | PASS — grep returns 0 matches |
| README references are project-level `.claude/mcp.json` (correct) | PASS — not affected by this change |
| Claude docs confirm `~/.claude.json` for global scope | PASS — [docs link](https://code.claude.com/docs/en/mcp#local-scope) |