### PR TITLE
fix: remove compromised litellm from shipped packages, add NOTICE.txt

### DIFF
--- a/.test/pyproject.toml
+++ b/.test/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 [project.optional-dependencies]
 databricks = ["databricks-sdk>=0.20.0"]
 dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
-optimize = ["gepa>=0.1.0", "tiktoken>=0.7.0"]
+optimize = ["gepa>=0.1.0", "tiktoken>=0.7.0", "litellm<=1.82.6"]
 agent = ["claude-agent-sdk>=0.1.39"]
 # judges group: install separately when mlflow-deepeval/mlflow-ragas are published
 # judges = ["mlflow-deepeval>=0.1.0", "mlflow-ragas>=0.1.0"]

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,100 @@
+Databricks AI Dev Kit
+Copyright 2026 Databricks, Inc.
+
+This product is licensed under the Databricks License. See the LICENSE.md
+file for the full license text.
+
+This product includes software developed by third parties. Below is a list
+of those third-party components and their respective licenses.
+
+________________________________________________________________________________
+
+MIT License (https://opensource.org/licenses/MIT)
+
+  fastmcp
+  https://github.com/jlowin/fastmcp
+  Copyright (c) 2024 Jeremiah Lowin
+
+  mcp (Python SDK)
+  https://github.com/modelcontextprotocol/python-sdk
+  Copyright (c) 2024 Anthropic, PBC
+
+  sqlglot
+  https://github.com/tobymao/sqlglot
+  Copyright (c) 2023 Toby Mao
+
+  sqlfluff
+  https://github.com/sqlfluff/sqlfluff
+  Copyright (c) 2019 Alan Cruickshank
+
+  claude-agent-sdk
+  https://github.com/anthropics/claude-code
+  Copyright (c) 2024 Anthropic, PBC
+
+  fastapi
+  https://github.com/fastapi/fastapi
+  Copyright (c) 2018 Sebastian Ramirez
+
+  sqlalchemy
+  https://github.com/sqlalchemy/sqlalchemy
+  Copyright (c) 2005-2024 Michael Bayer and contributors
+
+  alembic
+  https://github.com/sqlalchemy/alembic
+  Copyright (c) 2009-2024 Michael Bayer
+
+  greenlet
+  https://github.com/python-greenlet/greenlet
+  Copyright (c) Alexey Borzenkov
+
+  pydantic
+  https://github.com/pydantic/pydantic
+  Copyright (c) 2017-2024 Samuel Colvin and other contributors
+
+  requests
+  https://github.com/psf/requests
+  Copyright (c) 2011-2024 Kenneth Reitz
+
+________________________________________________________________________________
+
+BSD 3-Clause License (https://opensource.org/licenses/BSD-3-Clause)
+
+  uvicorn
+  https://github.com/encode/uvicorn
+  Copyright (c) 2017-present, Encode OSS Ltd.
+
+  httpx
+  https://github.com/encode/httpx
+  Copyright (c) 2019-present, Encode OSS Ltd.
+
+________________________________________________________________________________
+
+Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+
+  databricks-sdk
+  https://github.com/databricks/databricks-sdk-py
+  Copyright (c) 2023 Databricks, Inc.
+
+  anthropic (Python SDK)
+  https://github.com/anthropics/anthropic-sdk-python
+  Copyright (c) 2023 Anthropic, PBC
+
+________________________________________________________________________________
+
+AGPL-3.0 License (https://www.gnu.org/licenses/agpl-3.0.html)
+
+  pymupdf
+  https://github.com/pymupdf/PyMuPDF
+  Copyright (c) 2015-2024 Artifex Software, Inc.
+
+________________________________________________________________________________
+
+LGPL-3.0 License (https://www.gnu.org/licenses/lgpl-3.0.html)
+
+  psycopg2-binary
+  https://github.com/psycopg/psycopg2
+  Copyright (c) 2001-2024 Federico Di Gregorio and Daniele Varrazzo
+
+  psycopg (psycopg3)
+  https://github.com/psycopg/psycopg
+  Copyright (c) 2020-2024 Daniele Varrazzo

--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ The source in this project is provided subject to the [Databricks License](https
 | [mcp](https://github.com/modelcontextprotocol/python-sdk) | ≥1.0.0 | MIT | https://github.com/modelcontextprotocol/python-sdk |
 | [sqlglot](https://github.com/tobymao/sqlglot) | ≥20.0.0 | MIT | https://github.com/tobymao/sqlglot |
 | [sqlfluff](https://github.com/sqlfluff/sqlfluff) | ≥3.0.0 | MIT | https://github.com/sqlfluff/sqlfluff |
-| [litellm](https://github.com/BerriAI/litellm) | ≥1.0.0 | MIT | https://github.com/BerriAI/litellm |
 | [pymupdf](https://github.com/pymupdf/PyMuPDF) | ≥1.24.0 | AGPL-3.0 | https://github.com/pymupdf/PyMuPDF |
 | [claude-agent-sdk](https://github.com/anthropics/claude-code) | ≥0.1.19 | MIT | https://github.com/anthropics/claude-code |
 | [fastapi](https://github.com/fastapi/fastapi) | ≥0.115.8 | MIT | https://github.com/fastapi/fastapi |

--- a/databricks-builder-app/pyproject.toml
+++ b/databricks-builder-app/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
   "requests>=2.31.0",
   "sqlglot>=20.0.0",
   "sqlfluff>=3.0.0",
-  "litellm>=1.0.0",
   "pymupdf>=1.24.0",
   # Conflict resolution pins for Databricks Apps pre-installed packages
   "tenacity==9.0.0",

--- a/databricks-builder-app/requirements.txt
+++ b/databricks-builder-app/requirements.txt
@@ -31,7 +31,6 @@ fastmcp>=0.1.0
 requests>=2.31.0
 sqlglot>=20.0.0
 sqlfluff>=3.0.0
-litellm>=1.0.0
 pymupdf>=1.24.0
 
 # Conflict resolution pins for Databricks Apps pre-installed packages


### PR DESCRIPTION
## Summary

- **Security**: LiteLLM v1.82.7/v1.82.8 were compromised via CI/CD supply chain attack ([details](https://ramimac.me/trivy-teampcp/#phase-09)). Our repo declared `litellm>=1.0.0` in shipped packages but **never actually imported it** — phantom dependency.
- **Removed** `litellm` from `databricks-builder-app/pyproject.toml`, `databricks-builder-app/requirements.txt` (already removed from `databricks-tools-core` upstream)
- **Pinned** `litellm<=1.82.6` in `.test/pyproject.toml` optimize group where it's actually used
- **Removed** litellm from README third-party licenses table
- **Added** `NOTICE.txt` with third-party software attribution grouped by license type

## Test plan

- [ ] Verify `litellm` does not appear in any shipped package dependency lists
- [ ] Verify `.test` optimize install resolves `litellm<=1.82.6`
- [ ] Review `NOTICE.txt` for completeness against shipped dependencies

This pull request was AI-assisted by Isaac.