### PR TITLE
fix: correct Real-Time Mode (Pattern 3) in kafka-streaming skill

### DIFF
--- a/databricks-skills/databricks-spark-structured-streaming/kafka-streaming.md
+++ b/databricks-skills/databricks-spark-structured-streaming/kafka-streaming.md
@@ -140,30 +140,30 @@ df_bronze.writeStream \
 
 ### Pattern 3: Real-Time Mode (Sub-Second Latency)
 
-Use RTM for < 800ms latency requirements:
+Use RTM for sub-second (as low as 5ms) latency requirements. Requires DBR 16.4 LTS+:
 
 ```python
-# Real-time trigger (Databricks 13.3+)
+# Real-time trigger (DBR 16.4 LTS+)
+# Requirements: dedicated cluster, no autoscaling, no Photon, outputMode("update")
+# Spark config on cluster: spark.databricks.streaming.realTimeMode.enabled = true
 query = (enriched_df
     .select(col("key"), col("value"))
     .writeStream
     .format("kafka")
     .option("kafka.bootstrap.servers", brokers)
     .option("topic", "output-events")
-    .trigger(realTime=True)  # Enable RTM
+    .outputMode("update")         # RTM only supports update mode
+    .trigger(realTime="5 minutes")  # PySpark requires specifying the checkpoint interval
     .option("checkpointLocation", checkpoint_path)
     .start()
 )
 
-# RTM Cluster Requirements
-spark.conf.set("spark.databricks.photon.enabled", "true")
-spark.conf.set("spark.sql.streaming.stateStore.providerClass", 
-               "com.databricks.sql.streaming.state.RocksDBStateProvider")
-
 # When to use RTM:
-# - Latency < 800ms required
-# - Photon enabled
-# - Fixed-size cluster (no autoscaling)
+# - Sub-second latency required (achieves as low as 5ms E2E)
+# - Photon must be DISABLED (not supported with RTM)
+# - Autoscaling must be DISABLED
+# - Dedicated (single-user) cluster only
+# - forEachBatch is NOT supported in RTM
 ```
 
 ### Pattern 4: Event Enrichment (Kafka to Kafka with Delta)


### PR DESCRIPTION
## Summary
- Fixes incorrect Real-Time Mode (RTM) configuration and requirements in the `kafka-streaming` skill's Pattern 3
- Corrected against the official Databricks docs: https://docs.databricks.com/aws/en/structured-streaming/real-time

### Key corrections:
- **DBR version**: `13.3+` → `16.4 LTS+`
- **Photon**: was listed as required → must be **disabled** (not supported with RTM)
- **Spark config**: removed `photon.enabled` and RocksDB settings; added `spark.databricks.streaming.realTimeMode.enabled = true`
- **Trigger syntax**: `trigger(realTime=True)` → `trigger(realTime="5 minutes")` (PySpark requires specifying the checkpoint interval)
- **Output mode**: added `outputMode("update")` (only mode RTM supports)
- **Latency**: `< 800ms` → `as low as 5ms E2E`
- **Limitations**: added note that `forEachBatch` is not supported in RTM

## Test plan
- [ ] Verify Pattern 3 code example matches the official Databricks RTM documentation
- [ ] Confirm no other patterns in the file were modified