### PR TITLE
Fix claude-agent-sdk hash after republish

### DIFF
--- a/databricks-builder-app/requirements.txt
+++ b/databricks-builder-app/requirements.txt
@@ -772,6 +772,9 @@ jaraco-functools==4.4.0 \
     --hash=sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176 \
     --hash=sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb
     # via keyring
+jeepney==0.9.0 \
+    --hash=sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683
+    # via secretstorage
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
@@ -2129,6 +2132,9 @@ sentry-sdk==3.0.0a7 \
     --hash=sha256:439a858d409b84407560df6b7ebb760acd9ad3d14e05cd919ae36b204e411cb2 \
     --hash=sha256:ada791a77c2d489e07b04c068e0fcacd6bbcfe1cb40b5f303207738baf38e868
     # via fastapi-cloud-cli
+secretstorage==3.5.0 \
+    --hash=sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137
+    # via keyring
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de


### PR DESCRIPTION
## Summary
- Updates the hash for `claude-agent-sdk` in `databricks-builder-app/requirements.txt` as the package was republished with different contents

## Test plan
- [x] Verify `pip install -r requirements.txt` succeeds with the updated hash