### PR TITLE
Add Windsurf support to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ AI-Driven Development (vibe coding) on Databricks just got a whole lot better. T
   - [Antigravity](https://antigravity.google)
   - [Codex](https://openai.com/codex/)
   - [Copilot](https://github.com/features/copilot/cli)
+  - [Windsurf](https://windsurf.com)
 
 
 ### Install in existing project
 By default this will install at a project level rather than a user level. This is often a good fit, but requires you to run your client from the exact directory that was used for the install.
-_Note: Project configuration files can be re-used in other projects. You find these configs under .claude, .cursor, .gemini, .codex, .github or .agents_
+_Note: Project configuration files can be re-used in other projects. You find these configs under .claude, .cursor, .gemini, .codex, .github, .agents, .windsurf, or .codeium_
 
 #### Mac / Linux
 
@@ -93,7 +94,7 @@ bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-ki
 **Install for specific tools only**
 
 ```bash
-bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools cursor,gemini,antigravity
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools cursor,gemini,antigravity,windsurf
 ```
 
 </details>

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,7 @@
 #
 # Databricks AI Dev Kit - Unified Installer (Windows)
 #
-# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, and Antigravity.
+# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, and Windsurf.
 #
 # Usage: irm https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.ps1 -OutFile install.ps1
 #        .\install.ps1 [OPTIONS]
@@ -233,7 +233,7 @@ while ($i -lt $args.Count) {
             Write-Host "  --mcp-only            Skip skills installation"
             Write-Host "  --mcp-path PATH       Path to MCP server installation"
             Write-Host "  --silent              Silent mode (no output except errors)"
-            Write-Host "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity"
+            Write-Host "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf"
             Write-Host "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
             Write-Host "  --skills LIST         Comma-separated skill names to install (overrides profile)"
             Write-Host "  --list-skills         List available skills and profiles, then exit"
@@ -569,6 +569,8 @@ function Invoke-DetectTools {
     $hasGemini  = $null -ne (Get-Command gemini -ErrorAction SilentlyContinue)
     $hasAntigravity = ($null -ne (Get-Command antigravity -ErrorAction SilentlyContinue)) -or
                       (Test-Path "$env:LOCALAPPDATA\Programs\Antigravity\Antigravity.exe")
+    $hasWindsurf = ($null -ne (Get-Command windsurf -ErrorAction SilentlyContinue)) -or
+                   (Test-Path "$env:LOCALAPPDATA\Programs\Windsurf\Windsurf.exe")
 
     $claudeState  = $hasClaude;  $claudeHint  = if ($hasClaude)  { "detected" } else { "not found" }
     $cursorState  = $hasCursor;  $cursorHint  = if ($hasCursor)  { "detected" } else { "not found" }
@@ -576,9 +578,10 @@ function Invoke-DetectTools {
     $copilotState = $hasCopilot; $copilotHint = if ($hasCopilot) { "detected" } else { "not found" }
     $geminiState  = $hasGemini;  $geminiHint  = if ($hasGemini)  { "detected" } else { "not found" }
     $antigravityState = $hasAntigravity; $antigravityHint = if ($hasAntigravity) { "detected" } else { "not found" }
+    $windsurfState = $hasWindsurf; $windsurfHint = if ($hasWindsurf) { "detected" } else { "not found" }
 
     # If nothing detected, default to claude
-    if (-not $hasClaude -and -not $hasCursor -and -not $hasCodex -and -not $hasCopilot -and -not $hasGemini -and -not $hasAntigravity) {
+    if (-not $hasClaude -and -not $hasCursor -and -not $hasCodex -and -not $hasCopilot -and -not $hasGemini -and -not $hasAntigravity -and -not $hasWindsurf) {
         $claudeState = $true
         $claudeHint  = "default"
     }
@@ -595,6 +598,7 @@ function Invoke-DetectTools {
         @{ Label = "OpenAI Codex";   Value = "codex";        State = $codexState;        Hint = $codexHint }
         @{ Label = "Gemini CLI";     Value = "gemini";       State = $geminiState;       Hint = $geminiHint }
         @{ Label = "Antigravity";    Value = "antigravity";  State = $antigravityState;  Hint = $antigravityHint }
+        @{ Label = "Windsurf";       Value = "windsurf";     State = $windsurfState;     Hint = $windsurfHint }
     )
 
     $result = Select-Checkbox -Items $items
@@ -1164,6 +1168,13 @@ function Install-Skills {
                     $dirs += Join-Path $BaseDir ".agents\skills"
                 }
             }
+            "windsurf" {
+                if ($script:Scope -eq "global") {
+                    $dirs += Join-Path $env:USERPROFILE ".codeium\windsurf\skills"
+                } else {
+                    $dirs += Join-Path $BaseDir ".windsurf\skills"
+                }
+            }
         }
     }
     $dirs = $dirs | Select-Object -Unique
@@ -1589,6 +1600,14 @@ function Write-McpConfigs {
                 Write-GeminiMcpJson (Join-Path $env:USERPROFILE ".gemini\antigravity\mcp_config.json")
                 Write-Ok "Antigravity MCP config"
             }
+            "windsurf" {
+                if ($script:Scope -eq "project") {
+                    Write-Warn "Windsurf only supports global MCP configuration."
+                    Write-Msg "  Config written to ~/.codeium/windsurf/mcp_config.json"
+                }
+                Write-McpJson (Join-Path $env:USERPROFILE ".codeium\windsurf\mcp_config.json")
+                Write-Ok "Windsurf MCP config"
+            }
         }
     }
 }
@@ -1642,6 +1661,10 @@ function Show-Summary {
     }
     if ($script:Tools -match 'antigravity') {
         Write-Msg "$step. Open your project in Antigravity to use Databricks skills and MCP tools"
+        $step++
+    }
+    if ($script:Tools -match 'windsurf') {
+        Write-Msg "$step. Restart Windsurf to pick up the databricks MCP server (Windsurf -> Settings -> Windsurf Settings -> MCP)"
         $step++
     }
     Write-Msg "$step. Open your project in your tool of choice"

--- a/install.sh
+++ b/install.sh
@@ -1103,9 +1103,9 @@ install_skills() {
                 ;;
             windsurf)
                 if [ "$SCOPE" = "global" ]; then
-                    dirs+=("$HOME/.windsurf/rules")
+                    dirs+=("$HOME/.codeium/windsurf/skills")
                 else
-                    dirs+=("$base_dir/.windsurf/rules")
+                    dirs+=("$base_dir/.windsurf/skills")
                 fi
                 ;;
         esac
@@ -1499,11 +1499,11 @@ write_mcp_configs() {
                 ok "Antigravity MCP config"
                 ;;
             windsurf)
-                if [ "$SCOPE" = "global" ]; then
-                    write_mcp_json "$HOME/.codeium/windsurf/mcp_config.json"
-                else
-                    write_mcp_json "$base_dir/.codeium/windsurf/mcp_config.json"
+                if [ "$SCOPE" = "project" ]; then
+                    warn "Windsurf only supports global MCP configuration."
+                    msg "  Config written to ${B}~/.codeium/windsurf/mcp_config.json${N}"
                 fi
+                write_mcp_json "$HOME/.codeium/windsurf/mcp_config.json"
                 ok "Windsurf MCP config"
                 ;;
         esac

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 #
 # Databricks AI Dev Kit - Unified Installer
 #
-# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, and Antigravity.
+# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, and Windsurf.
 #
 # Usage: bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) [OPTIONS]
 #
@@ -149,7 +149,7 @@ while [ $# -gt 0 ]; do
             echo "  --mcp-only            Skip skills installation"
             echo "  --mcp-path PATH       Path to MCP server installation (default: ~/.ai-dev-kit)"
             echo "  --silent              Silent mode (no output except errors)"
-            echo "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity"
+            echo "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf"
             echo "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
             echo "  --skills LIST         Comma-separated skill names to install (overrides profile)"
             echo "  --list-skills         List available skills and profiles, then exit"
@@ -503,6 +503,7 @@ detect_tools() {
     local has_copilot=false
     local has_gemini=false
     local has_antigravity=false
+    local has_windsurf=false
 
     command -v claude >/dev/null 2>&1 && has_claude=true
     { [ -d "/Applications/Cursor.app" ] || command -v cursor >/dev/null 2>&1; } && has_cursor=true
@@ -510,19 +511,21 @@ detect_tools() {
     { [ -d "/Applications/Visual Studio Code.app" ] || command -v code >/dev/null 2>&1; } && has_copilot=true
     { command -v gemini >/dev/null 2>&1 || [ -f "$HOME/.gemini/local/gemini" ]; } && has_gemini=true
     { [ -d "/Applications/Antigravity.app" ] || command -v antigravity >/dev/null 2>&1; } && has_antigravity=true
+    { [ -d "/Applications/Windsurf.app" ] || command -v windsurf >/dev/null 2>&1; } && has_windsurf=true
 
     # Build checkbox items: "Label|value|on_or_off|hint"
-    local claude_state="off" cursor_state="off" codex_state="off" copilot_state="off" gemini_state="off" antigravity_state="off"
-    local claude_hint="not found" cursor_hint="not found" codex_hint="not found" copilot_hint="not found" gemini_hint="not found" antigravity_hint="not found"
+    local claude_state="off" cursor_state="off" codex_state="off" copilot_state="off" gemini_state="off" antigravity_state="off" windsurf_state="off"
+    local claude_hint="not found" cursor_hint="not found" codex_hint="not found" copilot_hint="not found" gemini_hint="not found" antigravity_hint="not found" windsurf_hint="not found"
     [ "$has_claude" = true ]        && claude_state="on"        && claude_hint="detected"
     [ "$has_cursor" = true ]        && cursor_state="on"        && cursor_hint="detected"
     [ "$has_codex" = true ]         && codex_state="on"         && codex_hint="detected"
     [ "$has_copilot" = true ]       && copilot_state="on"       && copilot_hint="detected"
     [ "$has_gemini" = true ]        && gemini_state="on"        && gemini_hint="detected"
     [ "$has_antigravity" = true ]   && antigravity_state="on"   && antigravity_hint="detected"
+    [ "$has_windsurf" = true ]      && windsurf_state="on"      && windsurf_hint="detected"
 
     # If nothing detected, pre-select claude as default
-    if [ "$has_claude" = false ] && [ "$has_cursor" = false ] && [ "$has_codex" = false ] && [ "$has_copilot" = false ] && [ "$has_gemini" = false ] && [ "$has_antigravity" = false ]; then
+    if [ "$has_claude" = false ] && [ "$has_cursor" = false ] && [ "$has_codex" = false ] && [ "$has_copilot" = false ] && [ "$has_gemini" = false ] && [ "$has_antigravity" = false ] && [ "$has_windsurf" = false ]; then
         claude_state="on"
         claude_hint="default"
     fi
@@ -539,6 +542,7 @@ detect_tools() {
             "OpenAI Codex|codex|${codex_state}|${codex_hint}" \
             "Gemini CLI|gemini|${gemini_state}|${gemini_hint}" \
             "Antigravity|antigravity|${antigravity_state}|${antigravity_hint}" \
+            "Windsurf|windsurf|${windsurf_state}|${windsurf_hint}" \
         )
     else
         # Silent: use detected defaults
@@ -549,6 +553,7 @@ detect_tools() {
         [ "$has_codex" = true ]         && tools="${tools:+$tools }codex"
         [ "$has_gemini" = true ]        && tools="${tools:+$tools }gemini"
         [ "$has_antigravity" = true ]   && tools="${tools:+$tools }antigravity"
+        [ "$has_windsurf" = true ]      && tools="${tools:+$tools }windsurf"
         [ -z "$tools" ] && tools="claude"
         TOOLS="$tools"
     fi
@@ -1096,6 +1101,13 @@ install_skills() {
                     dirs+=("$base_dir/.agents/skills")
                 fi
                 ;;
+            windsurf)
+                if [ "$SCOPE" = "global" ]; then
+                    dirs+=("$HOME/.windsurf/rules")
+                else
+                    dirs+=("$base_dir/.windsurf/rules")
+                fi
+                ;;
         esac
     done
 
@@ -1486,6 +1498,14 @@ write_mcp_configs() {
                 write_gemini_mcp_json "$HOME/.gemini/antigravity/mcp_config.json"
                 ok "Antigravity MCP config"
                 ;;
+            windsurf)
+                if [ "$SCOPE" = "global" ]; then
+                    write_mcp_json "$HOME/.codeium/windsurf/mcp_config.json"
+                else
+                    write_mcp_json "$base_dir/.codeium/windsurf/mcp_config.json"
+                fi
+                ok "Windsurf MCP config"
+                ;;
         esac
     done
 }
@@ -1531,6 +1551,10 @@ summary() {
         fi
         if echo "$TOOLS" | grep -q antigravity; then
             msg "${step}. Open your project in Antigravity to use Databricks skills and MCP tools"
+            step=$((step + 1))
+        fi
+        if echo "$TOOLS" | grep -q windsurf; then
+            msg "${step}. Restart Windsurf to pick up the ${B}databricks${N} MCP server (Windsurf → Settings → Windsurf Settings → MCP)"
             step=$((step + 1))
         fi
         msg "${step}. Open your project in your tool of choice"


### PR DESCRIPTION
## Summary
Adds Windsurf as a supported tool in `install.sh`, mirroring the existing Cursor pattern.

## Motivation
The README lists Windsurf as a supported AI coding assistant ("Claude Code, Cursor, Antigravity, Windsurf, etc."), but `install.sh` only handled `claude`, `cursor`, `copilot`, `codex`, `gemini`, and `antigravity`. Windsurf users had to manually copy skills into `~/.windsurf/rules` and hand-write `~/.codeium/windsurf/mcp_config.json` — which is exactly what I did before writing this patch.

## Changes

**`install.sh`**
- Detect Windsurf via `/Applications/Windsurf.app` or `windsurf` on PATH
- Add Windsurf row to interactive checkbox tool picker + silent-mode default
- Install skills to `~/.windsurf/rules` (global) or `./.windsurf/rules` (project)
- Write MCP config to `~/.codeium/windsurf/mcp_config.json` (global) or `./.codeium/windsurf/mcp_config.json` (project), reusing the existing `write_mcp_json` helper
- Add Windsurf restart hint to the "Next steps" summary
- Update `--tools` help text and header comment

**`README.md`**
- Add Windsurf to prerequisites list
- Add `.windsurf` / `.codeium` to the per-project config-dirs note
- Add `windsurf` to the `--tools` example

## Testing
- `bash -n install.sh` — syntax OK
- Global install exercised end-to-end:
  ```
  bash ./install.sh --tools windsurf --global --force
  ```
  Verified `~/.codeium/windsurf/mcp_config.json` is valid JSON with the `databricks` MCP server key, skills copied into `~/.windsurf/rules/` (Databricks + MLflow + APX), and Windsurf's MCP Registry reports **databricks — 44/44 tools enabled** against the `e2-demo-field-eng` profile.
- Interactive path (`bash ./install.sh` with no flags, project scope) also works — new Windsurf row appears in the checkbox picker.

## Note
Submitting from a personal GitHub account (`rytizzle`) because EMU restrictions on my Databricks GH account (`ryan-tom_data`) prevent forking this repo. I am a Databricks Field Engineer — ryan.tom@databricks.com. Happy to re-submit via a different mechanism if preferred.