### PR TITLE
Quote PARENT_DIR in setup script

### DIFF
--- a/databricks-mcp-server/setup.sh
+++ b/databricks-mcp-server/setup.sh
@@ -7,7 +7,7 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PARENT_DIR=$(dirname ${SCRIPT_DIR})
+PARENT_DIR="$(dirname "${SCRIPT_DIR}")"
 TOOLS_CORE_DIR="${PARENT_DIR}/databricks-tools-core"
 echo AI Dev Kit directory: $PARENT_DIR
 echo MCP Server directory: $SCRIPT_DIR


### PR DESCRIPTION
This PR fixes the unquoted path assignment in ai-dev-kit/databricks-mcp-server/setup.sh to make the setup script safer for paths containing spaces.