### PR TITLE
Add Resources sections to docs, mlflow-evaluation, python-sdk, agent-bricks skills

### DIFF
--- a/databricks-skills/databricks-agent-bricks/SKILL.md
+++ b/databricks-skills/databricks-agent-bricks/SKILL.md
@@ -209,3 +209,11 @@ manage_mas(
 - `1-knowledge-assistants.md` - Detailed KA patterns and examples
 - `databricks-genie` skill - Detailed Genie patterns, curation, and examples
 - `2-supervisor-agents.md` - Detailed MAS patterns and examples
+
+## Resources
+
+- [AI/BI Genie Spaces](https://docs.databricks.com/aws/en/genie/)
+- [Mosaic AI Agent Framework](https://docs.databricks.com/aws/en/generative-ai/agent-framework/index.html)
+- [Knowledge Assistants](https://docs.databricks.com/aws/en/generative-ai/agent-framework/build-knowledge-assistant.html)
+- [Multi-Agent Supervisors](https://docs.databricks.com/aws/en/generative-ai/agent-framework/build-multi-agent-system.html)
+- [Model Serving Endpoints](https://docs.databricks.com/aws/en/machine-learning/model-serving/index.html)

--- a/databricks-skills/databricks-docs/SKILL.md
+++ b/databricks-skills/databricks-docs/SKILL.md
@@ -62,3 +62,11 @@ The llms.txt file is organized by category:
 - **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** - Governance and catalog management
 - **[databricks-model-serving](../databricks-model-serving/SKILL.md)** - Serving endpoints and model deployment
 - **[databricks-mlflow-evaluation](../databricks-mlflow-evaluation/SKILL.md)** - MLflow 3 GenAI evaluation workflows
+
+## Resources
+
+- [Databricks Documentation Home](https://docs.databricks.com/)
+- [llms.txt Index](https://docs.databricks.com/llms.txt) — machine-readable doc index for searching
+- [Release Notes](https://docs.databricks.com/aws/en/release-notes/)
+- [Databricks Knowledge Base](https://kb.databricks.com/)
+- [REST API Reference](https://docs.databricks.com/api/workspace/introduction)

--- a/databricks-skills/databricks-mlflow-evaluation/SKILL.md
+++ b/databricks-skills/databricks-mlflow-evaluation/SKILL.md
@@ -146,3 +146,11 @@ See `GOTCHAS.md` for complete list.
 - **[databricks-agent-bricks](../databricks-agent-bricks/SKILL.md)** - Building agents that can be evaluated with this skill
 - **[databricks-python-sdk](../databricks-python-sdk/SKILL.md)** - SDK patterns used alongside MLflow APIs
 - **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** - Unity Catalog tables for managed evaluation datasets
+
+## Resources
+
+- [MLflow GenAI Evaluation Guide](https://docs.databricks.com/aws/en/mlflow/llm-evaluate.html)
+- [MLflow Scorers Reference](https://mlflow.org/docs/latest/llms/llm-evaluate/index.html)
+- [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html)
+- [Agent Evaluation on Databricks](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/index.html)
+- [MLflow Python API](https://mlflow.org/docs/latest/python_api/index.html)

--- a/databricks-skills/databricks-python-sdk/SKILL.md
+++ b/databricks-skills/databricks-python-sdk/SKILL.md
@@ -623,3 +623,12 @@ If I'm unsure about a method, I should:
 - **[databricks-model-serving](../databricks-model-serving/SKILL.md)** - serving endpoint management
 - **[databricks-vector-search](../databricks-vector-search/SKILL.md)** - vector index operations
 - **[databricks-lakebase-provisioned](../databricks-lakebase-provisioned/SKILL.md)** - managed PostgreSQL via SDK
+
+## Resources
+
+- [Databricks SDK for Python](https://docs.databricks.com/aws/en/dev-tools/sdk-python.html)
+- [SDK API Reference (PyPI)](https://databricks-sdk-py.readthedocs.io/)
+- [Databricks CLI](https://docs.databricks.com/aws/en/dev-tools/cli/index.html)
+- [Databricks Connect](https://docs.databricks.com/aws/en/dev-tools/databricks-connect/index.html)
+- [REST API Reference](https://docs.databricks.com/api/workspace/introduction)
+- [Authentication](https://docs.databricks.com/aws/en/dev-tools/auth/index.html)


### PR DESCRIPTION
## Summary
Adds external documentation links (Resources section) to 4 skills that were missing them:
- **databricks-docs**: docs home, llms.txt, release notes, Knowledge Base, REST API
- **databricks-mlflow-evaluation**: MLflow eval guide, scorers, tracing, agent evaluation
- **databricks-python-sdk**: SDK docs, PyPI reference, CLI, Connect, REST API, authentication
- **databricks-agent-bricks**: Genie, agent framework, Knowledge Assistants, MAS, model serving

## Test proof
All links verified as valid Databricks/MLflow documentation URLs.