### PR TITLE
Add databricks-ai-gateway skill

### DIFF
--- a/databricks-skills/databricks-agent-bricks/SKILL.md
+++ b/databricks-skills/databricks-agent-bricks/SKILL.md
@@ -204,6 +204,7 @@ manage_mas(
 - **[databricks-spark-declarative-pipelines](../databricks-spark-declarative-pipelines/SKILL.md)** - Build bronze/silver/gold tables consumed by Genie Spaces
 - **[databricks-model-serving](../databricks-model-serving/SKILL.md)** - Deploy custom agent endpoints used as MAS agents
 - **[databricks-vector-search](../databricks-vector-search/SKILL.md)** - Build vector indexes for RAG applications paired with KAs
+- **[databricks-ai-gateway](../databricks-ai-gateway/SKILL.md)** - Add guardrails, rate limits, and governance to deployed agents
 
 ## See Also
 

--- a/databricks-skills/databricks-ai-gateway/1-guardrails.md
+++ b/databricks-skills/databricks-ai-gateway/1-guardrails.md
@@ -1,0 +1,336 @@
+# Guardrails
+
+Filter and transform LLM input and output with safety, PII, keyword, topic, and custom guardrails applied at the AI Gateway layer.
+
+## Request Flow
+
+```
+Client → [Input Guardrails] → LLM → [Output Guardrails] → Client
+```
+
+Input guardrails inspect and can reject or modify the request before it reaches the model. Output guardrails inspect and can reject or modify the response before it reaches the client.
+
+## Guardrail Types Reference
+
+| Type | What it does | Input supported | Output supported |
+|------|-------------|----------------|-----------------|
+| Safety | Blocks unsafe content (hate speech, self-harm, sexual content, violence) | Yes | Yes |
+| PII Detection | Detects PII and blocks, masks, or allows based on config | Yes | Yes |
+| Keyword Blocking | Rejects requests/responses containing specified keywords | Yes | Yes |
+| Topic Restrictions | Restricts conversations to specified valid topics | Yes | No |
+| LLM Judge (Beta) | Uses an LLM with editable prompts to evaluate content | Yes | Yes |
+| Custom Guardrails (Private Preview) | Routes content to a separate model serving endpoint for evaluation | Yes | Yes |
+
+## PII Detection
+
+### PII BLOCK
+
+Reject any request or response containing PII.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            )
+        ),
+        output=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            )
+        ),
+    ),
+)
+```
+
+### PII MASK
+
+Redact detected PII (e.g., replace SSNs with `[REDACTED]`) and pass the sanitized content through.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.MASK
+            )
+        ),
+        output=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.MASK
+            )
+        ),
+    ),
+)
+```
+
+### PII NONE
+
+Detect PII and log it (visible in inference tables) but allow the request/response through unchanged.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.NONE
+            )
+        ),
+    ),
+)
+```
+
+## Safety Filters
+
+Enable built-in safety classification on both input and output. Blocks content flagged as hate speech, self-harm, sexual content, or violence.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(safety=True),
+        output=AiGatewayGuardrailParameters(safety=True),
+    ),
+)
+```
+
+## Keyword Blocking
+
+Reject requests or responses containing any of the specified keywords. Matching is case-insensitive.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            invalid_keywords=["competitor_name", "confidential"]
+        ),
+        output=AiGatewayGuardrailParameters(
+            invalid_keywords=["competitor_name", "confidential"]
+        ),
+    ),
+)
+```
+
+## Topic Restrictions
+
+Restrict the endpoint to only respond about specified topics. Requests outside these topics are rejected. Topic restrictions apply to input only.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            valid_topics=["databricks", "data engineering", "machine learning"]
+        ),
+    ),
+)
+```
+
+## LLM Judge Guardrails (Beta)
+
+LLM judge guardrails use an LLM to evaluate input or output against a custom prompt you define. The judge model, prompt, and pass/fail criteria are fully configurable. This allows guardrail logic beyond what keyword or safety filters can express.
+
+LLM judge guardrails are configured via the UI or REST API. They are not yet represented in the Python SDK classes above.
+
+**REST API example** -- LLM judge that detects financial advice:
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/ai-gateway" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "guardrails": {
+      "input": {
+        "llm_judge": {
+          "model": "databricks-meta-llama-3-3-70b-instruct",
+          "prompt": "Evaluate whether the following message is asking for personalized financial advice (e.g., specific investment recommendations, portfolio allocation, tax strategies for an individual). General educational content about financial concepts is allowed. Respond with PASS if the message is safe, or FAIL if it requests personalized financial advice.",
+          "behaviour": "BLOCK"
+        }
+      },
+      "output": {
+        "llm_judge": {
+          "model": "databricks-meta-llama-3-3-70b-instruct",
+          "prompt": "Evaluate whether the following response contains personalized financial advice. General educational content is allowed. Respond with PASS if the response is safe, or FAIL if it contains personalized financial advice.",
+          "behaviour": "BLOCK"
+        }
+      }
+    }
+  }'
+```
+
+## Custom Guardrails (Private Preview)
+
+> **Private Preview** -- Contact your Databricks account team to enable this feature.
+
+Custom guardrails let you deploy a separate model serving endpoint as the guardrail evaluator. The gateway routes input or output to your custom endpoint, which returns a pass/fail decision. This is useful when you need proprietary evaluation logic (e.g., a fine-tuned classifier for domain-specific compliance).
+
+**Conceptual REST API example:**
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/ai-gateway" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "guardrails": {
+      "input": {
+        "custom": {
+          "endpoint_name": "my-compliance-classifier",
+          "behaviour": "BLOCK"
+        }
+      },
+      "output": {
+        "custom": {
+          "endpoint_name": "my-compliance-classifier",
+          "behaviour": "BLOCK"
+        }
+      }
+    }
+  }'
+```
+
+The custom guardrail endpoint must accept the same input format and return a response with a `pass` boolean field.
+
+## Combined Example
+
+Full configuration combining PII BLOCK on input, PII MASK on output, safety on both, keyword blocking on input, and topic restrictions on input.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            ),
+            safety=True,
+            invalid_keywords=["competitor_name", "confidential"],
+            valid_topics=["databricks", "data engineering", "machine learning"],
+        ),
+        output=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.MASK
+            ),
+            safety=True,
+        ),
+    ),
+)
+```
+
+## Limitations
+
+- Output guardrails are not supported for embedding endpoints
+- Output guardrails are not supported for streaming responses
+- Input guardrails add ~100-500ms latency
+- Custom guardrails (Private Preview) require a separate serving endpoint
+- LLM judge guardrails add latency proportional to the judge model's response time
+
+## SA Scenario
+
+**Customer wants GPT-4 endpoint with PII protection and per-team rate limits.**
+
+**Approach:**
+
+1. Configure PII BLOCK on input to reject any request containing PII before it reaches the model:
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="gpt-4-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            )
+        ),
+        output=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.MASK
+            )
+        ),
+    ),
+)
+```
+
+2. PII BLOCK on input ensures no PII reaches the model. PII MASK on output catches any PII the model generates in its response and redacts it before returning to the client.
+
+3. For per-team rate limits, see [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) -- use `AiGatewayRateLimitKey.USER_GROUP` with team group names to set QPM/TPM limits per team.

