### PR TITLE
Skip Lakebase bundle deploy if project already exists

### DIFF
--- a/databricks-builder-app/scripts/deploy.sh
+++ b/databricks-builder-app/scripts/deploy.sh
@@ -142,11 +142,16 @@ echo -e "${YELLOW}[2/${TOTAL_STEPS}] Deploying Lakebase...${NC}"
 if [ "$SKIP_LAKEBASE" = true ]; then
   echo -e "  ${GREEN}✓${NC} Skipped (--skip-lakebase)"
 else
-  cd "$PROJECT_DIR"
-  BUNDLE_ARGS=""
-  if [ -n "$PROFILE" ]; then BUNDLE_ARGS="--profile $PROFILE"; fi
-  databricks bundle deploy $BUNDLE_ARGS --var "lakebase_project_id=${LAKEBASE_PROJECT_ID}" 2>&1
-  echo -e "  ${GREEN}✓${NC} Lakebase project '${LAKEBASE_PROJECT_ID}' deployed"
+  # Check if the Lakebase project already exists before deploying
+  if databricks postgres get-project "projects/${LAKEBASE_PROJECT_ID}" $CLI_ARGS &>/dev/null; then
+    echo -e "  ${GREEN}✓${NC} Lakebase project '${LAKEBASE_PROJECT_ID}' already exists, skipping bundle deploy"
+  else
+    cd "$PROJECT_DIR"
+    BUNDLE_ARGS=""
+    if [ -n "$PROFILE" ]; then BUNDLE_ARGS="--profile $PROFILE"; fi
+    databricks bundle deploy $BUNDLE_ARGS --var "lakebase_project_id=${LAKEBASE_PROJECT_ID}" 2>&1
+    echo -e "  ${GREEN}✓${NC} Lakebase project '${LAKEBASE_PROJECT_ID}' deployed"
+  fi
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
- The deploy script now checks if the Lakebase Postgres project already exists (via `databricks postgres get-project`) before running `databricks bundle deploy`
- Prevents Terraform from failing with `"project with such id already exists"` on repeat deployments
- The existing `--skip-lakebase` flag still works as a manual override

## Test plan
- [ ] Run `deploy.sh` against a workspace where the Lakebase project already exists — should skip bundle deploy
- [ ] Run `deploy.sh` against a fresh workspace — should create the project as before
- [ ] Run `deploy.sh --skip-lakebase` — should still skip as before