### PR TITLE
feat: add databricks-lakebridge skill for data migration

### DIFF
--- a/databricks-skills/README.md
+++ b/databricks-skills/README.md
@@ -59,6 +59,7 @@ cp -r ai-dev-kit/databricks-skills/databricks-agent-bricks .claude/skills/
 - **databricks-spark-declarative-pipelines** - SDP (formerly DLT) in SQL/Python
 - **databricks-jobs** - Multi-task workflows, triggers, schedules
 - **databricks-synthetic-data-gen** - Realistic test data with Faker
+- **databricks-lakebridge** - Lakebridge: analyze, transpile, and reconcile for data migration
 
 ### 🚀 Development & Deployment
 - **databricks-asset-bundles** - DABs for multi-environment deployments

--- a/databricks-skills/databricks-lakebridge/SKILL.md
+++ b/databricks-skills/databricks-lakebridge/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: databricks-lakebridge
+description: "Databricks Labs Lakebridge: analyze source code complexity, transpile SQL/ETL to Databricks, and reconcile data between source and target systems."
+---
+
+Lakebridge is a Databricks Labs tool for data migration. It provides three core capabilities: **Analyze** (assess source code complexity), **Transpile** (convert SQL/ETL to Databricks), and **Reconcile** (verify data consistency post-migration).
+
+Documentation: https://databrickslabs.github.io/lakebridge/
+Repository: https://github.com/databrickslabs/lakebridge
+
+## When to Use
+
+Use this skill when the user mentions: "lakebridge", "transpile", "reconcile", "analyze" (in a migration context), "SQL migration", "code conversion", "data reconciliation", "Switch", "BladeBridge", "Morpheus", "remorph", or migrating from other databases/ETL tools to Databricks.
+
+## Overview
+
+| Capability | Description | CLI Command | Reference |
+|------------|-------------|-------------|-----------|
+| **Analyze** | Assess source code complexity and generate migration inventory | `databricks labs lakebridge analyze` | analyze.md |
+| **Transpile** | Convert SQL/ETL code to Databricks-compatible formats | `databricks labs lakebridge transpile` | transpile.md |
+| **Reconcile** | Verify data consistency between source and target systems | `databricks labs lakebridge reconcile` | reconcile.md |
+
+## Prerequisites
+
+1. **Databricks CLI** installed and authenticated:
+   ```bash
+   databricks auth login --host <workspace-url> --profile <profile-name>
+   ```
+
+2. **Install Lakebridge**:
+   ```bash
+   databricks labs install lakebridge --profile <profile-name>
+   ```
+
+3. **Install transpilers** (for Transpile capability):
+   ```bash
+   databricks labs lakebridge install-transpile --profile <profile-name>
+   ```
+   To include the LLM-powered Switch transpiler:
+   ```bash
+   databricks labs lakebridge install-transpile --include-llm-transpiler true --profile <profile-name>
+   ```
+
+## Quick Start
+
+### Analyze: Assess Source Code Complexity
+
+```bash
+databricks labs lakebridge analyze \
+  --source-directory /path/to/source/code \
+  --report-file /path/to/report.json \
+  --source-tech <source_technology>
+```
+
+See analyze.md for supported source technologies and configuration details.
+
+### Transpile: Convert SQL to Databricks
+
+```bash
+# Pattern-based transpilation (BladeBridge/Morpheus)
+databricks labs lakebridge transpile \
+  --transpiler-config-path /path/to/config.json \
+  --input-source /path/to/input \
+  --source-dialect <dialect> \
+  --output-folder /path/to/output
+
+# LLM-powered transpilation (Switch)
+databricks labs lakebridge llm-transpile \
+  --input-source /path/to/input \
+  --output-ws-folder /Workspace/Users/<user>/output \
+  --source-dialect <dialect> \
+  --profile <profile-name>
+```
+
+See transpile.md for transpiler comparison and configuration.
+
+### Reconcile: Verify Data Consistency
+
+```bash
+# Interactive configuration
+databricks labs lakebridge configure-reconcile
+
+# Run reconciliation
+databricks labs lakebridge reconcile
+```
+
+See reconcile.md for report types and configuration reference.
+
+## CLI Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `analyze` | Analyze source code complexity and generate reports |
+| `install-transpile` | Install transpiler components on workspace |
+| `describe-transpile` | Show installed transpiler configuration |
+| `transpile` | Run pattern-based transpilation (BladeBridge/Morpheus) |
+| `llm-transpile` | Run LLM-powered transpilation (Switch) |
+| `configure-reconcile` | Interactive reconcile configuration |
+| `reconcile` | Run data reconciliation |
+| `aggregates-reconcile` | Run aggregate-level reconciliation |
+
+All commands support `--profile <profile-name>` to specify the Databricks CLI profile.
+
+## Common Issues
+
+- **Environment variables override profiles**: `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, and `DATABRICKS_AUTH_TYPE` take precedence over `--profile`. Unset them if you need to use a profile:
+  ```bash
+  (unset DATABRICKS_HOST DATABRICKS_TOKEN DATABRICKS_AUTH_TYPE; databricks labs lakebridge <command> --profile <profile-name>)
+  ```
+- **Transpiler not found**: Run `databricks labs lakebridge install-transpile` before using `transpile` or `llm-transpile`.
+- **Supported sources change frequently**: Always check the [official documentation](https://databrickslabs.github.io/lakebridge/) for the latest supported source systems and dialects.
+
+## Reference Files
+
+- **analyze.md** - Source code analysis and complexity assessment
+- **transpile.md** - SQL/ETL transpilation with BladeBridge, Morpheus, and Switch
+- **reconcile.md** - Data reconciliation between source and target
+
+## Related Skills
+
+- `databricks-config` - Manage workspace connections and authentication
+- `databricks-dbsql` - Databricks SQL features (useful for understanding target dialect)
+- `databricks-unity-catalog` - Unity Catalog and volumes (used by reconcile for output)

--- a/databricks-skills/databricks-lakebridge/analyze.md
+++ b/databricks-skills/databricks-lakebridge/analyze.md
@@ -1,0 +1,54 @@
+# Analyze
+
+The Analyze capability assesses source code complexity and generates a migration inventory. It produces a complexity score for each job/file, which feeds into the Conversion Calculator for migration planning.
+
+Documentation: https://databrickslabs.github.io/lakebridge/assessment
+
+## What It Does
+
+- **Job complexity assessment**: Scores each source file/job by complexity (Simple, Medium, Complex, Very Complex)
+- **Comprehensive inventory**: Maps programs, transformations, functions, variables, and dependencies
+- **Cross-system interdependency mapping**: Identifies relationships between jobs and systems
+
+## Supported Source Technologies
+
+Source technologies are frequently updated. Always check the official documentation for the latest list:
+https://databrickslabs.github.io/lakebridge/assessment/analyzer
+
+## CLI Commands
+
+### analyze
+
+Analyze source code and generate a complexity report:
+
+```bash
+databricks labs lakebridge analyze \
+  --source-directory /path/to/source/code \
+  --report-file /path/to/report.json \
+  --source-tech <source_technology>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--source-directory` | Path to directory containing source code |
+| `--report-file` | Output path for the analysis report (JSON) |
+| `--source-tech` | Source technology identifier (see docs for valid values) |
+
+## Complexity Scoring
+
+The analyzer assigns complexity scores based on source-technology-specific rules. Scoring criteria vary by platform (SQL, DataStage, Talend, SSIS, Alteryx, BODS, SAS, Pentaho, etc.).
+
+Scores feed into the Conversion Calculator to estimate migration effort and prioritize workloads.
+
+For detailed scoring rules per technology, see:
+https://databrickslabs.github.io/lakebridge/assessment/analyzer/complexity_scoring
+
+## Metadata Export
+
+Some source technologies require metadata extraction before analysis. The export process varies by platform:
+
+- SQL-based systems: Extract DDL and stored procedures
+- ETL tools: Export job definitions and metadata files
+
+For platform-specific export instructions, see:
+https://databrickslabs.github.io/lakebridge/assessment/analyzer/export_metadata

--- a/databricks-skills/databricks-lakebridge/reconcile.md
+++ b/databricks-skills/databricks-lakebridge/reconcile.md
@@ -1,0 +1,113 @@
+# Reconcile
+
+The Reconcile capability verifies data consistency between source and target systems after migration. It supports schema validation, row-level comparison, and column-level data reconciliation.
+
+Documentation: https://databrickslabs.github.io/lakebridge/reconcile
+
+## Report Types
+
+| Type | Description |
+|------|-------------|
+| `schema` | Validate datatype compatibility between source and target |
+| `row` | Row-level hash-based reconciliation |
+| `data` | Row and column-level reconciliation using join columns |
+| `all` | Combined data + schema validation |
+
+## Supported Source Systems
+
+Source systems are frequently updated. Always check the official documentation:
+https://databrickslabs.github.io/lakebridge/reconcile
+
+## CLI Commands
+
+### configure-reconcile
+
+Interactive wizard to generate reconcile configuration:
+
+```bash
+databricks labs lakebridge configure-reconcile
+```
+
+### reconcile
+
+Run data reconciliation:
+
+```bash
+databricks labs lakebridge reconcile
+```
+
+### aggregates-reconcile
+
+Run aggregate-level reconciliation (SUM, AVG, COUNT, MIN, MAX, etc.):
+
+```bash
+databricks labs lakebridge aggregates-reconcile
+```
+
+## Configuration
+
+Reconcile uses a JSON configuration file. Key configuration elements:
+
+### Table Configuration
+
+| Field | Description |
+|-------|-------------|
+| `source_name` | Fully qualified source table name (required) |
+| `target_name` | Fully qualified target table name (required) |
+| `join_columns` | Primary key columns for matching rows |
+| `select_columns` | Columns to include (default: all) |
+| `drop_columns` | Columns to exclude |
+| `column_mapping` | Source-to-target column name mapping |
+| `transformations` | SQL expressions for data normalization before comparison |
+| `filters` | WHERE conditions for source and/or target |
+
+### Thresholds
+
+| Field | Description |
+|-------|-------------|
+| `column_thresholds` | Per-column variance tolerance (percentile, boundary, or date type) |
+| `table_thresholds` | Overall mismatch tolerance for the table |
+
+### Aggregates
+
+Supported aggregate functions: `SUM`, `AVG`, `COUNT`, `MIN`, `MAX`, `MODE`, `STDDEV`, `VARIANCE`, `MEDIAN`
+
+### JDBC Reader Options
+
+For large tables, configure parallel reads:
+
+| Field | Description |
+|-------|-------------|
+| `number_partitions` | Number of parallel partitions |
+| `column` | Partition column |
+| `lower_bound` / `upper_bound` | Partition range |
+
+## Secret Scope Configuration
+
+Database credentials are stored in Databricks secret scopes:
+
+| Source System | Default Scope |
+|---------------|---------------|
+| General | `lakebridge_data_source` |
+| Snowflake | `lakebridge_snowflake` |
+| Oracle | `lakebridge_oracle` |
+| MS SQL Server | `lakebridge_mssql` |
+| Synapse | `lakebridge_synapse` |
+| Databricks | `lakebridge_databricks` |
+
+## Output Metrics Tables
+
+Reconciliation results are written to Delta tables:
+
+| Table | Description |
+|-------|-------------|
+| `schema_comparison` | Schema-level comparison results |
+| `schema_difference` | Schema differences between source and target |
+| `missing_in_src` | Rows present in target but missing in source |
+| `missing_in_tgt` | Rows present in source but missing in target |
+| `mismatch_data` | Row-level data mismatches |
+| `threshold_mismatch` | Mismatches exceeding defined thresholds |
+| `mismatch_columns` | Column-level mismatch summary |
+
+For full configuration reference and examples, see:
+https://databrickslabs.github.io/lakebridge/reconcile/reconcile_configuration

--- a/databricks-skills/databricks-lakebridge/transpile.md
+++ b/databricks-skills/databricks-lakebridge/transpile.md
@@ -1,0 +1,96 @@
+# Transpile
+
+The Transpile capability converts SQL and ETL code from various source systems to Databricks-compatible formats. Lakebridge provides three transpiler engines with different strengths.
+
+Documentation: https://databrickslabs.github.io/lakebridge/transpile
+
+## Transpiler Comparison
+
+| Transpiler | Approach | Strengths | Best For |
+|------------|----------|-----------|----------|
+| **BladeBridge** | Pattern-based (Perl + Python LSP) | Configurable rules, real-time LSP, handles ETL | DataStage, Informatica, large-scale SQL |
+| **Morpheus** | Grammar-based (ANTLR + Scala) | Deterministic, strong equivalence | Snowflake, T-SQL to Databricks SQL |
+| **Switch** | LLM-powered | Handles ambiguity, non-SQL formats, extensible | Complex SQL, Airflow, Python/Scala, custom sources |
+
+## Supported Source Dialects
+
+Source dialects and transpiler coverage are frequently updated. Always check the official documentation:
+https://databrickslabs.github.io/lakebridge/transpile
+
+## CLI Commands
+
+### install-transpile
+
+Install transpiler components to the Databricks workspace:
+
+```bash
+# Install core transpilers
+databricks labs lakebridge install-transpile --profile <profile-name>
+
+# Include LLM-powered Switch transpiler
+databricks labs lakebridge install-transpile --include-llm-transpiler true --profile <profile-name>
+```
+
+### describe-transpile
+
+Show installed transpiler configuration:
+
+```bash
+databricks labs lakebridge describe-transpile --profile <profile-name>
+```
+
+### transpile (BladeBridge / Morpheus)
+
+Run pattern-based or grammar-based transpilation:
+
+```bash
+databricks labs lakebridge transpile \
+  --transpiler-config-path /path/to/config.json \
+  --input-source /path/to/input \
+  --source-dialect <dialect> \
+  --output-folder /path/to/output \
+  --profile <profile-name>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--transpiler-config-path` | Path to transpiler configuration JSON |
+| `--input-source` | Path to source SQL/ETL files |
+| `--source-dialect` | Source dialect (e.g., snowflake, tsql, oracle) |
+| `--output-folder` | Local output directory |
+| `--catalog-name` | Unity Catalog name (optional) |
+| `--schema-name` | Schema name (optional) |
+| `--skip-validation` | Skip output validation (optional) |
+
+### llm-transpile (Switch)
+
+Run LLM-powered transpilation:
+
+```bash
+databricks labs lakebridge llm-transpile \
+  --input-source /path/to/input \
+  --output-ws-folder /Workspace/Users/<user>/output \
+  --source-dialect <dialect> \
+  --accept-terms true \
+  --profile <profile-name>
+```
+
+| Option | Description |
+|--------|-------------|
+| `--input-source` | Path to source files |
+| `--output-ws-folder` | Workspace output folder path |
+| `--source-dialect` | Source dialect (e.g., mssql, snowflake, oracle, airflow) |
+| `--accept-terms` | Accept terms of service (required) |
+| `--foundation-model` | Foundation model to use (optional) |
+| `--catalog-name` | Unity Catalog name (optional) |
+| `--schema-name` | Schema name (optional) |
+
+## Switch Customization
+
+Switch supports custom YAML prompts for extending transpilation behavior or adding new source types. For details on creating custom prompts, see:
+https://databrickslabs.github.io/lakebridge/transpile/pluggable_transpilers/switch/customizing_switch
+
+## Transpiler Configuration
+
+BladeBridge and Morpheus use JSON configuration files for custom rules, schema mapping, and dialect-specific overrides. For configuration reference, see:
+https://databrickslabs.github.io/lakebridge/transpile/pluggable_transpilers/bladebridge/bladebridge_configuration

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -42,7 +42,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-aibi-dashboards databricks-asset-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-lakebridge databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -76,6 +76,7 @@ get_skill_description() {
         "databricks-unity-catalog") echo "System tables for lineage, audit, billing" ;;
         "databricks-lakebase-autoscale") echo "Lakebase Autoscale - managed PostgreSQL with autoscaling" ;;
         "databricks-lakebase-provisioned") echo "Lakebase Provisioned - data connections and reverse ETL" ;;
+        "databricks-lakebridge") echo "Lakebridge - analyze, transpile, and reconcile for data migration" ;;
         "databricks-metric-views") echo "Unity Catalog Metric Views - governed business metrics in YAML" ;;
         "databricks-model-serving") echo "Model Serving - deploy MLflow models and AI agents" ;;
         "databricks-parsing") echo "Document parsing with ai_parse_document and custom RAG pipelines" ;;
@@ -116,6 +117,7 @@ get_skill_extra_files() {
         "databricks-unity-catalog") echo "5-system-tables.md" ;;
         "databricks-lakebase-autoscale") echo "projects.md branches.md computes.md connection-patterns.md reverse-etl.md" ;;
         "databricks-lakebase-provisioned") echo "connection-patterns.md reverse-etl.md" ;;
+        "databricks-lakebridge") echo "analyze.md transpile.md reconcile.md" ;;
         "databricks-metric-views") echo "yaml-reference.md patterns.md" ;;
         "databricks-model-serving") echo "1-classical-ml.md 2-custom-pyfunc.md 3-genai-agents.md 4-tools-integration.md 5-development-testing.md 6-logging-registration.md 7-deployment.md 8-querying-endpoints.md 9-package-requirements.md" ;;
         "databricks-mlflow-evaluation") echo "references/CRITICAL-interfaces.md references/GOTCHAS.md references/patterns-context-optimization.md references/patterns-datasets.md references/patterns-evaluation.md references/patterns-scorers.md references/patterns-trace-analysis.md references/user-journeys.md" ;;


### PR DESCRIPTION
## Summary

Add a new `databricks-lakebridge` skill covering [Databricks Labs Lakebridge](https://github.com/databrickslabs/lakebridge), a data migration toolkit with three core capabilities:

- **Analyze** (`analyze.md`) - Source code complexity assessment and migration inventory
- **Transpile** (`transpile.md`) - SQL/ETL conversion via BladeBridge, Morpheus, and Switch
- **Reconcile** (`reconcile.md`) - Data consistency verification between source and target systems

Also updates `install_skills.sh` (skill list, description, extra files) and `databricks-skills/README.md`.

### Type of Change
- [x] Feature

Adds a new skill to help users work with Lakebridge for data migration workflows. Supported source systems and dialects are not hardcoded; the skill directs users to the official documentation since these are frequently updated.

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

Used Claude Code to research existing skill patterns, draft skill content based on Lakebridge documentation, and create the PR.

### Testing

- Verified SKILL.md frontmatter matches existing skill conventions (databricks-lakebase-autoscale, databricks-vector-search, etc.)
- Confirmed all documentation URLs resolve to https://databrickslabs.github.io/lakebridge/
- Verified install_skills.sh correctly lists the new skill with description and extra files

### Related Issues

N/A - New skill addition

### Screenshots/Demos

N/A - Markdown-only changes