### PR TITLE
[fix] Added can_use_tool callback and prompt change to prevent AskUserQuestion error

### DIFF
--- a/databricks-builder-app/server/services/agent.py
+++ b/databricks-builder-app/server/services/agent.py
@@ -32,11 +32,14 @@ from typing import AsyncIterator
 from claude_agent_sdk import ClaudeAgentOptions, query, HookMatcher
 from claude_agent_sdk.types import (
   AssistantMessage,
+  PermissionResultAllow,
+  PermissionResultDeny,
   ResultMessage,
   StreamEvent,
   SystemMessage,
   TextBlock,
   ThinkingBlock,
+  ToolPermissionContext,
   ToolResultBlock,
   ToolUseBlock,
   UserMessage,
@@ -299,6 +302,39 @@ def _run_agent_in_fresh_loop(message, options, result_queue, context, is_cancell
   context.run(run_with_context)
 
 
+def _process_tool_result(block: ToolResultBlock, ask_user_tool_ids: set[str]) -> dict:
+  """Extract and normalize content from a ToolResultBlock for streaming."""
+  content = block.content
+  if isinstance(content, list):
+    texts = []
+    for item in content:
+      if isinstance(item, dict) and 'text' in item:
+        texts.append(item['text'])
+      elif isinstance(item, str):
+        texts.append(item)
+      else:
+        texts.append(str(item))
+    content = '\n'.join(texts) if texts else str(block.content)
+  elif not isinstance(content, str):
+    content = str(content)
+
+  # Rewrite AskUserQuestion results — the can_use_tool callback provides
+  # synthetic answers, but the CLI result text is misleading (e.g. "User has
+  # answered your questions: ..."). Replace with a clear message.
+  if block.tool_use_id in ask_user_tool_ids:
+    content = 'Asking user questions directly in conversation'
+  elif block.is_error and 'Stream closed' in content:
+    content = f'Tool execution interrupted: {content}. This may occur when operations exceed timeout limits or when the connection is interrupted. Check backend logs for more details.'
+    logger.warning(f'Tool result error (improved): {content}')
+
+  return {
+    'type': 'tool_result',
+    'tool_use_id': block.tool_use_id,
+    'content': content,
+    'is_error': block.is_error,
+  }
+
+
 async def stream_agent_response(
   project_id: str,
   message: str,
@@ -451,10 +487,37 @@ async def stream_agent_response(
       # Also print to stderr for immediate visibility during development
       print(f'[Claude stderr] {line.strip()}', file=sys.stderr, flush=True)
 
+    # Handle AskUserQuestion tool calls gracefully.
+    # With bypassPermissions and no callback, AskUserQuestion triggers an SDK
+    # error ("canUseTool callback is not provided") which produces is_error=True
+    # tool results — showing as "Failed" in downstream UIs like Lemma.
+    # This callback allows AskUserQuestion with a synthetic answer that redirects
+    # Claude to ask questions as normal text, avoiding the error path entirely.
+    async def can_use_tool(
+      tool_name: str, input_data: dict, _context: ToolPermissionContext,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+      if tool_name == "AskUserQuestion":
+        questions = input_data.get("questions", [])
+        answers = {
+          q.get("question", ""): "Please ask this question directly in your text response."
+          for q in questions
+        }
+        return PermissionResultAllow(
+          updated_input={"questions": questions, "answers": answers},
+        )
+      return PermissionResultAllow(updated_input=input_data)
+
+    # Required for can_use_tool in Python: a PreToolUse hook that keeps the
+    # stream open so the permission callback can be invoked.
+    async def _keepalive_hook(_input_data, _tool_use_id, _context):
+      return {"continue_": True}
+
     options = ClaudeAgentOptions(
       cwd=str(project_dir),
       allowed_tools=allowed_tools,
       permission_mode='bypassPermissions',  # Auto-accept all tools including MCP
+      can_use_tool=can_use_tool,  # Handle AskUserQuestion gracefully
+      hooks={"PreToolUse": [HookMatcher(matcher=None, hooks=[_keepalive_hook])]},
       resume=session_id,  # Resume from previous session if provided
       mcp_servers={'databricks': databricks_server},  # In-process SDK tools
       system_prompt=system_prompt,  # Databricks-focused system prompt
@@ -484,6 +547,8 @@ async def stream_agent_response(
     # Process messages from the queue with keepalive for long operations
     KEEPALIVE_INTERVAL = 15  # seconds - send keepalive if no activity
     last_activity = time.time()
+    # Track AskUserQuestion tool IDs to rewrite their results in the stream
+    ask_user_tool_ids: set[str] = set()
 
     while True:
       # Use timeout on queue.get to allow keepalive emission
@@ -534,6 +599,9 @@ async def stream_agent_response(
                 'thinking': block.thinking,
               }
             elif isinstance(block, ToolUseBlock):
+              # Track AskUserQuestion calls so we can rewrite their results
+              if block.name == 'AskUserQuestion':
+                ask_user_tool_ids.add(block.id)
               yield {
                 'type': 'tool_use',
                 'tool_id': block.id,
@@ -541,33 +609,7 @@ async def stream_agent_response(
                 'tool_input': block.input,
               }
             elif isinstance(block, ToolResultBlock):
-              # Extract content - may be string, list, or complex structure
-              content = block.content
-              if isinstance(content, list):
-                # Handle list of content blocks (e.g., [{'type': 'text', 'text': '...'}])
-                texts = []
-                for item in content:
-                  if isinstance(item, dict) and 'text' in item:
-                    texts.append(item['text'])
-                  elif isinstance(item, str):
-                    texts.append(item)
-                  else:
-                    texts.append(str(item))
-                content = '\n'.join(texts) if texts else str(block.content)
-              elif not isinstance(content, str):
-                content = str(content)
-
-              # Improve generic "Stream closed" error messages
-              if block.is_error and 'Stream closed' in content:
-                content = f'Tool execution interrupted: {content}. This may occur when operations exceed timeout limits or when the connection is interrupted. Check backend logs for more details.'
-                logger.warning(f'Tool result error (improved): {content}')
-
-              yield {
-                'type': 'tool_result',
-                'tool_use_id': block.tool_use_id,
-                'content': content,
-                'is_error': block.is_error,
-              }
+              yield _process_tool_result(block, ask_user_tool_ids)
 
         elif isinstance(msg, ResultMessage):
           yield {
@@ -592,32 +634,7 @@ async def stream_agent_response(
           if isinstance(msg_content, list):
             for block in msg_content:
               if isinstance(block, ToolResultBlock):
-                # Extract content - may be string, list, or complex structure
-                content = block.content
-                if isinstance(content, list):
-                  texts = []
-                  for item in content:
-                    if isinstance(item, dict) and 'text' in item:
-                      texts.append(item['text'])
-                    elif isinstance(item, str):
-                      texts.append(item)
-                    else:
-                      texts.append(str(item))
-                  content = '\n'.join(texts) if texts else str(block.content)
-                elif not isinstance(content, str):
-                  content = str(content)
-
-                # Improve generic "Stream closed" error messages
-                if block.is_error and 'Stream closed' in content:
-                  content = f'Tool execution interrupted: {content}. This may occur when operations exceed timeout limits or when the connection is interrupted. Check backend logs for more details.'
-                  logger.warning(f'Tool result error (improved): {content}')
-
-                yield {
-                  'type': 'tool_result',
-                  'tool_use_id': block.tool_use_id,
-                  'content': content,
-                  'is_error': block.is_error,
-                }
+                yield _process_tool_result(block, ask_user_tool_ids)
           # Skip string content (just echo of user input)
 
         elif isinstance(msg, StreamEvent):

--- a/databricks-builder-app/server/services/system_prompt.py
+++ b/databricks-builder-app/server/services/system_prompt.py
@@ -244,6 +244,7 @@ Use it as storage to track all the resources created in the project, and be able
 - MCP tool names use the format `mcp__databricks__<tool_name>` (e.g., `mcp__databricks__execute_sql`)
 - Use `upload_folder`/`upload_file` for file uploads, never manual steps
 - Use `create_or_update_pipeline` for pipelines, never SDK code
+- **Do NOT use the AskUserQuestion tool.** If you need clarifying information, ask your questions directly in your text response as a normal conversation turn. The user will reply naturally.
 
 {skills_section}
 


### PR DESCRIPTION
# AskUserQuestion Tool Failures in Downstream UIs

## Problem

When Claude calls the `AskUserQuestion` tool during a builder-app agent session, it produces `is_error=True` tool results. In downstream applications that proxy builder-app events, this renders as a red "Failed" status in the UI. The agent may also stop entirely instead of asking questions as normal text.

## Root Cause

The builder-app runs `claude-agent-sdk` with `permission_mode='bypassPermissions'` and **no `can_use_tool` callback** (`agent.py:454`).

`bypassPermissions` auto-allows regular tools (Bash, Write, etc.) at the CLI level without ever sending a control request to the SDK. However, `AskUserQuestion` is different — it requires structured user answers (`questions` + `answers` payload), so the CLI still sends a `can_use_tool` control request to the SDK.

With no callback registered, the SDK raises:

```
Exception("canUseTool callback is not provided")
```

Source: `claude_agent_sdk/_internal/query.py:241-242`

This error is returned to the CLI as a control protocol error response, which the CLI converts into a `ToolResultBlock` with `is_error=True`.

## Resolution

Two-layer fix applied:

### 1. System prompt instruction (primary)

Tells Claude not to use `AskUserQuestion` and to ask questions directly in text responses instead. This prevents the tool from being called in the first place.

**File:** `server/services/system_prompt.py`

```
- **Do NOT use the AskUserQuestion tool.** If you need clarifying information,
  ask your questions directly in your text response as a normal conversation turn.
  The user will reply naturally.
```

### 2. `can_use_tool` callback (safety net)

Intercepts `AskUserQuestion` with `PermissionResultAllow` and synthetic answers that redirect Claude to ask questions in text. Returns a successful result — no `is_error`, no red "Failed" in downstream UIs. All other tools pass through as auto-allowed.

Requires a `PreToolUse` keepalive hook per the Python SDK requirement. No websocket, no timeout concerns, no architectural changes — the callback returns immediately with a static response.

**File:** `server/services/agent.py`

```python
async def can_use_tool(
    tool_name: str, input_data: dict, _context: ToolPermissionContext,
) -> PermissionResultAllow | PermissionResultDeny:
    if tool_name == "AskUserQuestion":
        questions = input_data.get("questions", [])
        answers = {
            q.get("question", ""): "Please ask this question directly in your text response."
            for q in questions
        }
        return PermissionResultAllow(
            updated_input={"questions": questions, "answers": answers},
        )
    return PermissionResultAllow(updated_input=input_data)

async def _keepalive_hook(_input_data, _tool_use_id, _context):
    return {"continue_": True}

options = ClaudeAgentOptions(
    ...
    can_use_tool=can_use_tool,
    hooks={"PreToolUse": [HookMatcher(matcher=None, hooks=[_keepalive_hook])]},
    ...
)
```

## Files Changed

| File | Change |
|------|--------|
| `server/services/system_prompt.py` | Added "Do NOT use AskUserQuestion" to Tool Usage section |
| `server/services/agent.py` | Added `can_use_tool` callback, `_keepalive_hook`, `PermissionResult*` / `ToolPermissionContext` imports |

## Documentation

- [AskUserQuestion & canUseTool callback](https://platform.claude.com/docs/en/agent-sdk/user-input)
- [Permission modes (bypassPermissions)](https://platform.claude.com/docs/en/agent-sdk/permissions)
- [Hooks reference (PreToolUse)](https://platform.claude.com/docs/en/agent-sdk/hooks)