--- a/databricks-skills/databricks-ai-gateway/2-rate-limits-and-fallbacks.md
+++ b/databricks-skills/databricks-ai-gateway/2-rate-limits-and-fallbacks.md
@@ -1,0 +1,328 @@
+# Rate Limits and Fallbacks
+
+Control request throughput per user, team, or endpoint and enable automatic failover across served entities.
+
+## Rate Limits Overview
+
+AI Gateway supports two rate limit types:
+
+- **QPM (queries per minute)** -- limits the number of API calls. Works for all endpoint types.
+- **TPM (tokens per minute)** -- limits token consumption. Works only for Foundation Model API endpoints.
+
+Rate limits are **hierarchical**. You can set limits at multiple scopes simultaneously:
+
+1. **Endpoint-level** -- global cap across all callers
+2. **User-level** -- per-user fair sharing (identified by the authenticated principal)
+3. **User-group-level** -- team quotas (Databricks group name)
+4. **Service-principal-level** -- API client limits (application ID)
+
+When a caller exceeds their limit, the gateway returns **HTTP 429 Too Many Requests** with a `Retry-After` header. More specific rules (user/group/SP) are evaluated before the endpoint-level cap.
+
+## Rate Limit Key Reference
+
+| Key | Scope | Example Use Case |
+|-----|-------|------------------|
+| `ENDPOINT` | Global cap across all callers | Hard ceiling of 2000 QPM for the entire endpoint |
+| `USER` | Per-user (authenticated identity) | Fair sharing: each user gets 100 QPM |
+| `USER_GROUP` | Per-group (Databricks group name) | Team quotas: data-science-team gets 500 QPM |
+| `SERVICE_PRINCIPAL` | Per-service-principal (app ID) | API client limits: production pipeline SP gets 1000 QPM |
+
+## QPM Rate Limits
+
+Three rules: per-user default, group override, and endpoint cap.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit,
+    AiGatewayRateLimitKey,
+    AiGatewayRateLimitRenewalPeriod,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    rate_limits=[
+        # Every user gets 100 QPM by default
+        AiGatewayRateLimit(
+            calls=100,
+            key=AiGatewayRateLimitKey.USER,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # data-science-team group gets 500 QPM shared across members
+        AiGatewayRateLimit(
+            calls=500,
+            key=AiGatewayRateLimitKey.USER_GROUP,
+            principal="data-science-team",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # Hard cap for the entire endpoint
+        AiGatewayRateLimit(
+            calls=2000,
+            key=AiGatewayRateLimitKey.ENDPOINT,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+    ],
+)
+```
+
+## TPM Rate Limits
+
+Token-based limits for Foundation Model API endpoints.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit,
+    AiGatewayRateLimitKey,
+    AiGatewayRateLimitRenewalPeriod,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-fmapi-endpoint",
+    rate_limits=[
+        AiGatewayRateLimit(
+            tokens=50000,
+            key=AiGatewayRateLimitKey.USER,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        AiGatewayRateLimit(
+            tokens=500000,
+            key=AiGatewayRateLimitKey.ENDPOINT,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+    ],
+)
+```
+
+> **Important:** TPM limits only work for Foundation Model API endpoints, not custom models or agents. Use QPM (`calls`) for custom model and agent endpoints.
+
+## Combined Rate Limit Example
+
+Five rules layered: endpoint cap, default user, two group overrides, one service principal.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit,
+    AiGatewayRateLimitKey,
+    AiGatewayRateLimitRenewalPeriod,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    rate_limits=[
+        # 1. Endpoint-level hard cap
+        AiGatewayRateLimit(
+            calls=5000,
+            key=AiGatewayRateLimitKey.ENDPOINT,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # 2. Default per-user limit
+        AiGatewayRateLimit(
+            calls=100,
+            key=AiGatewayRateLimitKey.USER,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # 3. Engineering team gets a higher group quota
+        AiGatewayRateLimit(
+            calls=1500,
+            key=AiGatewayRateLimitKey.USER_GROUP,
+            principal="engineering",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # 4. Analytics team gets a moderate group quota
+        AiGatewayRateLimit(
+            calls=800,
+            key=AiGatewayRateLimitKey.USER_GROUP,
+            principal="analytics",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        # 5. Production pipeline service principal
+        AiGatewayRateLimit(
+            calls=2000,
+            key=AiGatewayRateLimitKey.SERVICE_PRINCIPAL,
+            principal="<service-principal-application-id>",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+    ],
+)
+```
+
+## Constraints
+
+| Constraint | Limit |
+|-----------|-------|
+| Max rate limit rules per endpoint | 20 |
+| Max group-specific rules (`USER_GROUP`) | 5 |
+| TPM (`tokens`) support | Foundation Model API endpoints only |
+| Renewal period | `minute` is the only supported value |
+| Burst behavior | Concurrent requests may briefly exceed the limit before counts are synchronized |
+
+## REST API Example
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/ai-gateway" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "rate_limits": [
+      {
+        "calls": 100,
+        "key": "user",
+        "renewal_period": "minute"
+      },
+      {
+        "calls": 500,
+        "key": "user_group",
+        "principal": "data-science-team",
+        "renewal_period": "minute"
+      },
+      {
+        "calls": 2000,
+        "key": "endpoint",
+        "renewal_period": "minute"
+      }
+    ]
+  }'
+```
+
+## Fallback Configuration
+
+`FallbackConfig` has a single field: `enabled: bool`.
+
+When enabled, if a served entity returns **429** (rate limited) or **5xx** (server error), the gateway automatically **round-robins** the request to other served entities on the same endpoint. This provides automatic failover without client-side retry logic.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import FallbackConfig
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    fallback_config=FallbackConfig(enabled=True),
+)
+```
+
+**Limitation:** Fallback requires multiple served entities configured on the endpoint. If the endpoint has only one served entity, there is nothing to fall back to.
+
+## Traffic Splitting
+
+Traffic splitting is configured on the **serving endpoint itself**, not via `put_ai_gateway`. Use `traffic_config` to route percentages of traffic to specific served entities. This is useful for gradual rollouts and A/B testing.
+
+Conceptual REST API example for a 90/10 split:
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/config" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "traffic_config": {
+      "routes": [
+        {
+          "served_model_name": "current-model",
+          "traffic_percentage": 90
+        },
+        {
+          "served_model_name": "new-model",
+          "traffic_percentage": 10
+        }
+      ]
+    },
+    "served_entities": [
+      {
+        "name": "current-model",
+        "entity_name": "catalog.schema.model-v1",
+        "entity_version": "3",
+        "workload_size": "Small",
+        "scale_to_zero_enabled": true
+      },
+      {
+        "name": "new-model",
+        "entity_name": "catalog.schema.model-v2",
+        "entity_version": "1",
+        "workload_size": "Small",
+        "scale_to_zero_enabled": true
+      }
+    ]
+  }'
+```
+
+Traffic percentages must sum to 100.
+
+## Common Patterns
+
+### Gradual Model Rollout
+
+Route 90% of traffic to the current model and 10% to a new model. Enable fallback so requests to the new model automatically retry on the current model if it errors.
+
+1. Configure the endpoint with two served entities and a 90/10 traffic split (see Traffic Splitting above).
+2. Enable fallback:
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import FallbackConfig
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    fallback_config=FallbackConfig(enabled=True),
+)
+```
+
+3. Monitor error rates in inference tables and system tables. Shift traffic gradually (90/10 -> 70/30 -> 50/50 -> 0/100) as confidence grows.
+
+### Cost Optimization
+
+Serve an expensive primary model and a cheaper fallback model on the same endpoint. Enable fallback so that when the primary hits rate limits (429) or errors (5xx), requests are routed to the cheaper model instead of failing.
+
+1. Configure two served entities: one for the high-quality model, one for the cost-effective model.
+2. Set traffic to 100/0 (all traffic to the primary by default).
+3. Enable fallback -- the cheaper model serves as a safety net.
+
+### Team-Based Quotas
+
+Give different teams different rate limits while enforcing a global cap.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit,
+    AiGatewayRateLimitKey,
+    AiGatewayRateLimitRenewalPeriod,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    rate_limits=[
+        AiGatewayRateLimit(
+            calls=1000,
+            key=AiGatewayRateLimitKey.USER_GROUP,
+            principal="engineering",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        AiGatewayRateLimit(
+            calls=500,
+            key=AiGatewayRateLimitKey.USER_GROUP,
+            principal="analytics",
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        AiGatewayRateLimit(
+            calls=3000,
+            key=AiGatewayRateLimitKey.ENDPOINT,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+    ],
+)
+```

--- a/databricks-skills/databricks-ai-gateway/3-inference-tables.md
+++ b/databricks-skills/databricks-ai-gateway/3-inference-tables.md
@@ -1,0 +1,132 @@
+# Inference Tables
+
+Log request/response payloads from serving endpoints to Unity Catalog Delta tables.
+
+## Overview
+
+Inference tables capture every request and response flowing through an AI Gateway endpoint. Payloads are written to a managed Delta table in Unity Catalog at `{catalog}.{schema}.{prefix}_request_response`. Use them for debugging failed requests, monitoring token usage and latency, and compliance auditing.
+
+## Enable Inference Tables
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import AiGatewayInferenceTableConfig
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    inference_table_config=AiGatewayInferenceTableConfig(
+        catalog_name="analytics",
+        schema_name="serving_logs",
+        table_name_prefix="my_endpoint",
+        enabled=True,
+    ),
+)
+```
+
+## REST API Example
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/ai-gateway" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inference_table_config": {
+      "catalog_name": "analytics",
+      "schema_name": "serving_logs",
+      "table_name_prefix": "my_endpoint",
+      "enabled": true
+    }
+  }'
+```
+
+## Table Schema Reference
+
+The table `{table_name_prefix}_request_response` contains:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `databricks_request_id` | STRING | Unique Databricks-assigned request ID |
+| `client_request_id` | STRING | Client-provided request ID (if set) |
+| `request_time` | TIMESTAMP | When the request was received |
+| `status_code` | INT | HTTP status code of the response |
+| `request_payload` | STRING | JSON-serialized request body |
+| `response_payload` | STRING | JSON-serialized response body |
+| `endpoint_name` | STRING | Name of the serving endpoint |
+| `input_token_count` | LONG | Tokens in the request prompt |
+| `output_token_count` | LONG | Tokens in the response completion |
+| `request_streaming` | BOOLEAN | Whether the request used streaming |
+
+## Query Examples
+
+```sql
+-- Request volume by hour
+SELECT date_trunc('hour', request_time) AS hour, COUNT(*) AS request_count
+FROM analytics.serving_logs.my_endpoint_request_response
+GROUP BY 1 ORDER BY 1 DESC;
+
+-- Average token usage per request
+SELECT
+  AVG(input_token_count) AS avg_input_tokens,
+  AVG(output_token_count) AS avg_output_tokens,
+  AVG(input_token_count + output_token_count) AS avg_total_tokens
+FROM analytics.serving_logs.my_endpoint_request_response
+WHERE request_time >= current_date() - INTERVAL 1 DAY;
+
+-- Error rate monitoring
+SELECT
+  date_trunc('hour', request_time) AS hour,
+  COUNT_IF(status_code != 200) AS errors,
+  COUNT(*) AS total,
+  ROUND(COUNT_IF(status_code != 200) / COUNT(*) * 100, 2) AS error_rate_pct
+FROM analytics.serving_logs.my_endpoint_request_response
+GROUP BY 1 ORDER BY 1 DESC;
+
+-- Find requests with high latency (proxy via large output)
+SELECT databricks_request_id, request_time, output_token_count, status_code
+FROM analytics.serving_logs.my_endpoint_request_response
+WHERE output_token_count > 2000
+ORDER BY output_token_count DESC LIMIT 20;
+
+-- Sample recent payloads for debugging
+SELECT databricks_request_id, status_code, request_payload, response_payload
+FROM analytics.serving_logs.my_endpoint_request_response
+ORDER BY request_time DESC LIMIT 5;
+```
+
+## Update or Disable
+
+You must disable inference tables before changing the catalog, schema, or prefix. This is a SDK constraint: update calls that change these fields while enabled will fail.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import AiGatewayInferenceTableConfig
+
+w = WorkspaceClient()
+
+# Step 1: Disable
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    inference_table_config=AiGatewayInferenceTableConfig(enabled=False),
+)
+
+# Step 2: Re-enable with new settings
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    inference_table_config=AiGatewayInferenceTableConfig(
+        catalog_name="new_catalog",
+        schema_name="new_schema",
+        table_name_prefix="new_prefix",
+        enabled=True,
+    ),
+)
+```
+
+## Limitations
+
+- Payloads larger than 1 MiB are excluded from logging
+- Table population can take up to an hour after first enable
+- Storage costs apply (data is stored in UC managed storage)
+- Must disable inference tables before changing catalog, schema, or prefix settings

--- a/databricks-skills/databricks-ai-gateway/4-observability.md
+++ b/databricks-skills/databricks-ai-gateway/4-observability.md
@@ -1,0 +1,172 @@
+# Observability
+
+Monitor usage, costs, and audit trails across all AI Gateway endpoints using system tables, usage tracking, and unified dashboards.
+
+## Three Pillars
+
+1. **Usage Tracking** -- System tables (`system.serving.*`) record per-request metadata: tokens, status codes, requester identity, and custom tags.
+2. **Payload Logging** -- Inference tables capture full request/response bodies. See [3-inference-tables.md](3-inference-tables.md).
+3. **V2 Unified Dashboard (Beta)** -- Single pane across LLM endpoints, coding agents, and MCP servers with real dollar cost attribution.
+
+## Enable Usage Tracking
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import AiGatewayUsageTrackingConfig
+
+w = WorkspaceClient()
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    usage_tracking_config=AiGatewayUsageTrackingConfig(enabled=True),
+)
+```
+
+## System Tables Reference
+
+### `system.serving.endpoint_usage`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `client_request_id` | STRING | Client-provided request ID |
+| `databricks_request_id` | STRING | Unique Databricks-assigned request ID |
+| `requester` | STRING | Identity of the user or service principal |
+| `status_code` | INT | HTTP status code of the response |
+| `request_time` | TIMESTAMP | When the request was received |
+| `input_token_count` | LONG | Tokens in the request prompt |
+| `output_token_count` | LONG | Tokens in the response completion |
+| `input_character_count` | LONG | Characters in the request prompt |
+| `output_character_count` | LONG | Characters in the response completion |
+| `usage_context` | MAP<STRING, STRING> | Custom key-value tags passed by the client |
+| `request_streaming` | BOOLEAN | Whether the request used streaming |
+| `endpoint_name` | STRING | Name of the serving endpoint |
+
+### `system.serving.served_entities`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `served_entity_id` | STRING | Unique ID for the served entity |
+| `account_id` | STRING | Databricks account ID |
+| `workspace_id` | STRING | Workspace ID where the endpoint lives |
+| `endpoint_name` | STRING | Name of the serving endpoint |
+| `entity_type` | STRING | One of: FEATURE_SPEC, EXTERNAL_MODEL, FOUNDATION_MODEL, CUSTOM_MODEL |
+| `external_model_config` | STRING | JSON config for external model entities |
+| `foundation_model_config` | STRING | JSON config for foundation model entities |
+| `custom_model_config` | STRING | JSON config for custom model entities |
+
+## Usage Queries
+
+```sql
+-- Daily token consumption by endpoint (last 30 days)
+SELECT endpoint_name, DATE(request_time) AS day,
+  SUM(input_token_count) AS input_tokens, SUM(output_token_count) AS output_tokens
+FROM system.serving.endpoint_usage
+WHERE request_time >= current_date() - INTERVAL 30 DAYS
+GROUP BY endpoint_name, DATE(request_time)
+ORDER BY day DESC;
+
+-- Top 10 users by request count
+SELECT requester, COUNT(*) AS requests, SUM(output_token_count) AS total_output_tokens
+FROM system.serving.endpoint_usage
+WHERE request_time >= current_date() - INTERVAL 7 DAYS
+GROUP BY requester ORDER BY requests DESC LIMIT 10;
+
+-- Error rate by endpoint (% non-200)
+SELECT endpoint_name, COUNT(*) AS total,
+  COUNT_IF(status_code != 200) AS errors,
+  ROUND(COUNT_IF(status_code != 200) / COUNT(*) * 100, 2) AS error_rate_pct
+FROM system.serving.endpoint_usage
+WHERE request_time >= current_date() - INTERVAL 7 DAYS
+GROUP BY endpoint_name ORDER BY error_rate_pct DESC;
+
+-- Token cost estimation (adjust rates to your contracts)
+WITH pricing AS (
+  SELECT 'llama-endpoint' AS endpoint, 0.00065 AS input_per_1k, 0.00195 AS output_per_1k
+  UNION ALL SELECT 'gpt-4o-endpoint', 0.0025, 0.01
+  UNION ALL SELECT 'claude-sonnet-endpoint', 0.003, 0.015)
+SELECT u.endpoint_name,
+  ROUND(SUM(u.input_token_count / 1000.0 * p.input_per_1k
+          + u.output_token_count / 1000.0 * p.output_per_1k), 2) AS estimated_cost_usd
+FROM system.serving.endpoint_usage u
+JOIN pricing p ON u.endpoint_name = p.endpoint
+WHERE u.request_time >= current_date() - INTERVAL 30 DAYS
+GROUP BY u.endpoint_name ORDER BY estimated_cost_usd DESC;
+```
+
+> **Note:** System tables record `request_time` but not latency. For p50/p90/p99 latency, use inference tables which capture both request and response timestamps.
+
+## Usage Context
+
+Attach custom key-value tags to requests for cost attribution. Pass via `extra_body` with the OpenAI-compatible client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://my-workspace.cloud.databricks.com/serving-endpoints",
+    api_key="dapi...",
+)
+
+response = client.chat.completions.create(
+    model="my-llm-endpoint",
+    messages=[{"role": "user", "content": "Summarize Q4 results"}],
+    extra_body={
+        "usage_context": {
+            "project": "chatbot",
+            "team": "data-science",
+            "cost_center": "CC-1234",
+        }
+    },
+)
+```
+
+Slice costs by usage context:
+
+```sql
+SELECT usage_context['project'] AS project, usage_context['team'] AS team,
+  COUNT(*) AS requests, SUM(input_token_count + output_token_count) AS total_tokens
+FROM system.serving.endpoint_usage
+WHERE request_time >= current_date() - INTERVAL 30 DAYS
+  AND usage_context['project'] IS NOT NULL
+GROUP BY 1, 2 ORDER BY total_tokens DESC;
+```
+
+## V2: Real Dollar Cost Attribution
+
+> **Beta** -- Available in AI Gateway V2.
+
+V2 calculates actual dollar costs instead of raw token counts. It accounts for provisioned throughput pricing, pay-per-token rates, and external provider pricing (OpenAI, Anthropic, etc.). Eliminates manual pricing CTEs and handles blended costs when endpoints use fallback routing across providers.
+
+## V2: Unified Dashboard
+
+V2 provides a single observability pane across LLM serving endpoints, coding agents (e.g., Databricks Assistant), and MCP servers.
+
+- **Cross-tool usage queries** -- Compare token consumption and costs across LLM endpoints and agent frameworks in one view.
+- **Genie Code integration** -- Ask natural language questions about your AI usage and get SQL-backed answers.
+- **MLflow trace debugging** -- Click from a dashboard anomaly directly into MLflow traces to debug specific requests.
+
+## Audit Trail Queries
+
+```sql
+-- Requests by a specific user in a time window
+SELECT databricks_request_id, endpoint_name, status_code, request_time,
+       input_token_count, output_token_count
+FROM system.serving.endpoint_usage
+WHERE requester = 'user@company.com'
+  AND request_time BETWEEN '2026-04-01' AND '2026-04-15'
+ORDER BY request_time DESC;
+
+-- All error requests to a specific endpoint
+SELECT databricks_request_id, requester, status_code, request_time
+FROM system.serving.endpoint_usage
+WHERE endpoint_name = 'my-llm-endpoint'
+  AND status_code != 200
+  AND request_time >= current_date() - INTERVAL 7 DAYS
+ORDER BY request_time DESC;
+
+-- Usage breakdown by usage_context tags
+SELECT usage_context['project'] AS project, usage_context['cost_center'] AS cost_center,
+  COUNT(*) AS requests, SUM(input_token_count) AS input_tokens, SUM(output_token_count) AS output_tokens
+FROM system.serving.endpoint_usage
+WHERE request_time >= current_date() - INTERVAL 30 DAYS
+GROUP BY 1, 2 ORDER BY requests DESC;
+```

--- a/databricks-skills/databricks-ai-gateway/5-coding-agents.md
+++ b/databricks-skills/databricks-ai-gateway/5-coding-agents.md
@@ -1,0 +1,123 @@
+# Coding Agent Integration
+
+Route coding agent traffic through AI Gateway V2 (Beta) for centralized authentication, rate limiting, guardrails, and audit logging.
+
+## Overview
+
+AI Gateway V2 proxies requests between developer IDEs and LLM providers. All traffic flows through the gateway instead of connecting directly to providers. Platform teams get a single dashboard for auth, rate limits, guardrails, and usage tracking across every coding tool.
+
+## Architecture
+
+```
+Developer IDE → AI Gateway V2 (Beta) → LLM Provider
+                  ├── Authentication (PAT / OAuth)
+                  ├── Rate Limits (per-user QPM)
+                  ├── Guardrails (PII, safety, keywords)
+                  └── Usage Logging (inference tables + system tables)
+```
+
+## Routing Paths Reference
+
+| Agent | Gateway Path | Config Location |
+|-------|-------------|-----------------|
+| Cursor | `/cursor/v1` | Cursor Settings > Models |
+| Codex CLI | `/codex/v1` | `~/.codex/config.toml` |
+| Gemini CLI | `/gemini` | `~/.gemini/.env` |
+| Claude Code | TBD (blog only, not in official docs yet) | Environment variables |
+
+## Cursor Setup
+
+1. Get your AI Gateway URL: `https://<workspace-url>/ai-gateway` or your account-level URL.
+2. Generate a Databricks PAT if you don't have one.
+3. In Cursor: **Settings > Models > Override OpenAI Base URL**:
+   ```
+   https://<ai-gateway-url>/cursor/v1
+   ```
+4. Set **API Key** to your Databricks PAT (`dapi...`).
+5. Add custom models as needed. The gateway routes to the correct provider based on model name.
+
+## Codex CLI Setup
+
+1. Authenticate with Databricks CLI (`databricks auth login`).
+2. Create or edit `~/.codex/config.toml`:
+
+```toml
+provider = "databricks"
+base_url = "https://<ai-gateway-url>/codex/v1"
+```
+
+Auth is inherited from the Databricks CLI session -- no separate API key needed.
+
+## Gemini CLI Setup
+
+Create or edit `~/.gemini/.env`:
+
+```bash
+GEMINI_MODEL="gemini-2.5-pro"
+GEMINI_API_BASE_URL="https://<ai-gateway-url>/gemini"
+GEMINI_API_KEY="dapi..."
+```
+
+`GEMINI_API_KEY` is your Databricks PAT.
+
+## Claude Code Setup
+
+> **Note:** Claude Code is mentioned in the [Databricks blog](https://www.databricks.com/blog) but not yet in official docs. The pattern below follows the expected convention.
+
+```bash
+export ANTHROPIC_BASE_URL="https://<ai-gateway-url>/anthropic"
+export ANTHROPIC_AUTH_TOKEN="dapi..."
+```
+
+Check the [official docs](https://docs.databricks.com/aws/en/ai-gateway/coding-agent-integration-beta) for updates.
+
+## OpenAI-Compatible API
+
+The gateway exposes an OpenAI-compatible endpoint. Any OpenAI-speaking tool connects without code changes, and you can switch backing models at the gateway layer without reconfiguring clients.
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="https://<ai-gateway-url>/v1", api_key="dapi...")
+response = client.chat.completions.create(
+    model="gpt-4o",  # Gateway routes to the correct provider
+    messages=[{"role": "user", "content": "Explain Unity Catalog."}],
+)
+print(response.choices[0].message.content)
+```
+
+## Rate Limiting Coding Agents
+
+Coding agents generate high request volume. Set per-user QPM limits to prevent any developer from saturating capacity.
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit, AiGatewayRateLimitKey, AiGatewayRateLimitRenewalPeriod,
+)
+w = WorkspaceClient()
+w.serving_endpoints.put_ai_gateway(
+    name="coding-agent-gateway",
+    rate_limits=[
+        AiGatewayRateLimit(calls=60, key=AiGatewayRateLimitKey.USER,
+                           renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE),
+        AiGatewayRateLimit(calls=5000, key=AiGatewayRateLimitKey.ENDPOINT,
+                           renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE),
+    ],
+)
+```
+
+See [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) for group-level limits, TPM, and fallback config.
+
+## Monitoring Coding Agent Usage
+
+The unified dashboard shows request volume, token consumption, error rates, and cost across all coding agents. Enable usage tracking and inference tables for full payload audit. See [4-observability.md](4-observability.md) for system table queries.
+
+## SA Scenario
+
+**Enterprise wants all developers using Cursor through gateway with PII guardrails and per-dev rate limits.**
+
+1. **Set up AI Gateway V2** -- create a gateway endpoint for coding agent traffic.
+2. **Configure Cursor per developer** -- distribute the base URL override (`https://<ai-gateway-url>/cursor/v1`) and each dev's Databricks PAT. Use workspace identity federation so requests map to known users.
+3. **Add PII guardrails** -- block PII on input, mask on output. See [1-guardrails.md](1-guardrails.md).
+4. **Add per-user rate limits** -- e.g., 60 QPM per user, 5000 QPM endpoint cap. See [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md).
+5. **Enable observability** -- turn on inference tables and usage tracking for full audit trail and cost visibility.

--- a/databricks-skills/databricks-ai-gateway/6-agentic-governance.md
+++ b/databricks-skills/databricks-ai-gateway/6-agentic-governance.md
@@ -1,0 +1,95 @@
+# Agentic Governance
+
+AI Gateway V2 (Beta) is the enterprise control plane for governing LLM endpoints, coding agents, and MCP servers across agentic AI workflows.
+
+## The Problem
+
+Agents orchestrate multi-step workflows that span LLM calls, MCP server invocations, and external API requests, touching sensitive data at every step. A single user query might trigger a chain: LLM reasoning, a Salesforce lookup via MCP, a database write, then another LLM call to synthesize results. Traditional governance tools operate in silos -- they can monitor individual endpoints or log individual API calls, but they cannot trace across these boundaries or provide a unified view of what an agent did, why, and on whose authority.
+
+## What V2 Adds
+
+Beyond V1's per-endpoint guardrails, rate limits, and inference tables, V2 introduces:
+
+- **MCP server governance** -- On-behalf-of user execution and tool access control for MCP connections
+- **On-behalf-of execution** -- Agent calls inherit the requesting user's permissions, not a shared service account
+- **Tool access control** -- Admins control which agents and teams can access which MCP servers and external systems
+- **Multi-step traceability** -- End-to-end audit trails across every hop in an agentic workflow
+- **Unified dashboard** -- Single pane of glass for spend, usage, and metrics across LLM endpoints, coding agents, and MCP servers
+- **Real dollar cost attribution** -- Actual costs (not just token counts) across all tool types, including external provider pricing
+
+## MCP Server Governance
+
+### On-Behalf-Of Execution
+
+When an agent calls an MCP server through AI Gateway, the call executes with the requesting user's exact permissions -- not a shared service account or the agent's own credentials. If user Alice asks an agent to query Salesforce via MCP, the MCP call runs as Alice with Alice's Salesforce permissions.
+
+This prevents privilege escalation. An agent cannot access data or perform actions beyond what the requesting user is authorized to do, even if the agent itself has broader connectivity. The agent inherits the user's identity for the duration of the call.
+
+### Tool Access Control
+
+Admins define which MCP tools each team or agent can access. For example:
+
+- The sales team's agents can access Salesforce and HubSpot MCP servers but not production databases
+- The engineering team's agents can access GitHub and JIRA MCP servers but not financial systems
+- A customer-facing chatbot agent can read from a product catalog MCP server but cannot write
+
+### MCP Audit Logging
+
+All MCP calls routed through AI Gateway are logged with:
+
+- **Requesting identity** -- Who initiated the action (end user, not the agent)
+- **Timestamp** -- When the call was made
+- **Connection name** -- Which MCP server was called
+- **HTTP method** -- What operation was performed
+- **On-behalf-of flag** -- Whether the call used delegated user credentials
+
+## Multi-Step Traceability
+
+An agentic workflow touches multiple systems in sequence. AI Gateway traces every step:
+
+```
+User request
+  → Agent receives query
+    → Agent calls LLM (gateway logs: model, tokens, latency, requester)
+      → LLM decides to use a tool
+    → Agent calls MCP server, e.g. Salesforce (gateway logs: connection, identity, method)
+      → MCP server returns data
+    → Agent calls LLM again with tool results (gateway logs: model, tokens, latency)
+  → Agent returns response to user
+```
+
+Every hop through the gateway produces an audit record. Together, these records answer:
+
+- **Who authorized each action?** The requesting user's identity is logged at every step, not just the initial request.
+- **What data was shared with which model?** Inference table payloads show exactly what was sent to each LLM call.
+- **Were policies enforced consistently?** Guardrails, rate limits, and access controls are applied and logged at each gateway hop.
+- **Can you trace the full chain?** A single request ID or correlation ID links every step from initial user query to final response.
+
+## Integration with MLflow Tracing
+
+AI Gateway audit logs and MLflow traces capture complementary views of the same agentic execution. Gateway logs record the infrastructure perspective: which endpoint was called, latency, status codes, token counts, and policy enforcement. MLflow traces record the application perspective: what the agent was reasoning about, which tool it chose and why, and how it assembled the final response.
+
+When an agent fails mid-chain, cross-referencing the two gives the full picture. The gateway log shows which step returned an error (e.g., a 403 from the Salesforce MCP connection), while the MLflow trace shows what the agent was attempting and how it handled the failure. Use the `databricks_request_id` to correlate records across both systems.
+
+For MLflow tracing setup and evaluation patterns, see the [databricks-mlflow-evaluation](../databricks-mlflow-evaluation/SKILL.md) skill.
+
+## Unified Dashboard
+
+The V2 dashboard provides a single view across all AI-powered tools in the organization:
+
+- **Total spend** -- Aggregated dollar costs across LLM endpoints, coding agents (Cursor, Codex CLI, Claude Code), and MCP servers
+- **Usage by team and department** -- Break down consumption by organizational unit using usage context tags
+- **Cross-tool metrics** -- Compare request volumes, error rates, and latency across endpoint types in one view
+- **Genie Code integration** -- Ask natural language questions against audit data ("Which team spent the most on external API calls last month?" or "Show me all MCP calls that used on-behalf-of execution in the last week") and get SQL-backed answers without writing queries
+
+For usage tracking configuration and system table queries, see [4-observability.md](4-observability.md).
+
+## V2 Beta Status
+
+AI Gateway V2 is currently in **Beta**. Key considerations:
+
+- V2 features do not incur additional charges during the Beta period
+- APIs and configuration interfaces may change before general availability
+- Not all features are available in all regions or cloud providers
+- Check the [AI Gateway Beta docs](https://docs.databricks.com/aws/en/ai-gateway/overview-beta) for the latest availability and feature status
+- Account admin or workspace admin permissions are required for V2 configuration

--- a/databricks-skills/databricks-ai-gateway/SKILL.md
+++ b/databricks-skills/databricks-ai-gateway/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: databricks-ai-gateway
+description: "Configure Databricks AI Gateway for serving endpoints and enterprise LLM governance. Use when (1) adding guardrails (safety, PII, custom) to endpoints, (2) setting rate limits or fallbacks, (3) enabling inference tables for payload logging, (4) tracking usage and costs via system tables, (5) governing coding agents (Cursor, Codex CLI, Gemini CLI, Claude Code), (6) managing MCP server access control. Covers both V1 per-endpoint gateway config and V2 enterprise control plane."
+---
+
+# Databricks AI Gateway
+
+Configure guardrails, rate limits, observability, and enterprise governance for LLM endpoints and coding agents.
+
+## Which Version Do You Need?
+
+| You want to... | Version | Reference |
+|----------------|---------|-----------|
+| Add guardrails, rate limits, or fallbacks to a **serving endpoint** | V1 (GA) | [1-guardrails.md](1-guardrails.md), [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) |
+| Enable payload logging on an endpoint | V1 (GA) | [3-inference-tables.md](3-inference-tables.md) |
+| Monitor usage, costs, and audit trails | V1 + V2 | [4-observability.md](4-observability.md) |
+| Govern **coding agents** (Cursor, Codex CLI, Gemini CLI, Claude Code) | V2 (Beta) | [5-coding-agents.md](5-coding-agents.md) |
+| Govern **MCP servers**, agentic workflows, unified control plane | V2 (Beta) | [6-agentic-governance.md](6-agentic-governance.md) |
+
+## Quick Decision: What Are You Configuring?
+
+| Task | Go To |
+|------|-------|
+| Block or mask PII in LLM requests/responses | [1-guardrails.md](1-guardrails.md) |
+| Add safety filters or topic restrictions | [1-guardrails.md](1-guardrails.md) |
+| Custom guardrails via LLM judge | [1-guardrails.md](1-guardrails.md) |
+| Per-user or per-team rate limits (QPM/TPM) | [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) |
+| Auto-failover across served entities | [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) |
+| Traffic splitting / A-B testing | [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) |
+| Log request/response payloads to Delta tables | [3-inference-tables.md](3-inference-tables.md) |
+| Query usage and cost system tables | [4-observability.md](4-observability.md) |
+| Set up Cursor / Codex CLI / Gemini CLI / Claude Code through gateway | [5-coding-agents.md](5-coding-agents.md) |
+| Govern MCP servers, trace agentic workflows | [6-agentic-governance.md](6-agentic-governance.md) |
+
+## Prerequisites
+
+- Unity Catalog enabled workspace
+- Model Serving endpoint already deployed (for V1) — see [databricks-model-serving](../databricks-model-serving/SKILL.md)
+- `databricks-sdk >= 0.40.0` (for `put_ai_gateway` method)
+- Account admin or workspace admin permissions (for V2 Beta)
+
+## SDK Class Reference
+
+All classes are in `databricks.sdk.service.serving`:
+
+| Class | Purpose |
+|-------|---------|
+| `AiGatewayGuardrails` | Container for input/output guardrail config |
+| `AiGatewayGuardrailParameters` | Guardrail filters: `invalid_keywords`, `pii`, `safety`, `valid_topics` |
+| `AiGatewayGuardrailPiiBehavior` | PII handling config (wraps the behavior enum) |
+| `AiGatewayGuardrailPiiBehaviorBehavior` | Enum: `BLOCK`, `MASK`, `NONE` |
+| `AiGatewayRateLimit` | Rate limit rule: `calls`, `tokens`, `key`, `principal`, `renewal_period` |
+| `AiGatewayRateLimitKey` | Enum: `USER`, `USER_GROUP`, `SERVICE_PRINCIPAL`, `ENDPOINT` |
+| `AiGatewayRateLimitRenewalPeriod` | Enum: `MINUTE` (only supported value) |
+| `AiGatewayInferenceTableConfig` | Payload logging: `catalog_name`, `schema_name`, `table_name_prefix`, `enabled` |
+| `AiGatewayUsageTrackingConfig` | System table usage tracking: `enabled` |
+| `FallbackConfig` | Auto-failover across served entities: `enabled` |
+
+## Quick Start: Enable PII Guardrails on an Endpoint
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails,
+    AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior,
+    AiGatewayGuardrailPiiBehaviorBehavior,
+    AiGatewayUsageTrackingConfig,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            )
+        ),
+        output=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.MASK
+            )
+        ),
+    ),
+    usage_tracking_config=AiGatewayUsageTrackingConfig(enabled=True),
+)
+```
+
+## Quick Start: Enable Rate Limits
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.serving import (
+    AiGatewayRateLimit,
+    AiGatewayRateLimitKey,
+    AiGatewayRateLimitRenewalPeriod,
+)
+
+w = WorkspaceClient()
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-llm-endpoint",
+    rate_limits=[
+        AiGatewayRateLimit(
+            calls=100,
+            key=AiGatewayRateLimitKey.USER,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+        AiGatewayRateLimit(
+            calls=2000,
+            key=AiGatewayRateLimitKey.ENDPOINT,
+            renewal_period=AiGatewayRateLimitRenewalPeriod.MINUTE,
+        ),
+    ],
+)
+```
+
+## REST API Quick Reference
+
+**Endpoint:** `PUT /api/2.0/serving-endpoints/{name}/ai-gateway`
+
+```bash
+curl -X PUT \
+  "${DATABRICKS_HOST}/api/2.0/serving-endpoints/my-llm-endpoint/ai-gateway" \
+  -H "Authorization: Bearer ${DATABRICKS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "guardrails": {
+      "input": {
+        "pii": {"behavior": "BLOCK"},
+        "safety": true
+      },
+      "output": {
+        "pii": {"behavior": "MASK"}
+      }
+    },
+    "rate_limits": [
+      {"calls": 100, "key": "user", "renewal_period": "minute"},
+      {"calls": 2000, "key": "endpoint", "renewal_period": "minute"}
+    ],
+    "usage_tracking_config": {"enabled": true},
+    "inference_table_config": {
+      "catalog_name": "analytics",
+      "schema_name": "serving_logs",
+      "table_name_prefix": "my_endpoint",
+      "enabled": true
+    }
+  }'
+```
+
+## Reference Files
+
+| Topic | File | When to Read |
+|-------|------|--------------|
+| Guardrails | [1-guardrails.md](1-guardrails.md) | PII, safety, keywords, topics, LLM judge, custom guardrails |
+| Rate Limits & Fallbacks | [2-rate-limits-and-fallbacks.md](2-rate-limits-and-fallbacks.md) | QPM/TPM limits, auto-failover, traffic splitting |
+| Inference Tables | [3-inference-tables.md](3-inference-tables.md) | Payload logging to UC Delta tables |
+| Observability | [4-observability.md](4-observability.md) | System tables, cost attribution, audit trails |
+| Coding Agents | [5-coding-agents.md](5-coding-agents.md) | Cursor, Codex CLI, Gemini CLI, Claude Code setup |
+| Agentic Governance | [6-agentic-governance.md](6-agentic-governance.md) | MCP governance, traceability, unified control plane |
+
+## MCP Tools
+
+> The `manage_serving_endpoint` MCP tool currently supports `get`, `list`, and `query` only. It does **not** support AI Gateway configuration. Use the Python SDK or REST API for gateway config.
+
+**Workflow using MCP tools:**
+
+| Step | Tool | Purpose |
+|------|------|---------|
+| 1. Check endpoint exists | `manage_serving_endpoint(action="get", name="...")` | Verify endpoint is READY |
+| 2. Configure AI Gateway | `execute_code` with SDK script | Apply guardrails, rate limits, etc. |
+| 3. Verify endpoint health | `manage_serving_endpoint(action="get", name="...")` | Confirm endpoint still healthy |
+| 4. Test the endpoint | `manage_serving_endpoint(action="query", name="...", messages=[...])` | Verify guardrails work |
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| **Output guardrails not triggering (streaming)** | Output guardrails do not work for streaming responses. Use non-streaming mode. |
+| **Output guardrails not working (embeddings)** | Output guardrails only support chat/completions, not embedding endpoints. |
+| **TPM rate limit rejected on custom model** | TPM limits only work for Foundation Model API endpoints. Use QPM for custom models. |
+| **Fallback not triggering** | Fallback round-robins across served entities on the same endpoint. Requires multiple served entities configured. |
+| **Payloads missing from inference table** | Payloads > 1 MiB are excluded from logging. Truncate large inputs. |
+| **Max rate limits exceeded** | Maximum 20 rate limit rules per endpoint, 5 group-specific. Consolidate groups. |
+| **`put_ai_gateway` not found** | Upgrade SDK: `pip install --upgrade databricks-sdk>=0.40.0` |
+| **Config update not taking effect** | Configuration updates take 20-60 seconds to propagate. Wait and retry. |
+
+### Critical: Use SDK Objects, Not Raw Dicts
+
+**WRONG** — passing raw dicts will fail:
+```python
+w.serving_endpoints.put_ai_gateway(
+    name="my-endpoint",
+    guardrails={"input": {"pii": {"behavior": "BLOCK"}}}  # TypeError
+)
+```
+
+**CORRECT** — use SDK dataclasses:
+```python
+from databricks.sdk.service.serving import (
+    AiGatewayGuardrails, AiGatewayGuardrailParameters,
+    AiGatewayGuardrailPiiBehavior, AiGatewayGuardrailPiiBehaviorBehavior,
+)
+
+w.serving_endpoints.put_ai_gateway(
+    name="my-endpoint",
+    guardrails=AiGatewayGuardrails(
+        input=AiGatewayGuardrailParameters(
+            pii=AiGatewayGuardrailPiiBehavior(
+                behavior=AiGatewayGuardrailPiiBehaviorBehavior.BLOCK
+            )
+        )
+    ),
+)
+```
+
+## Related Skills
+
+- **[databricks-model-serving](../databricks-model-serving/SKILL.md)** — Deploy the serving endpoints this skill configures
+- **[databricks-agent-bricks](../databricks-agent-bricks/SKILL.md)** — Agents that benefit from gateway governance
+- **[databricks-unity-catalog](../databricks-unity-catalog/SKILL.md)** — System tables for observability queries
+- **[databricks-python-sdk](../databricks-python-sdk/SKILL.md)** — SDK patterns and authentication
+
+## Resources
+
+- [AI Gateway Documentation (AWS)](https://docs.databricks.com/aws/en/ai-gateway/)
+- [AI Gateway Documentation (Azure)](https://learn.microsoft.com/en-us/azure/databricks/ai-gateway/)
+- [AI Gateway Documentation (GCP)](https://docs.databricks.com/gcp/en/ai-gateway/)
+- [Configure AI Gateway on Serving Endpoints](https://docs.databricks.com/aws/en/ai-gateway/configure-ai-gateway-endpoints)
+- [AI Gateway Beta Overview](https://docs.databricks.com/aws/en/ai-gateway/overview-beta)
+- [Coding Agent Integration](https://docs.databricks.com/aws/en/ai-gateway/coding-agent-integration-beta)

--- a/databricks-skills/databricks-model-serving/SKILL.md
+++ b/databricks-skills/databricks-model-serving/SKILL.md
@@ -310,6 +310,7 @@ Available helper methods:
 - **[databricks-genie](../databricks-genie/SKILL.md)** - Genie Spaces can serve as agents in multi-agent setups
 - **[databricks-mlflow-evaluation](../databricks-mlflow-evaluation/SKILL.md)** - Evaluate model and agent quality before deployment
 - **[databricks-jobs](../databricks-jobs/SKILL.md)** - Job-based async deployment used for agent endpoints
+- **[databricks-ai-gateway](../databricks-ai-gateway/SKILL.md)** - Add guardrails, rate limits, and observability to serving endpoints
 
 ## Resources
 

--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -47,7 +47,7 @@ MLFLOW_REPO_RAW_URL="https://raw.githubusercontent.com/mlflow/skills"
 MLFLOW_REPO_REF="main"
 
 # Databricks skills (hosted in this repo)
-DATABRICKS_SKILLS="databricks-agent-bricks databricks-ai-functions databricks-aibi-dashboards databricks-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-python-sdk databricks-execution-compute databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
+DATABRICKS_SKILLS="databricks-agent-bricks databricks-ai-gateway databricks-ai-functions databricks-aibi-dashboards databricks-bundles databricks-app-python databricks-config databricks-dbsql databricks-docs databricks-genie databricks-iceberg databricks-jobs databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views databricks-mlflow-evaluation databricks-model-serving databricks-python-sdk databricks-execution-compute databricks-spark-declarative-pipelines databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search databricks-zerobus-ingest spark-python-data-source"
 
 # MLflow skills (fetched from mlflow/skills repo)
 MLFLOW_SKILLS="agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics retrieving-mlflow-traces searching-mlflow-docs"
@@ -68,6 +68,7 @@ get_skill_description() {
     case "$1" in
         # Databricks skills
         "databricks-agent-bricks") echo "Knowledge Assistants, Genie Spaces, Supervisor Agents" ;;
+        "databricks-ai-gateway") echo "AI Gateway - guardrails, rate limits, observability, coding agent governance" ;;
         "databricks-ai-functions") echo "Built-in AI Functions (classify, extract, query, forecast, parse, etc.), doc processing & custom RAG" ;;
         "databricks-aibi-dashboards") echo "Databricks AI/BI Dashboards - create and manage dashboards" ;;
         "databricks-asset-bundles") echo "Databricks Asset Bundles - deployment and configuration" ;;                                                                                                                          


### PR DESCRIPTION
## Summary
- Adds a new `databricks-ai-gateway` skill covering both V1 (per-endpoint config) and V2 Beta (enterprise control plane)
- V1 coverage: guardrails (PII, safety, keywords, topics, LLM judge, custom), rate limits (QPM/TPM), inference tables, fallbacks, traffic splitting, observability via system tables
- V2 coverage: coding agent governance (Cursor, Codex CLI, Gemini CLI, Claude Code), MCP server access control, agentic multi-step traceability, unified dashboard
- Registers skill in `install_skills.sh` and adds cross-references to `databricks-model-serving` and `databricks-agent-bricks`

### Files
| File | Purpose |
|------|---------|
| `SKILL.md` | Main entrypoint with V1/V2 decision tables, quick starts, SDK reference, common issues |
| `1-guardrails.md` | PII BLOCK/MASK/NONE, safety, keywords, topics, LLM judge, custom guardrails |
| `2-rate-limits-and-fallbacks.md` | QPM/TPM hierarchy, fallback config, traffic splitting patterns |
| `3-inference-tables.md` | Payload logging to UC Delta tables |
| `4-observability.md` | System tables, cost attribution, audit trail queries |
| `5-coding-agents.md` | Cursor, Codex CLI, Gemini CLI, Claude Code gateway routing setup |
| `6-agentic-governance.md` | MCP governance, multi-step traceability, unified control plane |

## Test plan
- [x] `install_skills.sh --list` shows the new skill
- [x] All internal links (6 sub-files) resolve correctly
- [x] All cross-reference links (5 related skills) resolve correctly
- [x] No sub-files have accidental frontmatter
- [x] All 10 SDK class names verified against actual SDK source
- [x] Rate limits + usage tracking tested on custom model endpoint (`sn-lead-scoring-praneeth_paikray` on e2-demo-west)
- [x] Full config (guardrails + rate limits + usage tracking) tested on external model endpoint (`costco-meat-ai-gateway` on e2-demo-west)
- [x] Guardrails correctly rejected on custom model endpoint (documented limitation)
- [x] Both endpoints cleaned up and restored to original state

This pull request was AI-assisted by Isaac.