### PR TITLE
Fix: Prevent IME composition Enter from sending chat messages

### DIFF
--- a/databricks-builder-app/client/src/pages/ProjectPage.tsx
+++ b/databricks-builder-app/client/src/pages/ProjectPage.tsx
@@ -1055,7 +1055,7 @@ export default function ProjectPage() {
 
   // Handle keyboard submit
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSendMessage();
     }


### PR DESCRIPTION
## Summary
- Fix an issue where pressing Enter to confirm IME (Input Method Editor) composition (e.g., Japanese, Chinese, Korean input) inadvertently sends the chat message
- Add `e.nativeEvent.isComposing` check to `handleKeyDown` so that Enter during IME composition is ignored

## Changes
- `databricks-builder-app/client/src/pages/ProjectPage.tsx` — Add `!e.nativeEvent.isComposing` condition to the keyboard event handler

## Test plan
- [x] Type with an IME (e.g., Japanese), press Enter to confirm conversion → message should NOT be sent
- [x] Without IME active, press Enter → message should be sent as before
- [x] Shift+Enter → should insert a newline as before