### PR TITLE
Add experimental branch installation option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,23 +157,91 @@ The experimental branch allows users to opt-in to early access features. It must
           PR_NUMBER="${{ steps.find-or-create-pr.outputs.pr_number }}"
 
           echo ""
-          echo "╔══════════════════════════════════════════════════════════════════╗"
-          echo "║                    ❌ RELEASE BLOCKED                            ║"
-          echo "╠══════════════════════════════════════════════════════════════════╣"
-          echo "║                                                                  ║"
-          echo "║  The experimental branch has merge conflicts with main.          ║"
-          echo "║                                                                  ║"
-          echo "║  Before releasing, you must:                                     ║"
-          echo "║                                                                  ║"
-          echo "║  1. Resolve conflicts in PR #$PR_NUMBER"
-          echo "║     $PR_URL"
-          echo "║                                                                  ║"
-          echo "║  2. Merge the PR                                                 ║"
-          echo "║                                                                  ║"
-          echo "║  3. Re-trigger this workflow (push to VERSION or re-run)         ║"
-          echo "║                                                                  ║"
-          echo "╚══════════════════════════════════════════════════════════════════╝"
+          echo "❌ RELEASE BLOCKED - Merge conflicts detected"
           echo ""
+          echo "📋 Sync PR: $PR_URL"
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "                         HOW TO FIX"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Open Claude Code in the ai-dev-kit repo and paste this prompt:"
+          echo ""
+          cat << 'PROMPT'
+━━━━━━━━━━━━━━━━━━━━━ COPY BELOW THIS LINE ━━━━━━━━━━━━━━━━━━━━━
+
+Merge main into experimental and resolve any conflicts.
+
+## Step 1: Start the merge
+
+Run:
+  git checkout experimental
+  git pull
+  git merge origin/main
+
+## Step 2: Understand what's in experimental (IMPORTANT - do this BEFORE resolving)
+
+I need you to fully understand the experimental branch before touching any conflicts.
+
+1. List commits only in experimental:
+   git log main..experimental --oneline
+
+2. For each commit, read the actual changes (not just the message):
+   git show <commit-hash> --stat
+   Then read the key files if needed.
+
+3. Give me a detailed summary:
+   - What experimental features exist (describe each one)
+   - What files are experimental-only vs modified from main
+   - The intent/purpose of these experimental changes
+
+Do NOT proceed to conflict resolution until you've given me this summary.
+
+## Step 3: Analyze each conflict
+
+Run: git diff --name-only --diff-filter=U
+
+For each conflicted file:
+1. Show me the conflict markers (the <<<<<<< ======= >>>>>>> sections)
+2. Explain what MAIN is changing (likely: bugfix, stable feature, refactor)
+3. Explain what EXPERIMENTAL is changing (likely: early-access feature)
+4. Explain if these changes are independent or overlapping
+
+## Step 4: Resolve conflicts
+
+Apply these rules:
+- **Independent changes** (different parts of file): Keep BOTH - main's updates AND experimental's features
+- **Compatible changes** (e.g., main fixed a bug in code experimental also modified): Apply main's fix within experimental's version
+- **Conflicting intent**: STOP and ask me. Based on your analysis from Step 2, explain the tradeoff and give me clear options to choose from.
+
+## Step 5: Complete the merge
+
+After ALL conflicts are resolved, commit with a detailed message:
+
+  git add .
+  git commit -m "Merge main into experimental
+
+  Kept from main:
+  - [list bugfixes and features from main]
+
+  Preserved from experimental:
+  - [list experimental features preserved]
+
+  Resolutions:
+  - [list any non-trivial merge decisions]
+  "
+  git push origin experimental
+
+## Step 6: Confirm
+
+Tell me when the merge is pushed so I can re-run the release workflow.
+
+━━━━━━━━━━━━━━━━━━━━━ COPY ABOVE THIS LINE ━━━━━━━━━━━━━━━━━━━━━
+PROMPT
+          echo ""
+          echo "After the merge is pushed, re-run this workflow."
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
           exit 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,237 @@
