### PR TITLE
Fix stale skill name in install_skills.sh description lookup

### DIFF
--- a/databricks-skills/install_skills.sh
+++ b/databricks-skills/install_skills.sh
@@ -70,7 +70,7 @@ get_skill_description() {
         "databricks-agent-bricks") echo "Knowledge Assistants, Genie Spaces, Supervisor Agents" ;;
         "databricks-ai-functions") echo "Built-in AI Functions (classify, extract, query, forecast, parse, etc.), doc processing & custom RAG" ;;
         "databricks-aibi-dashboards") echo "Databricks AI/BI Dashboards - create and manage dashboards" ;;
-        "databricks-asset-bundles") echo "Databricks Asset Bundles - deployment and configuration" ;;                                                                                                                          
+        "databricks-bundles") echo "Databricks Asset Bundles - deployment and configuration" ;;                                                                                                                          
         "databricks-app-apx") echo "Databricks Apps with React/Next.js (APX framework)" ;;                                                                                                                                     
         "databricks-app-python") echo "Databricks Apps with Python (Dash, Streamlit) and foundation model integration" ;;     
         "databricks-config") echo "Profile authentication setup for Databricks" ;;


### PR DESCRIPTION
## Summary

`databricks-skills/install_skills.sh`'s `get_skill_description` case branch still used the pre-rename name `databricks-asset-bundles` after the skill directory was renamed to `databricks-bundles` (#314 / commit `45f73e3`). The active skill lists (`DATABRICKS_SKILLS` at line 50, the `--list-skills` output, the install summary) already use the new name, so every call to `get_skill_description databricks-bundles` fell through to `*) echo "Unknown skill"` — the installer displayed "Unknown skill" as the description for the bundles skill.

## Changes

- `databricks-skills/install_skills.sh:73` — rename case branch `"databricks-asset-bundles"` → `"databricks-bundles"`.

## Test plan

- [x] `bash -n databricks-skills/install_skills.sh` — syntax clean.
- [x] Extracted the case statement in a standalone shell, confirmed:
  - `get_skill_description databricks-bundles` → `Databricks Asset Bundles - deployment and configuration` (was: `Unknown skill`)
  - `get_skill_description databricks-asset-bundles` → `Unknown skill` (old name is no longer referenced anywhere in the file, so this fallback is expected)
- [x] `grep databricks-asset-bundles databricks-skills/` returns no further references.

## Notes

- Out of scope: `databricks-builder-app/app.yaml_backup` still embeds several stale skill names (`databricks-asset-bundles`, `mlflow-evaluation`, `spark-declarative-pipelines`, `synthetic-data-generation`, `unstructured-pdf-generation`). The file is not loaded by any code I could find (only `app.yaml.example` is referenced by tooling) and is likely an orphan backup from a past deploy. Happy to delete or update it in a follow-up if maintainers confirm it's dead.