### PR TITLE
Fix stale SKILL_TOOL_MAPPING so builder-app skill filter works (fixes #479)

### DIFF
--- a/databricks-builder-app/server/services/skills_manager.py
+++ b/databricks-builder-app/server/services/skills_manager.py
@@ -29,6 +29,21 @@ SKILL_TOOL_MAPPING: dict[str, list[str]] = {
     'manage_uc_connections', 'manage_uc_tags', 'manage_uc_security_policies',
     'manage_uc_monitors', 'manage_uc_sharing',
     'manage_volume_files', 'get_volume_folder_details',
+    'manage_metric_views',
+  ],
+  'databricks-vector-search': [
+    'manage_vs_endpoint', 'manage_vs_index', 'manage_vs_data', 'query_vs_index',
+  ],
+  'databricks-metric-views': ['manage_metric_views'],
+  # Provisioned and Autoscale Lakebase share the core database/sync/credential
+  # tools.  Autoscale additionally claims branch tools.  If either skill is
+  # enabled, the shared tools are available.
+  'databricks-lakebase-provisioned': [
+    'manage_lakebase_database', 'manage_lakebase_sync', 'generate_lakebase_credential',
+  ],
+  'databricks-lakebase-autoscale': [
+    'manage_lakebase_database', 'manage_lakebase_sync', 'generate_lakebase_credential',
+    'manage_lakebase_branch',
   ],
   # APX (FastAPI+React) and Python (Dash/Streamlit/etc.) share the same
   # app lifecycle tools — the skill content differs, not the MCP operations.

--- a/databricks-builder-app/server/services/skills_manager.py
+++ b/databricks-builder-app/server/services/skills_manager.py
@@ -19,40 +19,21 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 SKILL_TOOL_MAPPING: dict[str, list[str]] = {
   'databricks-agent-bricks': ['manage_ka', 'manage_mas'],
-  'databricks-aibi-dashboards': [
-    'create_or_update_dashboard', 'get_dashboard',
-    'delete_dashboard', 'publish_dashboard',
-  ],
-  'databricks-genie': [
-    'create_or_update_genie', 'get_genie', 'delete_genie', 'ask_genie',
-  ],
-  'databricks-spark-declarative-pipelines': [
-    'create_or_update_pipeline', 'get_pipeline',
-    'delete_pipeline', 'run_pipeline',
-  ],
-  'databricks-model-serving': [
-    'get_serving_endpoint_status', 'query_serving_endpoint', 'list_serving_endpoints',
-  ],
-  'databricks-jobs': [
-    'list_jobs', 'get_job', 'find_job_by_name', 'create_job', 'update_job',
-    'delete_job', 'run_job_now', 'get_run', 'get_run_output', 'cancel_run',
-    'list_runs', 'wait_for_run',
-  ],
+  'databricks-aibi-dashboards': ['manage_dashboard'],
+  'databricks-genie': ['manage_genie', 'ask_genie'],
+  'databricks-spark-declarative-pipelines': ['manage_pipeline', 'manage_pipeline_run'],
+  'databricks-model-serving': ['manage_serving_endpoint'],
+  'databricks-jobs': ['manage_jobs', 'manage_job_runs'],
   'databricks-unity-catalog': [
     'manage_uc_objects', 'manage_uc_grants', 'manage_uc_storage',
     'manage_uc_connections', 'manage_uc_tags', 'manage_uc_security_policies',
     'manage_uc_monitors', 'manage_uc_sharing',
-    'list_volume_files', 'upload_to_volume', 'download_from_volume',
-    'delete_from_volume', 'create_volume_directory', 'get_volume_file_info',
+    'manage_volume_files', 'get_volume_folder_details',
   ],
   # APX (FastAPI+React) and Python (Dash/Streamlit/etc.) share the same
   # app lifecycle tools — the skill content differs, not the MCP operations.
-  'databricks-app-apx': [
-    'create_or_update_app', 'get_app', 'delete_app',
-  ],
-  'databricks-app-python': [
-    'create_or_update_app', 'get_app', 'delete_app',
-  ],
+  'databricks-app-apx': ['manage_app'],
+  'databricks-app-python': ['manage_app'],
 }
 
 

--- a/databricks-builder-app/tests/test_skills_manager.py
+++ b/databricks-builder-app/tests/test_skills_manager.py
@@ -1,0 +1,89 @@
+"""Tests for ``server.services.skills_manager``.
+
+The module is loaded directly from its file path so we do not trigger
+``server.services.__init__`` (which pulls in heavier services whose relative
+imports only resolve when the full app is running).
+"""
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_skills_manager():
+  """Load skills_manager.py without importing the server.services package."""
+  module_path = Path(__file__).resolve().parents[1] / 'server' / 'services' / 'skills_manager.py'
+  spec = importlib.util.spec_from_file_location('skills_manager_under_test', module_path)
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+def _load_live_mcp_tool_names() -> set[str]:
+  """Return the set of tool names currently registered with the MCP server.
+
+  Uses the same import/enumeration pattern as ``databricks_tools.py`` so the
+  test reflects the tools the running app actually exposes.
+  """
+  import asyncio
+
+  from databricks_mcp_server.server import mcp
+  from databricks_mcp_server.tools import (  # noqa: F401
+    compute,
+    file,
+    pipelines,
+    sql,
+  )
+
+  tool_manager = getattr(mcp, '_tool_manager', None)
+  registered = getattr(tool_manager, '_tools', None)
+  if registered:
+    return set(registered.keys())
+
+  tools_list = asyncio.run(mcp.list_tools())
+  return {t.name for t in tools_list}
+
+
+def test_skill_tool_mapping_matches_registered_mcp_tools():
+  """Every tool name in SKILL_TOOL_MAPPING must exist in the MCP server.
+
+  Without this guard, the MCP server can rename/consolidate a tool while
+  SKILL_TOOL_MAPPING keeps referring to the dead name. ``get_allowed_mcp_tools``
+  then silently lets the new (unmapped) tool through even when the owning skill
+  is disabled — the per-skill filter becomes a no-op.
+  """
+  sm = _load_skills_manager()
+  live = _load_live_mcp_tool_names()
+  stale: dict[str, list[str]] = {}
+  for skill, names in sm.SKILL_TOOL_MAPPING.items():
+    missing = [n for n in names if n not in live]
+    if missing:
+      stale[skill] = missing
+
+  assert not stale, (
+    f'SKILL_TOOL_MAPPING references tools that do not exist in the MCP server: '
+    f'{stale}. Update the mapping or rename the server tool.'
+  )
+
+
+def test_get_allowed_mcp_tools_blocks_disabled_skill():
+  """Disabling a skill must actually remove its mapped tools from the allowed set.
+
+  Regression test for the drift bug: when SKILL_TOOL_MAPPING referred to legacy
+  tool names (``list_jobs``, ``create_or_update_dashboard``, …) that no longer
+  existed, this filter became a no-op because the real ``manage_*`` tools were
+  never listed.
+  """
+  sm = _load_skills_manager()
+  all_tools = [
+    'mcp__databricks__manage_jobs',
+    'mcp__databricks__manage_job_runs',
+    'mcp__databricks__manage_dashboard',
+    'mcp__databricks__execute_sql',  # not mapped to any skill — always allowed
+  ]
+
+  allowed = sm.get_allowed_mcp_tools(all_tools, enabled_skills=['databricks-aibi-dashboards'])
+
+  assert 'mcp__databricks__manage_jobs' not in allowed
+  assert 'mcp__databricks__manage_job_runs' not in allowed
+  assert 'mcp__databricks__manage_dashboard' in allowed
+  assert 'mcp__databricks__execute_sql' in allowed


### PR DESCRIPTION
## Summary

Fixes #479. Every entry in `SKILL_TOOL_MAPPING` in `databricks-builder-app/server/services/skills_manager.py` referenced legacy, per-verb MCP tool names (`list_jobs`, `create_or_update_dashboard`, `get_app`, …) that no longer exist — the MCP server now exposes consolidated `manage_*` tools. Because `get_allowed_mcp_tools()` treats any tool *not* present in the mapping as "always allowed", disabling a skill in the builder-app UI never actually hid its real MCP tools. The per-skill filter was silently a no-op.

This PR points every mapping at the current tool names, adds mappings for skills that were previously unrepresented, and adds a test that cross-checks `SKILL_TOOL_MAPPING` against the live MCP tool registry so the two cannot drift silently again.

## Changes

**`databricks-builder-app/server/services/skills_manager.py`** — update `SKILL_TOOL_MAPPING`:

| Skill | Before | After |
|---|---|---|
| `databricks-jobs` | `list_jobs`, `get_job`, `find_job_by_name`, `create_job`, `update_job`, `delete_job`, `run_job_now`, `get_run`, `get_run_output`, `cancel_run`, `list_runs`, `wait_for_run` | `manage_jobs`, `manage_job_runs` |
| `databricks-aibi-dashboards` | `create_or_update_dashboard`, `get_dashboard`, `delete_dashboard`, `publish_dashboard` | `manage_dashboard` |
| `databricks-genie` | `create_or_update_genie`, `get_genie`, `delete_genie`, `ask_genie` | `manage_genie`, `ask_genie` |
| `databricks-spark-declarative-pipelines` | `create_or_update_pipeline`, `get_pipeline`, `delete_pipeline`, `run_pipeline` | `manage_pipeline`, `manage_pipeline_run` |
| `databricks-model-serving` | `get_serving_endpoint_status`, `query_serving_endpoint`, `list_serving_endpoints` | `manage_serving_endpoint` |
| `databricks-unity-catalog` (volume + metric tools) | `list_volume_files`, `upload_to_volume`, `download_from_volume`, `delete_from_volume`, `create_volume_directory`, `get_volume_file_info` | `manage_volume_files`, `get_volume_folder_details`, `manage_metric_views` |
| `databricks-app-apx` / `databricks-app-python` | `create_or_update_app`, `get_app`, `delete_app` | `manage_app` |
| `databricks-vector-search` | _(unmapped — always allowed)_ | `manage_vs_endpoint`, `manage_vs_index`, `manage_vs_data`, `query_vs_index` |
| `databricks-metric-views` | _(unmapped)_ | `manage_metric_views` |
| `databricks-lakebase-provisioned` | _(unmapped)_ | `manage_lakebase_database`, `manage_lakebase_sync`, `generate_lakebase_credential` |
| `databricks-lakebase-autoscale` | _(unmapped)_ | provisioned tools + `manage_lakebase_branch` |

`databricks-agent-bricks` (`manage_ka`, `manage_mas`) and the `manage_uc_*` entries under `databricks-unity-catalog` were already correct and are unchanged.

`manage_metric_views` is intentionally shared between `databricks-unity-catalog` and the standalone `databricks-metric-views` skill — per `get_allowed_mcp_tools()`'s semantics, a tool claimed by multiple skills is available when any of them is enabled.

**`databricks-builder-app/tests/test_skills_manager.py`** — new file:

1. `test_skill_tool_mapping_matches_registered_mcp_tools` — enumerates the running MCP server's tools (same pattern `databricks_tools.py` uses at startup) and asserts every name in `SKILL_TOOL_MAPPING` exists. Verified: this test fails with a clear error when an unknown name is introduced, and passes after this PR's fix.
2. `test_get_allowed_mcp_tools_blocks_disabled_skill` — regression test that disabling `databricks-jobs` actually removes `manage_jobs` / `manage_job_runs` from the allowed set while keeping unmapped `execute_sql` available.

The test loads `skills_manager.py` directly via `importlib.util.spec_from_file_location` rather than `from server.services.skills_manager import …`, because importing through `server.services.__init__` triggers unrelated relative imports (`..db.database`) that don't resolve without the full app context. Same reason the existing `server/services/test_clusters.py` currently fails to collect — that's a separate pre-existing issue out of scope here.

## Test plan

- [x] `uv run pytest databricks-builder-app/tests/test_skills_manager.py -v` — 2 passed (all new `manage_*` names verified against the live MCP server)
- [x] Verified the drift test actually fails by temporarily injecting a fake dead name (`list_jobs_DEAD`), then reverted
- [x] `ruff check` and `ruff format` clean on both changed files (no new lints; pre-existing E501 in `skills_manager.py:107` left alone)