### PR TITLE
Fix install.sh: use append (+=) for Claude skill dirs like other tools

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -686,7 +686,7 @@ install_skills() {
     # Determine target directories (array so paths with spaces work)
     for tool in $TOOLS; do
         case $tool in
-            claude) dirs=("$base_dir/.claude/skills") ;;
+            claude) dirs+=("$base_dir/.claude/skills") ;;
             cursor) echo "$TOOLS" | grep -q claude || dirs+=("$base_dir/.cursor/skills") ;;
             copilot) dirs+=("$base_dir/.github/skills") ;;
             codex) dirs+=("$base_dir/.agents/skills") ;;


### PR DESCRIPTION
## Summary
- Fixes a bug where the Claude case in `install_skills()` used `dirs=(...)` (assignment) instead of `dirs+=(...)` (append)
- This would wipe previously added skill directories if Claude wasn't the first tool processed
- Example: `--tools copilot,claude` would lose the `.github/skills` copilot directory because Claude's `dirs=` overwrites the array
- All other tools (cursor, copilot, codex, gemini) already correctly use `+=`

## Test proof

```bash
# Before fix (line 689):
claude) dirs=("$base_dir/.claude/skills") ;;   # = overwrites array

# After fix:
claude) dirs+=("$base_dir/.claude/skills") ;;  # += appends to array

# All other tools already use +=:
cursor)  ... dirs+=("$base_dir/.cursor/skills") ;;
copilot) dirs+=("$base_dir/.github/skills") ;;
codex)   dirs+=("$base_dir/.agents/skills") ;;
gemini)  dirs+=("$base_dir/.gemini/skills") ;;
```

| Test | Result |
|------|--------|
| `--tools claude` (single tool) — behavior unchanged | PASS |
| `--tools copilot,claude` — copilot dir preserved after Claude processes | PASS (was broken before) |
| `--tools claude,cursor,copilot` — all 3 dirs in array | PASS |
| Dedupe logic (line 697-702) still works correctly | PASS |