### PR TITLE
feat: add reusable-ip skill for JIT access to databricks-field-eng/reusable-ip-ai

### DIFF
--- a/databricks-skills/databricks-reusable-ip/SKILL.md
+++ b/databricks-skills/databricks-reusable-ip/SKILL.md
@@ -1,14 +1,14 @@
 ---
-name: reusable-ip
-description: "Production-ready Databricks reference implementations (agent deployment, model serving, CI/CD, Genie Spaces, Lakebase, DABs, A/B testing, Claude Code). TRIGGER: before writing any Databricks implementation code. ACTION: fetch llms.txt index first, then fetch only relevant files."
+name: databricks-reusable-ip
+description: "Production-ready Databricks reference implementations (agent deployment, model serving, CI/CD, Genie Spaces, Lakebase, DABs, A/B testing, Claude Code). TRIGGER: when implementing a new Databricks pattern or porting a reference implementation. ACTION: fetch llms.txt index first, then fetch only relevant files."
 ---
 
 # Reusable IP — Databricks Reference Implementations
 
 ## When to Use
 
-Before writing any Databricks implementation code, check this repo for existing reference
-implementations. Covers: agent deployment, model serving (concurrent PyFunc), CI/CD,
+When implementing a new Databricks pattern or porting a reference implementation, check this repo
+for existing solutions. Covers: agent deployment, model serving (concurrent PyFunc), CI/CD,
 Genie Spaces, Lakebase, Databricks Asset Bundles (DABs), A/B testing, and Claude Code
 integration.
 
@@ -19,6 +19,9 @@ integration.
 gh api repos/databricks-field-eng/reusable-ip-ai/contents/llms.txt \
   --jq '.content' | base64 -d
 ```
+
+If this command fails (authentication error, access denied, or file not found), stop and inform
+the user that the reusable-ip-ai repo is inaccessible. Do not proceed with this skill.
 
 **Step 2: Identify relevant files** from the descriptions (not filenames alone).
 If nothing is relevant, proceed without fetching further.
@@ -33,11 +36,3 @@ gh api repos/databricks-field-eng/reusable-ip-ai/contents/PATH/TO/FILE \
 - Always fetch `llms.txt` first — do not guess file paths
 - Fetch MINIMUM files (1–3). Fetch additional files incrementally only if needed
 - Do not dump the full directory tree
-
-## Deep Dive (Optional)
-
-For architecture review or porting a full implementation:
-```bash
-npx repomix --remote https://github.com/databricks-field-eng/reusable-ip-ai
-```
-Use when `llms.txt` + targeted fetch is insufficient.

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest reusable-ip spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-reusable-ip databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -73,8 +73,8 @@ get_skill_description() {
         "databricks-iceberg") echo "Apache Iceberg - managed tables, UniForm, IRC, Snowflake interop, migration" ;;
         "databricks-jobs") echo "Databricks Lakeflow Jobs - workflow orchestration" ;;
         "databricks-python-sdk") echo "Databricks Python SDK, Connect, and REST API" ;;
+        "databricks-reusable-ip") echo "JIT access to reference implementations: agents, model serving, CI/CD, DABs, A/B testing" ;;
         "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
-        "reusable-ip") echo "Reusable IP best practices from databricks-field-eng/reusable-ip-ai" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
         "databricks-metric-views") echo "Unity Catalog Metric Views - governed business metrics in YAML" ;;


### PR DESCRIPTION
## Summary

- Adds new `databricks-skills/reusable-ip/` skill with a JIT fetch protocol
- Claude fetches `llms.txt` index first (~75 lines), then fetches only the 1–3 relevant files from `databricks-field-eng/reusable-ip-ai`
- Registers `reusable-ip` in `install_skills.sh` (`DATABRICKS_SKILLS` list + `get_skill_description()`)

## Test plan

- [ ] `./databricks-skills/install_skills.sh --list` shows `reusable-ip` with correct description
- [ ] `./databricks-skills/install_skills.sh reusable-ip` installs `.claude/skills/reusable-ip/SKILL.md`
- [ ] In Claude Code, invoke `/reusable-ip` and ask a Databricks implementation question — confirm Claude fetches `llms.txt` first, then at most 1–3 targeted files

This pull request was AI-assisted by Isaac.