### PR TITLE
Fix install_skills_to_genie_code.sh uploading only 2 of 35 skills

### DIFF
--- a/databricks-skills/install_skills_to_genie_code.sh
+++ b/databricks-skills/install_skills_to_genie_code.sh
@@ -11,7 +11,7 @@ set -e
 PROFILE=${1:-"DEFAULT"}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-LOCAL_SKILLS_DIR="$PROJECT_ROOT/.claude/skills"
+LOCAL_SKILLS_DIR="$SCRIPT_DIR/.claude/skills"
 
 echo "================================================"
 echo "Deploying Skills to Databricks Assistant"


### PR DESCRIPTION
## Summary

Fixes #381

`install_skills_to_genie_code.sh` was only uploading 2 skills to the workspace instead of all 35.

**Problem:** `LOCAL_SKILLS_DIR` on line 14 was set to `$PROJECT_ROOT/.claude/skills` which resolves to `ai-dev-kit/.claude/skills`. However, `install_skills.sh` (called on line 31) installs all 35 skills into `ai-dev-kit/databricks-skills/.claude/skills` — a different directory. The upload loop on line 93 then only found the 2 pre-existing skills (`databricks-python-sdk` and `python-dev`) in the parent directory.

**Fix:** Changed `LOCAL_SKILLS_DIR` from `$PROJECT_ROOT/.claude/skills` to `$SCRIPT_DIR/.claude/skills` so it points to the same directory where `install_skills.sh` actually installs the skills.

## Test plan

- [x] Ran `./install_skills_to_genie_code.sh fevm-classic-stable-been2c` after the fix
- [x] Confirmed all 35 skills were uploaded to the workspace (previously only 2)
- [x] Verified skills visible in workspace at `/Users/<email>/.assistant/skills/`

Before
<img width="864" height="250" alt="image" src="https://github.com/user-attachments/assets/8bbaaf5b-242f-4075-98e0-317205d4b949" />

After
<img width="864" height="725" alt="image" src="https://github.com/user-attachments/assets/aeb56b23-d8eb-41d4-b6ad-5bd02429875e" />