+name: Release
+
+# Triggers when VERSION file is updated on main (typically via a version bump PR)
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'VERSION'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  SYNC_PR_BRANCH: sync-main-to-experimental
+  EXPERIMENTAL_BRANCH: experimental
+
+jobs:
+  sync-experimental:
+    name: Sync Experimental Branch
+    runs-on: ubuntu-latest
+    outputs:
+      synced: ${{ steps.check-sync.outputs.synced }}
+      pr_number: ${{ steps.find-or-create-pr.outputs.pr_number }}
+      pr_url: ${{ steps.find-or-create-pr.outputs.pr_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if experimental branch exists
+        id: check-experimental
+        run: |
+          if git ls-remote --heads origin ${{ env.EXPERIMENTAL_BRANCH }} | grep -q ${{ env.EXPERIMENTAL_BRANCH }}; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "::notice::Experimental branch does not exist yet. It will be created from main."
+          fi
+
+      - name: Create experimental branch if missing
+        if: steps.check-experimental.outputs.exists == 'false'
+        run: |
+          git checkout -b ${{ env.EXPERIMENTAL_BRANCH }}
+          git push origin ${{ env.EXPERIMENTAL_BRANCH }}
+          echo "::notice::Created '${{ env.EXPERIMENTAL_BRANCH }}' branch from main"
+
+      - name: Check if experimental is in sync with main
+        id: check-sync
+        if: steps.check-experimental.outputs.exists == 'true'
+        run: |
+          git fetch origin ${{ env.EXPERIMENTAL_BRANCH }}
+
+          # Check if main is ahead of experimental
+          BEHIND_COUNT=$(git rev-list --count origin/${{ env.EXPERIMENTAL_BRANCH }}..origin/main)
+
+          if [ "$BEHIND_COUNT" -eq 0 ]; then
+            echo "synced=true" >> $GITHUB_OUTPUT
+            echo "::notice::✅ Experimental branch is in sync with main"
+          else
+            echo "synced=false" >> $GITHUB_OUTPUT
+            echo "behind_count=$BEHIND_COUNT" >> $GITHUB_OUTPUT
+            echo "::warning::Experimental branch is $BEHIND_COUNT commit(s) behind main"
+          fi
+
+      - name: Find or create sync PR
+        id: find-or-create-pr
+        if: steps.check-sync.outputs.synced == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check for existing open PR
+          EXISTING_PR=$(gh pr list --head main --base ${{ env.EXPERIMENTAL_BRANCH }} --state open --json number,url --jq '.[0]')
+
+          if [ -n "$EXISTING_PR" ]; then
+            PR_NUMBER=$(echo "$EXISTING_PR" | jq -r '.number')
+            PR_URL=$(echo "$EXISTING_PR" | jq -r '.url')
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+            echo "pr_existed=true" >> $GITHUB_OUTPUT
+            echo "::notice::Found existing sync PR #$PR_NUMBER"
+          else
+            # Create new PR
+            PR_URL=$(gh pr create \
+              --title "🔄 Sync: merge main into experimental" \
+              --body "## Auto-generated sync PR
+
+This PR keeps the \`experimental\` branch up to date with \`main\`.
+
+### Why is this needed?
+The experimental branch allows users to opt-in to early access features. It must stay in sync with main to ensure experimental users get all stable fixes and features.
+
+### What to do?
+- **If this PR has no conflicts**: It will be auto-merged by the release workflow
+- **If this PR has conflicts**: Please resolve them manually, then the next release attempt will succeed
+
+---
+*This PR was automatically created by the release workflow.*" \
+              --head main \
+              --base ${{ env.EXPERIMENTAL_BRANCH }})
+
+            PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+            echo "pr_existed=false" >> $GITHUB_OUTPUT
+            echo "::notice::Created sync PR #$PR_NUMBER: $PR_URL"
+          fi
+
+      - name: Check PR mergeability
+        id: check-mergeable
+        if: steps.check-sync.outputs.synced == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.find-or-create-pr.outputs.pr_number }}"
+
+          # Wait a moment for GitHub to compute mergeability
+          sleep 5
+
+          # Get PR mergeable state
+          MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable --jq '.mergeable')
+
+          echo "mergeable=$MERGEABLE" >> $GITHUB_OUTPUT
+
+          if [ "$MERGEABLE" = "MERGEABLE" ]; then
+            echo "::notice::✅ Sync PR #$PR_NUMBER is mergeable (no conflicts)"
+          elif [ "$MERGEABLE" = "CONFLICTING" ]; then
+            echo "::error::❌ Sync PR #$PR_NUMBER has merge conflicts that must be resolved manually"
+          else
+            echo "::warning::⏳ Sync PR #$PR_NUMBER mergeability is unknown (state: $MERGEABLE)"
+          fi
+
+      - name: Auto-merge sync PR
+        id: auto-merge
+        if: steps.check-sync.outputs.synced == 'false' && steps.check-mergeable.outputs.mergeable == 'MERGEABLE'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.find-or-create-pr.outputs.pr_number }}"
+
+          echo "Auto-merging sync PR #$PR_NUMBER..."
+          gh pr merge "$PR_NUMBER" --merge --admin -t "Sync main into experimental (auto-merge)"
+
+          echo "merged=true" >> $GITHUB_OUTPUT
+          echo "::notice::✅ Successfully merged sync PR #$PR_NUMBER"
+
+      - name: Fail if conflicts exist
+        if: steps.check-sync.outputs.synced == 'false' && steps.check-mergeable.outputs.mergeable == 'CONFLICTING'
+        run: |
+          PR_URL="${{ steps.find-or-create-pr.outputs.pr_url }}"
+          PR_NUMBER="${{ steps.find-or-create-pr.outputs.pr_number }}"
+
+          echo ""
+          echo "╔══════════════════════════════════════════════════════════════════╗"
+          echo "║                    ❌ RELEASE BLOCKED                            ║"
+          echo "╠══════════════════════════════════════════════════════════════════╣"
+          echo "║                                                                  ║"
+          echo "║  The experimental branch has merge conflicts with main.          ║"
+          echo "║                                                                  ║"
+          echo "║  Before releasing, you must:                                     ║"
+          echo "║                                                                  ║"
+          echo "║  1. Resolve conflicts in PR #$PR_NUMBER"
+          echo "║     $PR_URL"
+          echo "║                                                                  ║"
+          echo "║  2. Merge the PR                                                 ║"
+          echo "║                                                                  ║"
+          echo "║  3. Re-trigger this workflow (push to VERSION or re-run)         ║"
+          echo "║                                                                  ║"
+          echo "╚══════════════════════════════════════════════════════════════════╝"
+          echo ""
+
+          exit 1
+
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: sync-experimental
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "::notice::Releasing version $VERSION"
+
+      - name: Check if tag already exists
+        id: check-tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "::warning::Tag v$VERSION already exists, skipping release creation"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create and push tag
+        if: steps.check-tag.outputs.exists == 'false'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          echo "::notice::Created tag v$VERSION"
+
+      - name: Create GitHub Release
+        if: steps.check-tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes \
+            --latest
+
+          echo ""
+          echo "╔══════════════════════════════════════════════════════════════════╗"
+          echo "║                    ✅ RELEASE SUCCESSFUL                         ║"
+          echo "╠══════════════════════════════════════════════════════════════════╣"
+          echo "║                                                                  ║"
+          echo "║  Version: v$VERSION"
+          echo "║                                                                  ║"
+          echo "║  • GitHub Release created                                        ║"
+          echo "║  • Experimental branch is in sync                                ║"
+          echo "║                                                                  ║"
+          echo "╚══════════════════════════════════════════════════════════════════╝"

--- a/install.ps1
+++ b/install.ps1
@@ -76,6 +76,7 @@ $script:ProfileProvided = $false
 $script:SkillsProfile = ""
 $script:UserSkills   = ""
 $script:ListSkills   = $false
+$script:Channel      = if ($env:DEVKIT_CHANNEL) { $env:DEVKIT_CHANNEL } else { "stable" }  # stable or experimental
 
 # Databricks skills (bundled in repo)
 $script:Skills = @(
@@ -219,6 +220,7 @@ while ($i -lt $args.Count) {
         { $_ -in "--skills-profile", "-SkillsProfile" } { $script:SkillsProfile = $args[$i + 1]; $i += 2 }
         { $_ -in "--skills", "-Skills" }       { $script:UserSkills = $args[$i + 1]; $i += 2 }
         { $_ -in "--list-skills", "-ListSkills" } { $script:ListSkills = $true; $i++ }
+        { $_ -in "--experimental", "-Experimental" } { $script:Channel = "experimental"; $i++ }
         { $_ -in "-f", "--force", "-Force" }   { $script:Force = $true; $i++ }
         { $_ -in "-h", "--help", "-Help" } {
             Write-Host "Databricks AI Dev Kit Installer (Windows)"
@@ -237,12 +239,14 @@ while ($i -lt $args.Count) {
             Write-Host "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
             Write-Host "  --skills LIST         Comma-separated skill names to install (overrides profile)"
             Write-Host "  --list-skills         List available skills and profiles, then exit"
+            Write-Host "  --experimental        Install from experimental branch (early access features)"
             Write-Host "  -f, --force           Force reinstall"
             Write-Host "  -h, --help            Show this help"
             Write-Host ""
             Write-Host "Environment Variables:"
             Write-Host "  AIDEVKIT_BRANCH       Branch or tag to install (default: latest release)"
             Write-Host "  AIDEVKIT_HOME         Installation directory (default: ~/.ai-dev-kit)"
+            Write-Host "  DEVKIT_CHANNEL        'stable' (default) or 'experimental'"
             Write-Host ""
             Write-Host "Examples:"
             Write-Host "  # Basic installation"
@@ -1620,6 +1624,9 @@ function Show-Summary {
     Write-Host ""
     Write-Host "Installation complete!" -ForegroundColor Green
     Write-Host "--------------------------------"
+    if ($script:Channel -eq "experimental") {
+        Write-Msg "Channel:  experimental 🧪"
+    }
     Write-Msg "Location: $($script:InstallDir)"
     Write-Msg "Scope:    $($script:Scope)"
     Write-Msg "Tools:    $(($script:Tools -split ' ') -join ', ')"
@@ -1648,6 +1655,15 @@ function Show-Summary {
     $step++
     Write-Msg "$step. Try: `"List my SQL warehouses`""
     Write-Host ""
+    if ($script:Channel -eq "experimental") {
+        Write-Host "  ============================================================" -ForegroundColor Yellow
+        Write-Host "  🧪 You're using the experimental channel" -ForegroundColor White
+        Write-Host "  ============================================================" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Msg "Thank you for testing early features! Your feedback helps us improve."
+        Write-Msg "Report issues: https://github.com/databricks-solutions/ai-dev-kit/issues"
+        Write-Host ""
+    }
 }
 
 # ─── Scope prompt ─────────────────────────────────────────────
@@ -1746,6 +1762,72 @@ function Invoke-PromptScope {
     $script:Scope = $values[$selected]
 }
 
+# ─── Release channel prompt ───────────────────────────────────
+function Invoke-PromptChannel {
+    # Skip if already set via --experimental flag or env var
+    if ($script:Channel -eq "experimental") { return }
+
+    # Skip in silent mode or non-interactive
+    if ($script:Silent) { return }
+    if (-not (Test-Interactive)) { return }
+
+    Write-Host ""
+    Write-Host "  Select release channel" -ForegroundColor White
+
+    $items = @(
+        @{ Label = "Stable";       Value = "stable";       Selected = $true;  Hint = "Latest stable release (recommended)" }
+        @{ Label = "Experimental"; Value = "experimental"; Selected = $false; Hint = "Early access to new features -- help us test!" }
+    )
+
+    $script:Channel = Select-Radio -Items $items
+
+    # If experimental was selected, re-download and re-exec from experimental branch
+    if ($script:Channel -eq "experimental") {
+        Write-Host ""
+        Write-Host "  ============================================================" -ForegroundColor Yellow
+        Write-Host "  🧪 Experimental Channel" -ForegroundColor White
+        Write-Host "  ============================================================" -ForegroundColor Yellow
+        Write-Host ""
+        Write-Host "  You're about to install the " -NoNewline
+        Write-Host "experimental" -ForegroundColor White -NoNewline
+        Write-Host " version of AI Dev Kit."
+        Write-Host "  This includes early access features that may change or break."
+        Write-Host ""
+        Write-Host "  We'd love your feedback!" -ForegroundColor White
+        Write-Host "  Report issues: https://github.com/databricks-solutions/ai-dev-kit/issues" -ForegroundColor Blue
+        Write-Host "  Discussions:   https://github.com/databricks-solutions/ai-dev-kit/discussions" -ForegroundColor Blue
+        Write-Host ""
+        Write-Host "  Downloading installer from experimental branch..." -ForegroundColor DarkGray
+        Write-Host ""
+
+        # Build argument list preserving current flags
+        $newArgs = @("--experimental")
+        if ($script:Force)               { $newArgs += "--force" }
+        if ($script:Silent)              { $newArgs += "--silent" }
+        if ($script:UserTools)           { $newArgs += "--tools"; $newArgs += $script:UserTools }
+        if ($script:UserMcpPath)         { $newArgs += "--mcp-path"; $newArgs += $script:UserMcpPath }
+        if ($script:SkillsProfile)       { $newArgs += "--skills-profile"; $newArgs += $script:SkillsProfile }
+        if ($script:UserSkills)          { $newArgs += "--skills"; $newArgs += $script:UserSkills }
+        if ($script:ScopeExplicit -and $script:Scope -eq "global") { $newArgs += "--global" }
+        if ($script:Profile_ -ne "DEFAULT") { $newArgs += "--profile"; $newArgs += $script:Profile_ }
+        if (-not $script:InstallMcp)     { $newArgs += "--skills-only" }
+        if (-not $script:InstallSkills)  { $newArgs += "--mcp-only" }
+
+        # Download experimental installer to a temp file and execute
+        $expUrl = "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.ps1"
+        $tempScript = Join-Path $env:TEMP "ai-dev-kit-install-experimental.ps1"
+        try {
+            Invoke-WebRequest -Uri $expUrl -OutFile $tempScript -UseBasicParsing -ErrorAction Stop
+        } catch {
+            Write-Err "Failed to download experimental installer from ${expUrl}: $($_.Exception.Message)"
+        }
+
+        # Execute the experimental installer with preserved args, then exit
+        & $tempScript @newArgs
+        exit $LASTEXITCODE
+    }
+}
+
 # ─── Auth prompt ──────────────────────────────────────────────
 function Invoke-PromptAuth {
     if ($script:Silent) { return }
@@ -1796,6 +1878,9 @@ function Invoke-Main {
         Write-Host "Databricks AI Dev Kit Installer" -ForegroundColor White
         Write-Host "--------------------------------"
     }
+
+    # ── Step 1: Release channel selection (may re-exec from experimental branch) ──
+    Invoke-PromptChannel
 
     # Check dependencies
     Write-Step "Checking prerequisites"
@@ -1849,6 +1934,9 @@ function Invoke-Main {
         Write-Host ""
         Write-Host "  Summary" -ForegroundColor White
         Write-Host "  ------------------------------------"
+        if ($script:Channel -eq "experimental") {
+            Write-Host "  Channel:     " -NoNewline; Write-Host "experimental 🧪" -ForegroundColor Yellow
+        }
         Write-Host "  Tools:       " -NoNewline; Write-Host "$(($script:Tools -split ' ') -join ', ')" -ForegroundColor Green
         Write-Host "  Profile:     " -NoNewline; Write-Host $script:Profile_ -ForegroundColor Green
         Write-Host "  Scope:       " -NoNewline; Write-Host $script:Scope -ForegroundColor Green
@@ -1858,10 +1946,14 @@ function Invoke-Main {
         if ($script:InstallSkills) {
             $skTotal = $script:SelectedSkills.Count + $script:SelectedMlflowSkills.Count + $script:SelectedApxSkills.Count
             if (-not [string]::IsNullOrWhiteSpace($script:UserSkills)) {
-                Write-Host "  Skills:      " -NoNewline; Write-Host "custom selection ($skTotal skills)" -ForegroundColor Green
+                Write-Host "  Skills:      " -NoNewline
+                Write-Host "custom selection ($skTotal skills)" -ForegroundColor Green -NoNewline
+                Write-Host " (will be overwritten, backup your changes first)" -ForegroundColor Yellow
             } else {
                 $profileDisplay = if ([string]::IsNullOrWhiteSpace($script:SkillsProfile)) { "all" } else { $script:SkillsProfile }
-                Write-Host "  Skills:      " -NoNewline; Write-Host "$profileDisplay ($skTotal skills)" -ForegroundColor Green
+                Write-Host "  Skills:      " -NoNewline
+                Write-Host "$profileDisplay ($skTotal skills)" -ForegroundColor Green -NoNewline
+                Write-Host " (will be overwritten, backup your changes first)" -ForegroundColor Yellow
             }
         }
         if ($script:InstallMcp) {

--- a/install.ps1
+++ b/install.ps1
@@ -1803,7 +1803,6 @@ function Invoke-PromptChannel {
         # Build argument list preserving current flags
         $newArgs = @("--experimental")
         if ($script:Force)               { $newArgs += "--force" }
-        if ($script:Silent)              { $newArgs += "--silent" }
         if ($script:UserTools)           { $newArgs += "--tools"; $newArgs += $script:UserTools }
         if ($script:UserMcpPath)         { $newArgs += "--mcp-path"; $newArgs += $script:UserMcpPath }
         if ($script:SkillsProfile)       { $newArgs += "--skills-profile"; $newArgs += $script:SkillsProfile }

--- a/install.sh
+++ b/install.sh
@@ -1663,21 +1663,20 @@ prompt_channel() {
         echo -e "  ${D}Downloading installer from experimental branch...${N}"
         echo ""
 
-        # Build the command with all current flags preserved
-        local args="--experimental"
-        [ "$FORCE" = true ] && args="$args --force"
-        [ "$SILENT" = true ] && args="$args --silent"
-        [ -n "$USER_TOOLS" ] && args="$args --tools $USER_TOOLS"
-        [ -n "$USER_MCP_PATH" ] && args="$args --mcp-path $USER_MCP_PATH"
-        [ -n "$SKILLS_PROFILE" ] && args="$args --skills-profile $SKILLS_PROFILE"
-        [ -n "$USER_SKILLS" ] && args="$args --skills $USER_SKILLS"
-        [ "$SCOPE_EXPLICIT" = true ] && [ "$SCOPE" = "global" ] && args="$args --global"
-        [ "$PROFILE" != "DEFAULT" ] && args="$args --profile $PROFILE"
-        [ "$INSTALL_MCP" = false ] && args="$args --skills-only"
-        [ "$INSTALL_SKILLS" = false ] && args="$args --mcp-only"
+        # Build the command with all current flags preserved (array preserves quoting)
+        local args=("--experimental")
+        [ "$FORCE" = true ] && args+=("--force")
+        [ -n "$USER_TOOLS" ] && args+=("--tools" "$USER_TOOLS")
+        [ -n "$USER_MCP_PATH" ] && args+=("--mcp-path" "$USER_MCP_PATH")
+        [ -n "$SKILLS_PROFILE" ] && args+=("--skills-profile" "$SKILLS_PROFILE")
+        [ -n "$USER_SKILLS" ] && args+=("--skills" "$USER_SKILLS")
+        [ "$SCOPE_EXPLICIT" = true ] && [ "$SCOPE" = "global" ] && args+=("--global")
+        [ "$PROFILE" != "DEFAULT" ] && args+=("--profile" "$PROFILE")
+        [ "$INSTALL_MCP" = false ] && args+=("--skills-only")
+        [ "$INSTALL_SKILLS" = false ] && args+=("--mcp-only")
 
         # Download and execute the experimental installer
-        exec bash <(curl -fsSL "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.sh") $args
+        exec bash <(curl -fsSL "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.sh") "${args[@]}"
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1799,11 +1799,11 @@ main() {
         [ "$INSTALL_MCP" = true ]    && echo -e "  MCP server:  ${G}${INSTALL_DIR}${N}"
         if [ "$INSTALL_SKILLS" = true ]; then
             if [ -n "$USER_SKILLS" ]; then
-                echo -e "  Skills:      ${G}custom selection${N}"
+                echo -e "  Skills:      ${G}custom selection${N} ${Y}(will be overwritten, backup your changes first)${N}"
             else
                 local sk_total=0
                 for _ in $SELECTED_SKILLS $SELECTED_MLFLOW_SKILLS $SELECTED_APX_SKILLS; do sk_total=$((sk_total + 1)); done
-                echo -e "  Skills:      ${G}${SKILLS_PROFILE:-all} ($sk_total skills)${N}"
+                echo -e "  Skills:      ${G}${SKILLS_PROFILE:-all} ($sk_total skills)${N} ${Y}(will be overwritten, backup your changes first)${N}"
             fi
         fi
         [ "$INSTALL_MCP" = true ]    && echo -e "  MCP config:  ${G}yes${N}"

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,7 @@ USER_TOOLS=""
 USER_MCP_PATH="${DEVKIT_MCP_PATH:-}"
 SKILLS_PROFILE="${DEVKIT_SKILLS_PROFILE:-}"
 USER_SKILLS="${DEVKIT_SKILLS:-}"
+CHANNEL="${DEVKIT_CHANNEL:-stable}"  # stable or experimental
 
 # Convert string booleans from env vars to actual booleans
 [ "$FORCE" = "true" ] || [ "$FORCE" = "1" ] && FORCE=true || FORCE=false
@@ -135,6 +136,7 @@ while [ $# -gt 0 ]; do
         --list-skills)    LIST_SKILLS=true; shift ;;
         --silent)         SILENT=true; shift ;;
         --tools)          USER_TOOLS="$2"; shift 2 ;;
+        --experimental)   CHANNEL="experimental"; shift ;;
         -f|--force)       FORCE=true; shift ;;
         -h|--help)        
             echo "Databricks AI Dev Kit Installer"
@@ -153,6 +155,7 @@ while [ $# -gt 0 ]; do
             echo "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
             echo "  --skills LIST         Comma-separated skill names to install (overrides profile)"
             echo "  --list-skills         List available skills and profiles, then exit"
+            echo "  --experimental        Install from experimental branch (early access features)"
             echo "  -f, --force           Force reinstall"
             echo "  -h, --help            Show this help"
             echo ""
@@ -166,6 +169,7 @@ while [ $# -gt 0 ]; do
             echo "  DEVKIT_SKILLS_PROFILE Comma-separated skill profiles"
             echo "  DEVKIT_SKILLS         Comma-separated skill names"
             echo "  DEVKIT_SILENT         Set to 'true' for silent mode"
+            echo "  DEVKIT_CHANNEL        'stable' (default) or 'experimental'"
             echo "  AIDEVKIT_HOME         Installation directory (default: ~/.ai-dev-kit)"
             echo ""
             echo "Examples:"
@@ -1509,6 +1513,7 @@ summary() {
         echo ""
         echo -e "${G}${B}Installation complete!${N}"
         echo "────────────────────────────────"
+        [ "$CHANNEL" = "experimental" ] && msg "Channel:  ${Y}experimental 🧪${N}"
         msg "Location: $INSTALL_DIR"
         msg "Scope:    $SCOPE"
         msg "Tools:    $(echo "$TOOLS" | tr ' ' ', ')"
@@ -1537,6 +1542,15 @@ summary() {
         step=$((step + 1))
         msg "${step}. Try: \"List my SQL warehouses\""
         echo ""
+        if [ "$CHANNEL" = "experimental" ]; then
+            echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+            echo -e "  ${B}🧪 You're using the experimental channel${N}"
+            echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+            echo ""
+            msg "Thank you for testing early features! Your feedback helps us improve."
+            msg "Report issues: ${BL}https://github.com/databricks-solutions/ai-dev-kit/issues${N}"
+            echo ""
+        fi
     fi
 }
 
@@ -1609,6 +1623,64 @@ prompt_scope() {
     SCOPE="${values[$selected]}"
 }
 
+# Prompt for release channel (stable vs experimental)
+prompt_channel() {
+    # Skip if already set via --experimental flag or env var
+    if [ "$CHANNEL" = "experimental" ]; then
+        return
+    fi
+
+    # Skip in silent mode or non-interactive
+    if [ "$SILENT" = true ] || [ ! -e /dev/tty ]; then
+        return
+    fi
+
+    echo ""
+    echo -e "  ${B}Select release channel${N}"
+
+    local selected
+    selected=$(radio_select \
+        "Stable|stable|on|Latest stable release (recommended)" \
+        "Experimental|experimental|off|Early access to new features — help us test!" \
+    )
+
+    CHANNEL="$selected"
+
+    # If experimental was selected, re-download and re-exec from experimental branch
+    if [ "$CHANNEL" = "experimental" ]; then
+        echo ""
+        echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+        echo -e "  ${B}🧪 Experimental Channel${N}"
+        echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+        echo ""
+        echo -e "  You're about to install the ${B}experimental${N} version of AI Dev Kit."
+        echo -e "  This includes early access features that may change or break."
+        echo ""
+        echo -e "  ${B}We'd love your feedback!${N}"
+        echo -e "  Report issues: ${BL}https://github.com/databricks-solutions/ai-dev-kit/issues${N}"
+        echo -e "  Discussions:   ${BL}https://github.com/databricks-solutions/ai-dev-kit/discussions${N}"
+        echo ""
+        echo -e "  ${D}Downloading installer from experimental branch...${N}"
+        echo ""
+
+        # Build the command with all current flags preserved
+        local args="--experimental"
+        [ "$FORCE" = true ] && args="$args --force"
+        [ "$SILENT" = true ] && args="$args --silent"
+        [ -n "$USER_TOOLS" ] && args="$args --tools $USER_TOOLS"
+        [ -n "$USER_MCP_PATH" ] && args="$args --mcp-path $USER_MCP_PATH"
+        [ -n "$SKILLS_PROFILE" ] && args="$args --skills-profile $SKILLS_PROFILE"
+        [ -n "$USER_SKILLS" ] && args="$args --skills $USER_SKILLS"
+        [ "$SCOPE_EXPLICIT" = true ] && [ "$SCOPE" = "global" ] && args="$args --global"
+        [ "$PROFILE" != "DEFAULT" ] && args="$args --profile $PROFILE"
+        [ "$INSTALL_MCP" = false ] && args="$args --skills-only"
+        [ "$INSTALL_SKILLS" = false ] && args="$args --mcp-only"
+
+        # Download and execute the experimental installer
+        exec bash <(curl -fsSL "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.sh") $args
+    fi
+}
+
 # Prompt to run auth
 prompt_auth() {
     if [ "$SILENT" = true ] || [ ! -e /dev/tty ]; then
@@ -1664,6 +1736,9 @@ main() {
         echo "────────────────────────────────"
     fi
     
+    # ── Step 1: Release channel selection (may re-exec from experimental branch) ──
+    prompt_channel
+
     # Check dependencies
     step "Checking prerequisites"
     check_deps
@@ -1717,6 +1792,7 @@ main() {
         echo ""
         echo -e "  ${B}Summary${N}"
         echo -e "  ────────────────────────────────────"
+        [ "$CHANNEL" = "experimental" ] && echo -e "  Channel:     ${Y}experimental 🧪${N}"
         echo -e "  Tools:       ${G}$(echo "$TOOLS" | tr ' ' ', ')${N}"
         echo -e "  Profile:     ${G}${PROFILE}${N}"
         echo -e "  Scope:       ${G}${SCOPE}${N}"


### PR DESCRIPTION
## Summary

- Adds **experimental channel selection** during installation, allowing users to opt-in to early access features
- Adds **release workflow** that ensures the `experimental` branch stays in sync with `main`

## Changes

### `install.sh` - Experimental channel UI
- New `--experimental` flag and `DEVKIT_CHANNEL` env var
- Interactive radio selector (Stable vs Experimental) as first prompt
- When experimental is selected:
  - Shows feedback request with GitHub links
  - Re-downloads `install.sh` from `experimental` branch
  - Re-executes with `--experimental` flag (preserving other args)
- Channel shown in summary and completion messages with 🧪 indicator

### `.github/workflows/release.yml` - Release automation
Triggers on `VERSION` file changes on main:

1. **Sync check**: Is `experimental` behind `main`?
2. **If behind**: Creates/finds sync PR (`main` → `experimental`)
   - No conflicts → auto-merge, proceed with release
   - Conflicts → block release with clear error message + PR link
3. **If synced**: Creates git tag + GitHub Release

## Test plan

- [ ] Test `--experimental` flag directly
- [ ] Test interactive channel selection (choose experimental)
- [ ] Verify re-exec downloads from experimental branch
- [ ] Test release workflow with experimental in sync
- [ ] Test release workflow with experimental behind (should auto-merge)
- [ ] Test release workflow with conflicts (should block with clear message)

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)