### PR TITLE
fix: parse query_tags string into List[QueryTag] for execute_statement

### DIFF
--- a/databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py
+++ b/databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py
@@ -86,7 +86,13 @@ class SQLExecutor:
         if row_limit is not None:
             exec_params["row_limit"] = row_limit
         if query_tags:
-            exec_params["query_tags"] = query_tags
+            from databricks.sdk.service.sql import QueryTag
+            exec_params["query_tags"] = [
+                QueryTag(key=k.strip(), value=v.strip())
+                for pair in query_tags.split(",")
+                for k, v in [pair.split(":", 1)]
+                if ":" in pair
+            ]
 
         # Submit the statement
         try:


### PR DESCRIPTION
## Summary
- `execute_sql` crashes with `'str' object has no attribute 'as_dict'` when `query_tags` is provided
- The SDK expects `Optional[List[QueryTag]]`, not a raw string
- Parse `"key:value,key2:value2"` into `[QueryTag(key=..., value=...)]` before passing to `execute_statement()`

## Changes
- `databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py` — 7 lines changed (lines 88-94)

## Test Plan
Tested against live Databricks API (serverless warehouse):
- ✅ No query_tags (baseline) — SUCCEEDED
- ❌ String `"team:eng"` (current bug) — `'str' object has no attribute 'as_dict'`
- ✅ `[QueryTag(key='team', value='eng')]` (fix) — SUCCEEDED
- ✅ Edge cases: empty string, single tag, colons in values, spaces, malformed input

Fixes #358