### PR TITLE
fix: update databricks-vector-search skill with search modes and operations docs

### DIFF
--- a/databricks-skills/databricks-vector-search/SKILL.md
+++ b/databricks-skills/databricks-vector-search/SKILL.md
@@ -31,8 +31,8 @@ Databricks Vector Search provides managed vector similarity search with automati
 
 | Type | Latency | Capacity | Cost | Best For |
 |------|---------|----------|------|----------|
-| **Standard** | ~50-100ms | 320M vectors (768 dim) | Higher | Real-time, low-latency |
-| **Storage-Optimized** | ~250ms | 1B+ vectors (768 dim) | 7x lower | Large-scale, cost-sensitive |
+| **Standard** | 20-50ms | 320M vectors (768 dim) | Higher | Real-time, low-latency |
+| **Storage-Optimized** | 300-500ms | 1B+ vectors (768 dim) | 7x lower | Large-scale, cost-sensitive |
 
 ## Index Types
 
@@ -184,13 +184,15 @@ results = w.vector_search_indexes.query_index(
 
 ### Hybrid Search (Semantic + Keyword)
 
+Hybrid search combines vector similarity (ANN) with BM25 keyword scoring. Use it when queries contain exact terms that must match — SKUs, error codes, proper nouns, or technical terminology — where pure semantic search might miss keyword-specific results. See [search-modes.md](search-modes.md) for detailed guidance on choosing between ANN and hybrid search.
+
 ```python
 # Combines vector similarity with keyword matching
 results = w.vector_search_indexes.query_index(
     index_name="catalog.schema.my_index",
     columns=["id", "content"],
-    query_text="machine learning algorithms",
-    query_type="hybrid",  # Enable hybrid search
+    query_text="SPARK-12345 executor memory error",
+    query_type="HYBRID",
     num_results=10
 )
 ```
@@ -212,20 +214,26 @@ results = w.vector_search_indexes.query_index(
 
 ### Storage-Optimized Filters (SQL-like)
 
+Storage-Optimized endpoints use SQL-like filter syntax via the `databricks-vectorsearch` package's `filters` parameter (accepts a string):
+
 ```python
-# filter_string uses SQL-like syntax
-results = w.vector_search_indexes.query_index(
-    index_name="catalog.schema.my_index",
-    columns=["id", "content"],
+from databricks.vector_search.client import VectorSearchClient
+
+vsc = VectorSearchClient()
+index = vsc.get_index(endpoint_name="my-storage-endpoint", index_name="catalog.schema.my_index")
+
+# SQL-like filter syntax for storage-optimized endpoints
+results = index.similarity_search(
     query_text="machine learning",
+    columns=["id", "content"],
     num_results=10,
-    filter_string="category = 'ai' AND status IN ('active', 'pending')"
+    filters="category = 'ai' AND status IN ('active', 'pending')"
 )
 
 # More filter examples
-filter_string="price > 100 AND price < 500"
-filter_string="department LIKE 'eng%'"
-filter_string="created_at >= '2024-01-01'"
+# filters="price > 100 AND price < 500"
+# filters="department LIKE 'eng%'"
+# filters="created_at >= '2024-01-01'"
 ```
 
 ### Trigger Index Sync
@@ -253,6 +261,8 @@ scan_result = w.vector_search_indexes.scan_index(
 |-------|------|-------------|
 | Index Types | [index-types.md](index-types.md) | Detailed comparison of Delta Sync (managed/self-managed) vs Direct Access |
 | End-to-End RAG | [end-to-end-rag.md](end-to-end-rag.md) | Complete walkthrough: source table → endpoint → index → query → agent integration |
+| Search Modes | [search-modes.md](search-modes.md) | When to use semantic (ANN) vs hybrid search, decision guide |
+| Operations | [troubleshooting-and-operations.md](troubleshooting-and-operations.md) | Monitoring, cost optimization, capacity planning, migration |
 
 ## CLI Quick Reference
 
@@ -288,7 +298,7 @@ databricks vector-search indexes delete-index \
 |-------|----------|
 | **Index sync slow** | Use Storage-Optimized endpoints (20x faster indexing) |
 | **Query latency high** | Use Standard endpoint for <100ms latency |
-| **filters_json not working** | Storage-Optimized uses `filter_string` (SQL syntax) |
+| **filters_json not working** | Storage-Optimized uses SQL-like string filters via `databricks-vectorsearch` package's `filters` parameter |
 | **Embedding dimension mismatch** | Ensure query and index dimensions match |
 | **Index not updating** | Check pipeline_type; use sync_index() for TRIGGERED |
 | **Out of capacity** | Upgrade to Storage-Optimized (1B+ vectors) |
@@ -297,10 +307,10 @@ databricks vector-search indexes delete-index \
 
 Databricks provides built-in embedding models:
 
-| Model | Dimensions | Use Case |
-|-------|------------|----------|
-| `databricks-gte-large-en` | 1024 | English text, high quality |
-| `databricks-bge-large-en` | 1024 | English text, general |
+| Model | Dimensions | Context Window | Use Case |
+|-------|------------|----------------|----------|
+| `databricks-gte-large-en` | 1024 | 8192 tokens | English text, high quality |
+| `databricks-bge-large-en` | 1024 | 512 tokens | English text, general purpose |
 
 ```python
 # Use with managed embeddings
@@ -350,7 +360,7 @@ The following MCP tools are available for managing Vector Search infrastructure.
 - **Delta Sync recommended** — easier than Direct Access for most scenarios
 - **Hybrid search** — available for both Delta Sync and Direct Access indexes
 - **`columns_to_sync` matters** — only synced columns are available in query results; include all columns you need
-- **Filter syntax differs by endpoint** — Standard uses `filters_json` (dict), Storage-Optimized uses `filter_string` (SQL)
+- **Filter syntax differs by endpoint** — Standard uses dict-format filters, Storage-Optimized uses SQL-like string filters. Use the `databricks-vectorsearch` package's `filters` parameter which accepts both formats
 - **Management vs runtime** — MCP tools above handle lifecycle management; for agent tool-calling at runtime, use `VectorSearchRetrieverTool` or the Databricks managed Vector Search MCP server
 
 ## Related Skills

--- a/databricks-skills/databricks-vector-search/end-to-end-rag.md
+++ b/databricks-skills/databricks-vector-search/end-to-end-rag.md
@@ -119,13 +119,13 @@ query_vs_index(
 The filter syntax depends on the endpoint type used when creating the index.
 
 ```python
-# Storage-Optimized endpoint (used in this walkthrough): SQL-like filter_string
+# Storage-Optimized endpoint (used in this walkthrough): SQL-like filter syntax
 query_vs_index(
     index_name="catalog.schema.knowledge_base_index",
     columns=["doc_id", "title", "content"],
     query_text="How do I govern my data?",
     num_results=3,
-    filter_string="category = 'governance'"
+    filters="category = 'governance'"
 )
 
 # Standard endpoint (if you created a Standard endpoint instead): JSON filters_json
@@ -236,4 +236,4 @@ Then sync — the index automatically handles deletions via Delta change data fe
 | **"Column not found in index"** | Column must be in `columns_to_sync`. Recreate index with the column included |
 | **Embeddings not computed** | Ensure `embedding_model_endpoint_name` is a valid serving endpoint |
 | **Stale results after table update** | For TRIGGERED pipelines, you must call `sync_vs_index` manually |
-| **Filter not working** | Standard endpoints use `filters_json` (dict), Storage-Optimized use `filter_string` (SQL) |
+| **Filter not working** | Standard endpoints use dict-format filters (`filters_json`), Storage-Optimized use SQL-like string filters (`filters`) |

--- a/databricks-skills/databricks-vector-search/search-modes.md
+++ b/databricks-skills/databricks-vector-search/search-modes.md
@@ -1,0 +1,142 @@
+# Vector Search Modes
+
+Databricks Vector Search supports three search modes: **ANN** (semantic, default), **HYBRID** (semantic + keyword), and **FULL_TEXT** (keyword only, beta). ANN and HYBRID work with Delta Sync and Direct Access indexes.
+
+## Semantic Search (ANN)
+
+ANN (Approximate Nearest Neighbor) is the default search mode. It finds documents by vector similarity — matching the *meaning* of your query against stored embeddings.
+
+### When to use
+
+- Conceptual or meaning-based queries ("How do I handle errors in my pipeline?")
+- Paraphrased input where exact terms may not appear in the documents
+- Multilingual scenarios where query and document languages may differ
+- General-purpose RAG retrieval
+
+### Example
+
+```python
+# ANN is the default — no query_type parameter needed
+results = w.vector_search_indexes.query_index(
+    index_name="catalog.schema.my_index",
+    columns=["id", "content"],
+    query_text="How do I handle errors in my pipeline?",
+    num_results=5
+)
+```
+
+## Hybrid Search
+
+Hybrid search combines vector similarity (ANN) with BM25 keyword scoring. It retrieves documents that are both semantically similar *and* contain matching keywords, then merges the results.
+
+### When to use
+
+- Queries containing exact terms that must appear: SKUs, product codes, error codes, acronyms
+- Proper nouns — company names, people, specific technologies
+- Technical documentation where terminology precision matters
+- Mixed-intent queries combining concepts with specific terms
+
+### Example
+
+```python
+results = w.vector_search_indexes.query_index(
+    index_name="catalog.schema.my_index",
+    columns=["id", "content"],
+    query_text="SPARK-12345 executor memory error",
+    query_type="HYBRID",
+    num_results=10
+)
+```
+
+## Decision Guide
+
+| Mode | Best for | Trade-off | Choose when |
+|------|----------|-----------|-------------|
+| **ANN** (default) | Conceptual queries, paraphrases, meaning-based search | Fastest; may miss exact keyword matches | You want documents *about* a topic regardless of exact wording |
+| **HYBRID** | Exact terms, codes, proper nouns, mixed-intent queries | ~2x resource usage vs ANN; max 200 results | Your queries contain specific identifiers or technical terms that must appear in results |
+| **FULL_TEXT** (beta) | Pure keyword search without vector embeddings | No semantic understanding; max 200 results | You need keyword matching only, without vector similarity |
+
+**Start with ANN.** Switch to HYBRID if you notice relevant documents being missed because they don't share vocabulary with the query.
+
+## Combining Search Modes with Filters
+
+Both search modes support filters. The filter syntax depends on your endpoint type:
+
+- **Standard endpoints** → `filters` as dict (or `filters_json` as JSON string via `databricks-sdk`)
+- **Storage-Optimized endpoints** → `filters` as SQL-like string (via `databricks-vectorsearch` package)
+
+### Standard endpoint with hybrid search
+
+```python
+results = w.vector_search_indexes.query_index(
+    index_name="catalog.schema.my_index",
+    columns=["id", "content", "category"],
+    query_text="SPARK-12345 executor memory error",
+    query_type="HYBRID",
+    num_results=10,
+    filters_json='{"category": "troubleshooting", "status": ["open", "in_progress"]}'
+)
+```
+
+### Storage-Optimized endpoint with hybrid search
+
+```python
+from databricks.vector_search.client import VectorSearchClient
+
+vsc = VectorSearchClient()
+index = vsc.get_index(endpoint_name="my-storage-endpoint", index_name="catalog.schema.my_index")
+
+results = index.similarity_search(
+    query_text="SPARK-12345 executor memory error",
+    columns=["id", "content", "category"],
+    query_type="hybrid",
+    num_results=10,
+    filters="category = 'troubleshooting' AND status IN ('open', 'in_progress')"
+)
+```
+
+## Using with Pre-Computed Embeddings
+
+If you compute embeddings yourself, use `query_vector` instead of `query_text` for ANN search:
+
+```python
+# ANN with pre-computed embedding (default)
+results = w.vector_search_indexes.query_index(
+    index_name="catalog.schema.my_index",
+    columns=["id", "content"],
+    query_vector=[0.1, 0.2, 0.3, ...],  # Your embedding vector
+    num_results=10
+)
+```
+
+For **hybrid search with self-managed embeddings** (indexes without an associated model endpoint), you must provide **both** `query_vector` and `query_text`. The vector is used for the ANN component and the text for the BM25 keyword component:
+
+```python
+# HYBRID with self-managed embeddings — requires both vector AND text
+results = w.vector_search_indexes.query_index(
+    index_name="catalog.schema.my_index",
+    columns=["id", "content"],
+    query_vector=[0.1, 0.2, 0.3, ...],  # For ANN similarity
+    query_text="executor memory error",   # For BM25 keyword matching
+    query_type="HYBRID",
+    num_results=10
+)
+```
+
+**Notes:**
+- For **ANN** queries: provide either `query_text` or `query_vector`, not both.
+- For **HYBRID** queries on **managed embedding indexes**: provide only `query_text` (the system handles both components).
+- For **HYBRID** queries on **self-managed indexes without a model endpoint**: provide both `query_vector` and `query_text`.
+- When using `query_text` alone, the index must have an associated embedding model (managed embeddings or `embedding_model_endpoint_name` on a Direct Access index).
+
+## Parameter Reference
+
+| Parameter | Type | Package | Description |
+|-----------|------|---------|-------------|
+| `query_text` | `str` | Both | Text query — requires embedding model on the index |
+| `query_vector` | `list[float]` | Both | Pre-computed embedding vector |
+| `query_type` | `str` | Both | `"ANN"` (default) or `"HYBRID"` or `"FULL_TEXT"` (beta) |
+| `columns` | `list[str]` | Both | Column names to return in results |
+| `num_results` | `int` | Both | Number of results (default: 10 in `databricks-sdk`, 5 in `databricks-vectorsearch`) |
+| `filters_json` | `str` | `databricks-sdk` | JSON dict filter string (Standard endpoints) |
+| `filters` | `str` or `dict` | `databricks-vectorsearch` | Dict for Standard, SQL-like string for Storage-Optimized |

--- a/databricks-skills/databricks-vector-search/troubleshooting-and-operations.md
+++ b/databricks-skills/databricks-vector-search/troubleshooting-and-operations.md
@@ -1,0 +1,177 @@
+# Vector Search Troubleshooting & Operations
+
+Operational guidance for monitoring, cost optimization, capacity planning, and migration of Databricks Vector Search resources.
+
+## Monitoring Endpoint Status
+
+Use `get_vs_endpoint` (MCP tool) or `w.vector_search_endpoints.get_endpoint()` (SDK) to check endpoint health.
+
+### Endpoint fields
+
+| Field | Description |
+|-------|-------------|
+| `state` | `ONLINE`, `PROVISIONING`, `OFFLINE`, `YELLOW_STATE`, `RED_STATE`, `DELETED` |
+| `message` | Human-readable status or error message |
+| `endpoint_type` | `STANDARD` or `STORAGE_OPTIMIZED` |
+| `num_indexes` | Number of indexes hosted on this endpoint |
+| `creation_timestamp` | When the endpoint was created |
+| `last_updated_timestamp` | When the endpoint was last modified |
+
+### Example
+
+```python
+endpoint = w.vector_search_endpoints.get_endpoint(endpoint_name="my-endpoint")
+print(f"State: {endpoint.endpoint_status.state.value}")
+print(f"Indexes: {endpoint.num_indexes}")
+```
+
+**What to do per state:**
+- `PROVISIONING` → Wait. Endpoint creation is asynchronous and can take several minutes.
+- `ONLINE` → Ready to serve queries and host indexes.
+- `OFFLINE` → Check the `message` field for error details. May require recreation.
+- `YELLOW_STATE` → Endpoint is degraded but still serving. Investigate the `message` field.
+- `RED_STATE` → Endpoint is unhealthy. Check `message` for details; may need support intervention.
+
+## Monitoring Index Status
+
+Use `get_vs_index` (MCP tool) or `w.vector_search_indexes.get_index()` (SDK) to check index health.
+
+### Index fields
+
+| Field | Description |
+|-------|-------------|
+| `status.ready` | Boolean — `True` when ready for queries, `False` when provisioning/syncing |
+| `status.message` | Status details or error information |
+| `status.index_url` | URL to access the index in the Databricks UI |
+| `status.indexed_row_count` | Number of rows currently indexed |
+| `delta_sync_index_spec.pipeline_id` | DLT pipeline ID (Delta Sync indexes only) — useful for debugging sync issues |
+| `index_type` | `DELTA_SYNC` or `DIRECT_ACCESS` |
+
+### Example
+
+```python
+index = w.vector_search_indexes.get_index(index_name="catalog.schema.my_index")
+if index.status.ready:
+    print("Index is ONLINE")
+else:
+    print(f"Index is NOT_READY: {index.status.message}")
+```
+
+## Pipeline Type Trade-offs
+
+Delta Sync indexes use a DLT pipeline to sync data from the source Delta table. The pipeline type determines sync behavior:
+
+| Pipeline Type | Behavior | Cost | Best for |
+|---------------|----------|------|----------|
+| **TRIGGERED** | Manual sync via `sync_vs_index()` | Lower — runs only when triggered | Batch updates, periodic refreshes, cost-sensitive workloads |
+| **CONTINUOUS** | Auto-syncs on source table changes | Higher — always running | Real-time freshness, applications needing up-to-date results |
+
+### Triggering a sync
+
+```python
+# For TRIGGERED pipelines only
+w.vector_search_indexes.sync_index(index_name="catalog.schema.my_index")
+# Check sync progress with get_index()
+```
+
+**Tip:** CONTINUOUS pipelines cannot be synced manually — they sync automatically. Calling `sync_index()` on a CONTINUOUS index will raise an error.
+
+## Cost Optimization
+
+### Endpoint type selection
+
+| Factor | Standard | Storage-Optimized |
+|--------|----------|-------------------|
+| Query latency | 20-50ms | 300-500ms |
+| Cost | Higher | ~7x lower |
+| Max capacity | 320M vectors (768 dim) | 1B+ vectors (768 dim) |
+| Indexing speed | Slower | 20x faster |
+
+**Recommendation:** Start with Storage-Optimized unless you need sub-100ms latency. It handles most RAG workloads well.
+
+### Reducing storage costs
+
+- Use `columns_to_sync` to limit which columns are synced to the index. Only synced columns are available in query results, so include only what you need.
+- Choose TRIGGERED pipelines for batch workloads to avoid continuous compute costs.
+
+```python
+# Only sync the columns you actually need in query results
+delta_sync_index_spec={
+    "source_table": "catalog.schema.documents",
+    "embedding_source_columns": [
+        {"name": "content", "embedding_model_endpoint_name": "databricks-gte-large-en"}
+    ],
+    "pipeline_type": "TRIGGERED",
+    "columns_to_sync": ["id", "content", "title"]  # Exclude large unused columns
+}
+```
+
+## Capacity Planning
+
+| Endpoint Type | Max Vectors (768 dim) | Guidance |
+|---------------|----------------------|----------|
+| Standard | ~320M | Suitable for most production workloads under 300M documents |
+| Storage-Optimized | 1B+ | Large-scale corpora, enterprise knowledge bases |
+
+**Estimating needs:**
+- One document typically maps to one vector (or multiple if chunked)
+- If chunking at ~512 tokens, expect 2-5 vectors per page of text
+- Monitor `num_indexes` on your endpoint to understand utilization
+
+## Migration Patterns
+
+### Changing endpoint type
+
+Endpoints are **immutable after creation** — you cannot change the type (Standard ↔ Storage-Optimized) of an existing endpoint. To migrate:
+
+1. **Create a new endpoint** with the desired type
+2. **Recreate indexes** on the new endpoint pointing to the same source tables
+3. **Wait for sync** to complete (check index state)
+4. **Update applications** to query the new index names
+5. **Delete old indexes**, then delete the old endpoint
+
+```python
+# Step 1: Create new endpoint
+w.vector_search_endpoints.create_endpoint(
+    name="my-endpoint-storage-optimized",
+    endpoint_type="STORAGE_OPTIMIZED"
+)
+
+# Step 2: Recreate index on new endpoint (same source table)
+w.vector_search_indexes.create_index(
+    name="catalog.schema.my_index_v2",
+    endpoint_name="my-endpoint-storage-optimized",
+    primary_key="id",
+    index_type="DELTA_SYNC",
+    delta_sync_index_spec={
+        "source_table": "catalog.schema.documents",
+        "embedding_source_columns": [
+            {"name": "content", "embedding_model_endpoint_name": "databricks-gte-large-en"}
+        ],
+        "pipeline_type": "TRIGGERED"
+    }
+)
+
+# Step 3: Trigger sync and wait for ONLINE state
+w.vector_search_indexes.sync_index(index_name="catalog.schema.my_index_v2")
+
+# Step 4: Update your application to use "catalog.schema.my_index_v2"
+# Step 5: Clean up old resources
+w.vector_search_indexes.delete_index(index_name="catalog.schema.my_index")
+w.vector_search_endpoints.delete_endpoint(endpoint_name="my-endpoint")
+```
+
+## Expanded Troubleshooting
+
+| Issue | Likely Cause | Solution |
+|-------|-------------|----------|
+| **Index stuck in NOT_READY** | Sync pipeline failed or source table issue | Check `message` field via `get_vs_index()`. Inspect the DLT pipeline using `pipeline_id`. |
+| **Embedding dimension mismatch** | Query vector dimensions ≠ index dimensions | Ensure your embedding model output matches the `embedding_dimension` in the index spec. |
+| **Permission errors on create** | Missing Unity Catalog privileges | User needs `CREATE TABLE` on the schema and `USE CATALOG`/`USE SCHEMA` privileges. |
+| **Index returns NOT_FOUND** | Wrong name format or index deleted | Index names must be fully qualified: `catalog.schema.index_name`. |
+| **Sync not running (TRIGGERED)** | Sync not triggered after source update | Call `sync_vs_index()` or `w.vector_search_indexes.sync_index()` after updating source data. |
+| **Endpoint NOT_FOUND** | Endpoint name typo or deleted | List all endpoints with `get_vs_endpoint()` (no name) to verify available endpoints. |
+| **Query returns empty results** | Index not yet synced, or filters too restrictive | Check index state is ONLINE. Verify `columns_to_sync` includes queried columns. Test without filters first. |
+| **filters_json has no effect** | Using wrong filter syntax for endpoint type | Standard endpoints use dict-format filters (`filters_json` in SDK, `filters` as dict in `databricks-vectorsearch`). Storage-Optimized endpoints use SQL-like string filters (`filters` as str in `databricks-vectorsearch`). |
+| **Quota or capacity errors** | Too many indexes or vectors | Check `num_indexes` on endpoint. Consider Storage-Optimized for higher capacity. |
+| **Upsert fails on Delta Sync** | Cannot upsert to Delta Sync indexes | Upsert/delete operations only work on Direct Access indexes. Delta Sync indexes update via their source table. |


### PR DESCRIPTION
## Summary
- Add `search-modes.md`: ANN vs HYBRID vs FULL_TEXT decision guide, filter combinations, self-managed embedding patterns
- Add `troubleshooting-and-operations.md`: endpoint/index monitoring, cost optimization, capacity planning, migration workflows
- Update `SKILL.md`: expand hybrid search section, add reference file links, update latency numbers and filter syntax for `databricks-vectorsearch` package
- Update `end-to-end-rag.md`: align filter parameter names with `databricks-vectorsearch` package

## Context
The `databricks-vector-search` skill had a bare 5-line hybrid search snippet with no explanation, and no guidance on production operations. This PR adds two on-demand reference files (zero context bloat) and makes small fixes to existing docs to align filter parameter names with the `databricks-vectorsearch` package API surface.

## Test plan
- [x] All relative links resolve correctly from SKILL.md
- [x] Code examples use correct parameter names matching `indexes.py` and `vector_search.py`
- [x] Rendered markdown reviewed for both new files
- [x] No claims about features not present in the codebase

This pull request was AI-assisted by Isaac.