### PR TITLE
fix: improve Cursor global MCP setup instructions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1523,8 +1523,19 @@ function Write-McpConfigs {
             }
             "cursor" {
                 if ($script:Scope -eq "global") {
-                    Write-Warn "Cursor global: configure in Settings > MCP"
-                    Write-Msg "  Command: $($script:VenvPython) | Args: $($script:McpEntry)"
+                    Write-Warn "Cursor global: manual MCP configuration required"
+                    Write-Msg "  1. Open Cursor -> Settings -> Cursor Settings -> Tools & MCP"
+                    Write-Msg "  2. Click New MCP Server"
+                    Write-Msg "  3. Add the following JSON config:"
+                    Write-Msg "     {"
+                    Write-Msg "       `"mcpServers`": {"
+                    Write-Msg "         `"databricks`": {"
+                    Write-Msg "           `"command`": `"$($script:VenvPython)`","
+                    Write-Msg "           `"args`": [`"$($script:McpEntry)`"],"
+                    Write-Msg "           `"env`": {`"DATABRICKS_CONFIG_PROFILE`": `"$($script:Profile)`"}"
+                    Write-Msg "         }"
+                    Write-Msg "       }"
+                    Write-Msg "     }"
                 } else {
                     Write-McpJson (Join-Path $BaseDir ".cursor\mcp.json")
                     Write-Ok "Cursor MCP config"

--- a/install.sh
+++ b/install.sh
@@ -1430,8 +1430,19 @@ write_mcp_configs() {
                 ;;
             cursor)
                 if [ "$SCOPE" = "global" ]; then
-                    warn "Cursor global: configure in Settings > MCP"
-                    msg "  Command: $VENV_PYTHON | Args: $MCP_ENTRY"
+                    warn "Cursor global: manual MCP configuration required"
+                    msg "  1. Open ${B}Cursor → Settings → Cursor Settings → Tools & MCP${N}"
+                    msg "  2. Click ${B}New MCP Server${N}"
+                    msg "  3. Add the following JSON config:"
+                    msg "     {"
+                    msg "       \"mcpServers\": {"
+                    msg "         \"databricks\": {"
+                    msg "           \"command\": \"$VENV_PYTHON\","
+                    msg "           \"args\": [\"$MCP_ENTRY\"],"
+                    msg "           \"env\": {\"DATABRICKS_CONFIG_PROFILE\": \"$PROFILE\"}"
+                    msg "         }"
+                    msg "       }"
+                    msg "     }"
                 else
                     write_mcp_json "$base_dir/.cursor/mcp.json"
                     ok "Cursor MCP config"


### PR DESCRIPTION
## Summary

- Replace vague "configure in Settings > MCP" message with step-by-step instructions for Cursor global MCP setup
- Include formatted JSON config that users can copy-paste directly into Cursor's MCP settings
- Fix applied to both `install.sh` (macOS/Linux) and `install.ps1` (Windows)

Closes #288

## Test plan

- [x] Verified output for global scope shows clear step-by-step instructions with readable JSON
- [x] Verified output for project scope is unchanged (`✓ Cursor MCP config`)

This pull request was AI-assisted by Claude Code.