### PR TITLE
[fix] Add explicit auth_type to WorkspaceClient and fix event draining on stream completion

### DIFF
--- a/databricks-builder-app/server/db/database.py
+++ b/databricks-builder-app/server/db/database.py
@@ -112,6 +112,7 @@ def _get_workspace_client():
                 host=os.environ.get('DATABRICKS_HOST', ''),
                 client_id=os.environ.get('DATABRICKS_CLIENT_ID', ''),
                 client_secret=os.environ.get('DATABRICKS_CLIENT_SECRET', ''),
+                auth_type='oauth-m2m',
                 **product_kwargs,
             )
         # Development mode - use default SDK auth

--- a/databricks-builder-app/server/routers/agent.py
+++ b/databricks-builder-app/server/routers/agent.py
@@ -436,6 +436,11 @@ async def stream_progress(execution_id: str, body: StreamProgressRequest):
 
             # Check if stream is complete or cancelled
             if stream.is_complete or stream.is_cancelled:
+                # Drain any events added between last poll and completion
+                remaining, _ = stream.get_events_since(last_timestamp)
+                for event in remaining:
+                    if event.get('type') != 'stream.completed':
+                        yield sse_event(event)
                 yield sse_event({
                     'type': 'stream.completed',
                     'is_error': stream.error is not None,

--- a/databricks-builder-app/server/services/active_stream.py
+++ b/databricks-builder-app/server/services/active_stream.py
@@ -77,7 +77,7 @@ class ActiveStream:
             Tuple of (events list, new cursor timestamp)
         """
         new_events = [
-            e.data for e in self.events
+            {**e.data, '_cursor': e.timestamp} for e in self.events
             if e.timestamp > cursor
         ]
 

--- a/databricks-builder-app/server/services/user.py
+++ b/databricks-builder-app/server/services/user.py
@@ -54,6 +54,7 @@ def _get_workspace_client() -> WorkspaceClient:
       host=os.environ.get('DATABRICKS_HOST', ''),
       client_id=os.environ.get('DATABRICKS_CLIENT_ID', ''),
       client_secret=os.environ.get('DATABRICKS_CLIENT_SECRET', ''),
+      auth_type='oauth-m2m',
       **product_kwargs,
     )
   # Development mode - use default SDK auth

--- a/databricks-tools-core/databricks_tools_core/auth.py
+++ b/databricks-tools-core/databricks_tools_core/auth.py
@@ -110,28 +110,34 @@ def get_workspace_client() -> WorkspaceClient:
     # Cross-workspace: explicit token overrides env OAuth so tool operations
     # target the caller-specified workspace instead of the app's own workspace
     if force and host and token:
-        return tag_client(WorkspaceClient(host=host, token=token, **product_kwargs))
+        return tag_client(
+            WorkspaceClient(host=host, token=token, auth_type="pat", **product_kwargs)
+        )
 
-    # In Databricks Apps (OAuth credentials in env), explicitly use OAuth M2M
-    # This prevents the SDK from detecting other auth methods like PAT or config file
+    # In Databricks Apps (OAuth credentials in env), explicitly use OAuth M2M.
+    # Setting auth_type="oauth-m2m" prevents the SDK from also reading
+    # DATABRICKS_TOKEN from os.environ and raising a "more than one
+    # authorization method configured" validation error.
     if _has_oauth_credentials():
         oauth_host = host or os.environ.get("DATABRICKS_HOST", "")
         client_id = os.environ.get("DATABRICKS_CLIENT_ID", "")
         client_secret = os.environ.get("DATABRICKS_CLIENT_SECRET", "")
 
-        # Explicitly configure OAuth M2M to prevent auth conflicts
         return tag_client(
             WorkspaceClient(
                 host=oauth_host,
                 client_id=client_id,
                 client_secret=client_secret,
+                auth_type="oauth-m2m",
                 **product_kwargs,
             )
         )
 
     # Development mode: use explicit token if provided
     if host and token:
-        return tag_client(WorkspaceClient(host=host, token=token, **product_kwargs))
+        return tag_client(
+            WorkspaceClient(host=host, token=token, auth_type="pat", **product_kwargs)
+        )
 
     if host:
         return tag_client(WorkspaceClient(host=host, **product_kwargs))


### PR DESCRIPTION
## Summary

- Fix Databricks SDK auth conflicts by adding explicit auth_type to all WorkspaceClient instantiations
- Fix SSE streaming to drain events that arrive between the last poll and stream completion
- Bump claude-agent-sdk to 0.1.20 and update Lakebase instance name for test deployment

## What changed

Auth fixes (auth.py, database.py, user.py):
- When both OAuth M2M credentials and a DATABRICKS_TOKEN are present in the environment, the Databricks SDK raises a "more than one authorization method configured" validation error. Adding auth_type="oauth-m2m" (or "pat" for token-based auth) tells the SDK exactly which method to use and prevents it from discovering conflicting credentials.

Cursor and event draining (agent.py, active_stream.py):
- Calling applications (e.g. Lemma) use cursor-based reconnection to resume SSE streams without replaying events. The _cursor timestamp is now included in each event so callers can track their position and pass it back on reconnect. Additionally, events arriving between the last poll and stream completion were being silently dropped — these are now drained before emitting stream.completed.