### PR TITLE
Fixed --skills flag to exclude core skills during explicit selection 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -667,7 +667,7 @@ resolve_skills() {
         local user_list
         user_list=$(echo "$USER_SKILLS" | tr ',' ' ')
         # Separate into DB, MLflow, and APX buckets, always include core
-        db_skills="$CORE_SKILLS"
+        db_skills=""
         for skill in $user_list; do
             if echo "$MLFLOW_SKILLS" | grep -qw "$skill"; then
                 mlflow_skills="${mlflow_skills:+$mlflow_skills }$skill"


### PR DESCRIPTION
Summary of changes:
Fixes #370 
Updated the resolve_skills() function in install.sh. Initialized db_skills as an empty string instead of pre-loading CORE_SKILLS when USER_SKILLS argument is explicitly provided.

Testing:
did bash install.sh --skills-only --skills databricks-jobs,databricks-dbsql and verified that only the two explicitly requested skills were staged for the installation