### PR TITLE
Prefer serverless warehouses in get_best_warehouse

### DIFF
--- a/databricks-tools-core/databricks_tools_core/sql/warehouse.py
+++ b/databricks-tools-core/databricks_tools_core/sql/warehouse.py
@@ -29,6 +29,8 @@ def list_warehouses(limit: int = 20) -> List[Dict[str, Any]]:
         - cluster_size: Size of the warehouse
         - auto_stop_mins: Auto-stop timeout in minutes
         - creator_name: Who created the warehouse
+        - warehouse_type: Type of warehouse (PRO, CLASSIC)
+        - enable_serverless_compute: Whether serverless compute is enabled
 
     Raises:
         Exception: If API request fails
@@ -59,39 +61,46 @@ def list_warehouses(limit: int = 20) -> List[Dict[str, Any]]:
                 "cluster_size": w.cluster_size,
                 "auto_stop_mins": w.auto_stop_mins,
                 "creator_name": w.creator_name,
+                "warehouse_type": getattr(w, "warehouse_type", None),
+                "enable_serverless_compute": getattr(w, "enable_serverless_compute", None),
             }
         )
 
     return result
 
 
-def _prefer_user_owned(warehouses: list, current_user: Optional[str]) -> list:
-    """Sort a list of warehouses so that those owned by the current user come first.
+def _sort_within_tier(warehouses: list, current_user: Optional[str]) -> list:
+    """Sort warehouses within a tier: serverless first, then user-owned.
 
     This is a *soft* preference — no warehouses are removed. Within the same
-    priority bucket, user-owned warehouses are simply tried first.
+    priority bucket, serverless warehouses are tried first, then user-owned.
 
     Args:
         warehouses: List of SDK warehouse objects.
         current_user: Current user's username/email, or None.
 
     Returns:
-        Reordered list (user-owned first, then the rest in original order).
+        Reordered list (serverless first, then user-owned, then the rest).
     """
-    if not current_user or not warehouses:
+    if not warehouses:
         return warehouses
-    user_lower = current_user.lower()
-    owned = [w for w in warehouses if (w.creator_name or "").lower() == user_lower]
-    others = [w for w in warehouses if (w.creator_name or "").lower() != user_lower]
-    return owned + others
+
+    def sort_key(w):
+        is_serverless = 0 if getattr(w, "enable_serverless_compute", False) else 1
+        user_lower = (current_user or "").lower()
+        is_owned = 0 if user_lower and (w.creator_name or "").lower() == user_lower else 1
+        return (is_serverless, is_owned)
+
+    return sorted(warehouses, key=sort_key)
 
 
 def get_best_warehouse() -> Optional[str]:
     """
     Select the best available SQL warehouse based on priority rules.
 
-    Within each priority tier, warehouses created by the current user are
-    preferred (soft preference — no warehouses are excluded).
+    Within each priority tier, serverless warehouses are preferred first
+    (instant start, auto-scale, no idle costs), then warehouses created
+    by the current user. No warehouses are excluded.
 
     Priority:
     1. Running warehouse named "Shared endpoint" or "dbdemos-shared-endpoint"
@@ -143,11 +152,11 @@ def get_best_warehouse() -> Optional[str]:
             offline_other.append(warehouse)
 
     # Within each tier, prefer warehouses owned by the current user
-    standard_shared = _prefer_user_owned(standard_shared, current_user)
-    online_shared = _prefer_user_owned(online_shared, current_user)
-    online_other = _prefer_user_owned(online_other, current_user)
-    offline_shared = _prefer_user_owned(offline_shared, current_user)
-    offline_other = _prefer_user_owned(offline_other, current_user)
+    standard_shared = _sort_within_tier(standard_shared, current_user)
+    online_shared = _sort_within_tier(online_shared, current_user)
+    online_other = _sort_within_tier(online_other, current_user)
+    offline_shared = _sort_within_tier(offline_shared, current_user)
+    offline_other = _sort_within_tier(offline_other, current_user)
 
     # Select based on priority
     if standard_shared:

--- a/databricks-tools-core/tests/unit/test_sql.py
+++ b/databricks-tools-core/tests/unit/test_sql.py
@@ -3,10 +3,11 @@
 from unittest import mock
 
 import pytest
-from databricks.sdk.service.sql import StatementState
+from databricks.sdk.service.sql import State, StatementState
 
 from databricks_tools_core.sql import execute_sql, execute_sql_multi
 from databricks_tools_core.sql.sql_utils import SQLExecutor
+from databricks_tools_core.sql.warehouse import _sort_within_tier, get_best_warehouse
 
 
 class TestExecuteSQLQueryTags:
@@ -118,3 +119,114 @@ class TestSQLExecutorQueryTags:
 
         call_kwargs = mock_client.statement_execution.execute_statement.call_args.kwargs
         assert "query_tags" not in call_kwargs
