### PR TITLE
fix: convert optional job params to SDK types in create_job

### DIFF
--- a/databricks-tools-core/databricks_tools_core/jobs/jobs.py
+++ b/databricks-tools-core/databricks_tools_core/jobs/jobs.py
@@ -12,6 +12,16 @@ from databricks.sdk.service.jobs import (
     JobCluster,
     JobEnvironment,
     JobSettings,
+    JobEmailNotifications,
+    WebhookNotifications,
+    JobNotificationSettings,
+    CronSchedule,
+    QueueSettings,
+    JobRunAs,
+    GitSource,
+    JobParameterDefinition,
+    JobsHealthRules,
+    JobDeployment,
 )
 
 from ..auth import get_workspace_client
@@ -210,31 +220,31 @@ def create_job(
                     env["spec"]["client"] = "4"
             kwargs["environments"] = [JobEnvironment.from_dict(env) for env in environments]
 
-        # Add optional parameters
+        # Add optional parameters, converting dicts to SDK objects
         if tags:
             kwargs["tags"] = tags
         if timeout_seconds is not None:
             kwargs["timeout_seconds"] = timeout_seconds
         if email_notifications:
-            kwargs["email_notifications"] = email_notifications
+            kwargs["email_notifications"] = JobEmailNotifications.from_dict(email_notifications)
         if webhook_notifications:
-            kwargs["webhook_notifications"] = webhook_notifications
+            kwargs["webhook_notifications"] = WebhookNotifications.from_dict(webhook_notifications)
         if notification_settings:
-            kwargs["notification_settings"] = notification_settings
+            kwargs["notification_settings"] = JobNotificationSettings.from_dict(notification_settings)
         if schedule:
-            kwargs["schedule"] = schedule
+            kwargs["schedule"] = CronSchedule.from_dict(schedule)
         if queue:
-            kwargs["queue"] = queue
+            kwargs["queue"] = QueueSettings.from_dict(queue)
         if run_as:
-            kwargs["run_as"] = run_as
+            kwargs["run_as"] = JobRunAs.from_dict(run_as)
         if git_source:
-            kwargs["git_source"] = git_source
+            kwargs["git_source"] = GitSource.from_dict(git_source)
         if parameters:
-            kwargs["parameters"] = parameters
+            kwargs["parameters"] = [JobParameterDefinition.from_dict(p) for p in parameters]
         if health:
-            kwargs["health"] = health
+            kwargs["health"] = JobsHealthRules.from_dict(health)
         if deployment:
-            kwargs["deployment"] = deployment
+            kwargs["deployment"] = JobDeployment.from_dict(deployment)
 
         # Add any extra settings
         kwargs.update(extra_settings)


### PR DESCRIPTION
## Summary
- Added missing SDK type imports (`JobEmailNotifications`, `CronSchedule`, `QueueSettings`, etc.)
- Convert all optional parameters in `create_job()` from raw dicts to proper SDK objects via `.from_dict()`, matching the existing pattern used for `tasks`, `job_clusters`, and `environments`
- Fixes SDK serialization errors when using features like email notifications, schedules, run_as, etc.

Fixes #399

## Test Results

### Test 1: `create_job` with `email_notifications` ✅
Created job `sample-job-with-notifications` with:
```json
"email_notifications": {
  "on_start": ["user@example.com"],
  "on_success": ["user@example.com"],
  "on_failure": ["user@example.com"]
}
```
**Result:** Job created successfully. GET confirmed all three notification lists persisted correctly.

### Test 2: `create_job` with `schedule`, `queue`, `parameters`, `health` ✅
Created job `test-sdk-type-conversion-full` with all optional params:
```json
"schedule": {"quartz_cron_expression": "0 0 9 * * ?", "timezone_id": "Asia/Kolkata", "pause_status": "PAUSED"},
"queue": {"enabled": true},
"parameters": [{"name": "env", "default": "dev"}],
"health": {"rules": [{"metric": "RUN_DURATION_SECONDS", "op": "GREATER_THAN", "value": 3600}]}
```
**Result:** Job created successfully. GET confirmed all parameters persisted with correct types and values.

### Summary

| Parameter | Status |
|---|---|
| `email_notifications` | ✅ Passed |
| `schedule` | ✅ Passed |
| `queue` | ✅ Passed |
| `parameters` | ✅ Passed |
| `health` | ✅ Passed |
| `webhook_notifications` | ⬜ Not tested (requires webhook endpoint) |
| `run_as` | ⬜ Not tested (requires service principal) |
| `git_source` | ⬜ Not tested (requires git integration) |
| `deployment` | ⬜ Not tested (requires deployment config) |

Both test jobs were cleaned up after verification.

This pull request was AI-assisted by Isaac.