+
+
+def _make_warehouse(id, name, state, creator_name="other@example.com",
+                    enable_serverless_compute=False):
+    """Helper to create a mock warehouse object."""
+    w = mock.Mock()
+    w.id = id
+    w.name = name
+    w.state = state
+    w.creator_name = creator_name
+    w.enable_serverless_compute = enable_serverless_compute
+    w.cluster_size = "Small"
+    w.auto_stop_mins = 10
+    return w
+
+
+class TestSortWithinTier:
+    """Tests for _sort_within_tier serverless and user-owned preference."""
+
+    def test_serverless_first(self):
+        """Serverless warehouses should come before classic ones."""
+        classic = _make_warehouse("c1", "Classic WH", State.RUNNING)
+        serverless = _make_warehouse("s1", "Serverless WH", State.RUNNING,
+                                     enable_serverless_compute=True)
+        result = _sort_within_tier([classic, serverless], current_user=None)
+        assert result[0].id == "s1"
+        assert result[1].id == "c1"
+
+    def test_serverless_before_user_owned(self):
+        """Serverless should be preferred over user-owned classic."""
+        classic_owned = _make_warehouse("c1", "My WH", State.RUNNING,
+                                        creator_name="me@example.com")
+        serverless_other = _make_warehouse("s1", "Other WH", State.RUNNING,
+                                           creator_name="other@example.com",
+                                           enable_serverless_compute=True)
+        result = _sort_within_tier([classic_owned, serverless_other],
+                                   current_user="me@example.com")
+        assert result[0].id == "s1"
+
+    def test_serverless_user_owned_first(self):
+        """Among serverless, user-owned should come first."""
+        serverless_other = _make_warehouse("s1", "Other Serverless", State.RUNNING,
+                                           creator_name="other@example.com",
+                                           enable_serverless_compute=True)
+        serverless_owned = _make_warehouse("s2", "My Serverless", State.RUNNING,
+                                           creator_name="me@example.com",
+                                           enable_serverless_compute=True)
+        result = _sort_within_tier([serverless_other, serverless_owned],
+                                   current_user="me@example.com")
+        assert result[0].id == "s2"
+        assert result[1].id == "s1"
+
+    def test_empty_list(self):
+        assert _sort_within_tier([], current_user="me@example.com") == []
+
+    def test_no_current_user(self):
+        """Without a current user, only serverless preference applies."""
+        classic = _make_warehouse("c1", "Classic", State.RUNNING)
+        serverless = _make_warehouse("s1", "Serverless", State.RUNNING,
+                                     enable_serverless_compute=True)
+        result = _sort_within_tier([classic, serverless], current_user=None)
+        assert result[0].id == "s1"
+
+
+class TestGetBestWarehouseServerless:
+    """Tests for serverless preference in get_best_warehouse."""
+
+    @mock.patch("databricks_tools_core.sql.warehouse.get_current_username",
+                return_value="me@example.com")
+    @mock.patch("databricks_tools_core.sql.warehouse.get_workspace_client")
+    def test_prefers_serverless_within_running_shared(self, mock_client_fn, mock_user):
+        """Among running shared warehouses, serverless should be picked."""
+        classic_shared = _make_warehouse("c1", "Shared WH", State.RUNNING)
+        serverless_shared = _make_warehouse("s1", "Shared Serverless", State.RUNNING,
+                                            enable_serverless_compute=True)
+        mock_client = mock.Mock()
+        mock_client.warehouses.list.return_value = [classic_shared, serverless_shared]
+        mock_client_fn.return_value = mock_client
+
+        result = get_best_warehouse()
+        assert result == "s1"
+
+    @mock.patch("databricks_tools_core.sql.warehouse.get_current_username",
+                return_value="me@example.com")
+    @mock.patch("databricks_tools_core.sql.warehouse.get_workspace_client")
+    def test_prefers_serverless_within_running_other(self, mock_client_fn, mock_user):
+        """Among running non-shared warehouses, serverless should be picked."""
+        classic = _make_warehouse("c1", "My WH", State.RUNNING)
+        serverless = _make_warehouse("s1", "Fast WH", State.RUNNING,
+                                     enable_serverless_compute=True)
+        mock_client = mock.Mock()
+        mock_client.warehouses.list.return_value = [classic, serverless]
+        mock_client_fn.return_value = mock_client
+
+        result = get_best_warehouse()
+        assert result == "s1"
+
+    @mock.patch("databricks_tools_core.sql.warehouse.get_current_username",
+                return_value="me@example.com")
+    @mock.patch("databricks_tools_core.sql.warehouse.get_workspace_client")
+    def test_tier_order_preserved_over_serverless(self, mock_client_fn, mock_user):
+        """A running shared classic should still beat a stopped serverless."""
+        running_shared_classic = _make_warehouse("c1", "Shared WH", State.RUNNING)
+        stopped_serverless = _make_warehouse("s1", "Fast WH", State.STOPPED,
+                                             enable_serverless_compute=True)
+        mock_client = mock.Mock()
+        mock_client.warehouses.list.return_value = [stopped_serverless, running_shared_classic]
+        mock_client_fn.return_value = mock_client
+
+        result = get_best_warehouse()
+        assert result == "c1"


### PR DESCRIPTION
Serverless warehouses start instantly, scale automatically, and have no idle costs. When the MCP auto-selects a classic warehouse, it causes a poor experience if serverless warehouses are available.

Within each priority tier, serverless warehouses are now preferred first, then user-owned. Also adds `warehouse_type` and `enable_serverless_compute` to `list_warehouses` output.