### PR TITLE
Skill update: ai functions update to v2 in document processing pipeline

### DIFF
--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -13,8 +13,8 @@ When processing documents with AI Functions, apply this order of preference for 
 | Stage | Preferred function | Use `ai_query` when... |
 |---|---|---|
 | Parse binary docs (PDF, DOCX, images) | `ai_parse_document` | Need image-level reasoning |
-| Extract flat/typed fields | `ai_extract` v2 | Schema exceeds 128 fields or 7 nesting levels |
-| Extract arrays of objects (e.g. line items) | `ai_extract` v2 | Deeply nested arrays exceeding 7-level limit |
+| Extract flat/typed fields | `ai_extract` | Schema exceeds 128 fields or 7 nesting levels |
+| Extract arrays of objects (e.g. line items) | `ai_extract` | Deeply nested arrays exceeding 7-level limit |
 | Classify document type or status | `ai_classify` | More than 20 categories |
 | Score item similarity / matching | `ai_similarity` | Need cross-document reasoning |
 | Summarize long sections | `ai_summarize` | — |

--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -130,7 +130,13 @@ def classified_docs():
         dlt.read("raw_parsed")
         .withColumn(
             "doc_type",
-            expr("ai_classify(text_blocks, array('invoice', 'purchase_order', 'receipt', 'contract', 'other'))")
+            expr("""
+                ai_classify(
+                    text_blocks,
+                    '["invoice", "purchase_order", "receipt", "contract", "other"]',
+                    MAP('version', '2.0')
+                ):response[0]::STRING
+            """)
         )
     )
 

--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -13,11 +13,12 @@ When processing documents with AI Functions, apply this order of preference for 
 | Stage | Preferred function | Use `ai_query` when... |
 |---|---|---|
 | Parse binary docs (PDF, DOCX, images) | `ai_parse_document` | Need image-level reasoning |
-| Extract flat fields from text | `ai_extract` | Schema has nested arrays |
+| Extract flat/typed fields | `ai_extract` v2 | Schema exceeds 128 fields or 7 nesting levels |
+| Extract arrays of objects (e.g. line items) | `ai_extract` v2 | Deeply nested arrays exceeding 7-level limit |
 | Classify document type or status | `ai_classify` | More than 20 categories |
 | Score item similarity / matching | `ai_similarity` | Need cross-document reasoning |
 | Summarize long sections | `ai_summarize` | — |
-| Extract nested JSON (e.g. line items) | `ai_query` with `responseFormat` | (This is the intended use case) |
+| Extract complex nested JSON | `ai_query` with `responseFormat` | Schema exceeds v2 limits (128 fields, 7 levels) |
 
 ---
 
@@ -80,7 +81,7 @@ Each logical step in your document workflow maps to a `@dlt.table` stage. Data f
 ```
 [Landing Volume]  →  Stage 1: ai_parse_document
                   →  Stage 2: ai_classify (document type)
-                  →  Stage 3: ai_extract (flat fields) + ai_query (nested JSON)
+                  →  Stage 3: ai_extract v2 (typed fields + arrays) + ai_query (deeply nested JSON)
                   →  Stage 4: ai_similarity (item matching)
                   →  Stage 5: Final Delta output table
 ```
@@ -129,29 +130,47 @@ def classified_docs():
     )
 
 
-# ── Stage 3a: Flat field extraction ──────────────────────────────────────────
-# Preferred: ai_extract for flat fields (vendor, date, total)
+# ── Stage 3a: Typed field extraction (ai_extract v2) ────────────────────────
+# Preferred: ai_extract v2 for typed fields (vendor, date, total)
 
-@dlt.table(comment="Flat header fields extracted from documents")
+@dlt.table(comment="Typed header fields extracted from documents (ai_extract v2)")
 def extracted_flat():
     return (
         dlt.read("classified_docs")
         .filter("doc_type = 'invoice'")
         .withColumn(
-            "header",
-            expr("ai_extract(text_blocks, array('invoice_number', 'vendor_name', 'issue_date', 'total_amount', 'tax_id'))")
+            "result",
+            expr("""
+                ai_extract(
+                    text_blocks,
+                    '{
+                      "invoice_number": {"type": "string"},
+                      "vendor_name": {"type": "string"},
+                      "issue_date": {"type": "string", "description": "Date in dd/mm/yyyy format"},
+                      "total_amount": {"type": "number"},
+                      "tax_id": {"type": "string", "description": "Vendor tax ID, digits only"}
+                    }',
+                    MAP('version', '2.0')
+                )
+            """)
         )
-        .select("path", "doc_type", "text_blocks", col("header"))
+        .selectExpr(
+            "path", "doc_type", "text_blocks",
+            "result:response AS header",
+            "result:error_message::STRING AS extract_error"
+        )
     )
 
 
-# ── Stage 3b: Nested JSON extraction (last resort: ai_query) ─────────────────
-# Use ai_query only because line_items is a nested array — ai_extract can't handle it
+# ── Stage 3b: Nested JSON extraction (ai_query fallback) ────────────────────
+# ai_extract v2 handles simple arrays of objects, but ai_query is used here
+# for deeply nested or complex schemas that may exceed v2's 7-level limit.
 
-@dlt.table(comment="Nested line items extracted — ai_query used for array schema only")
+@dlt.table(comment="Nested line items extracted — ai_query for complex nested arrays")
 def extracted_line_items():
     return (
         dlt.read("extracted_flat")
+        .filter("extract_error IS NULL")
         .withColumn(
             "ai_response",
             expr(f"""
@@ -188,7 +207,7 @@ def vendor_matched():
         extracted.crossJoin(vendors)
         .withColumn(
             "name_similarity",
-            expr("ai_similarity(header.vendor_name, vendor_name)")
+            expr("ai_similarity(header:vendor_name::STRING, vendor_name)")
         )
         .filter("name_similarity > 0.80")
         .orderBy("name_similarity", ascending=False)
@@ -208,10 +227,10 @@ def processed_docs():
         .selectExpr(
             "path",
             "doc_type",
-            "header.invoice_number",
-            "header.vendor_name",
-            "header.issue_date",
-            "header.total_amount",
+            "header:invoice_number::STRING AS invoice_number",
+            "header:vendor_name::STRING AS vendor_name",
+            "header:issue_date::STRING AS issue_date",
+            "header:total_amount::DOUBLE AS total_amount",
             "line_items.line_items AS items",
         )
     )
@@ -220,9 +239,14 @@ def processed_docs():
 @dlt.table(comment="Rows that failed at any extraction stage — review and reprocess")
 def processing_errors():
     return (
-        dlt.read("extracted_line_items")
-        .filter("extraction_error IS NOT NULL")
-        .select("path", "doc_type", col("extraction_error").alias("error"))
+        dlt.read("extracted_flat")
+        .filter("extract_error IS NOT NULL")
+        .select("path", "doc_type", col("extract_error").alias("error"))
+        .unionByName(
+            dlt.read("extracted_line_items")
+            .filter("extraction_error IS NOT NULL")
+            .select("path", "doc_type", col("extraction_error").alias("error"))
+        )
     )
 ```
 
@@ -463,7 +487,7 @@ with mlflow.start_run():
 ## Tips
 
 1. **Parse first, enrich second** — always run `ai_parse_document` as the first stage. Feed its text output to task-specific functions; never pass raw binary to `ai_query`.
-2. **Flat fields → `ai_extract`; nested arrays → `ai_query`** — this is the clearest decision boundary.
+2. **Typed fields + simple arrays → `ai_extract` v2; deeply nested JSON exceeding 7 levels → `ai_query`** — always pass `MAP('version', '2.0')` and access results through `:response`.
 3. **`failOnError => false` is mandatory in batch** — write errors to a sidecar `_errors` table rather than crashing the pipeline.
 4. **Truncate before sending to `ai_query`** — use `LEFT(text, 6000)` or chunk long documents to stay within context window limits.
 5. **Prompts belong in `config.yml`** — never hardcode prompt strings in pipeline code. A prompt change should be a config change, not a code change.

--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -105,7 +105,7 @@ PROMPT   = CFG["prompts"]["extract_invoice"]
 def raw_parsed():
     return (
         spark.read.format("binaryFile").load(VOL_IN)
-        .withColumn("parsed", expr("ai_parse_document(content)"))
+        .withColumn("parsed", expr("ai_parse_document(content, MAP('version', '2.0'))"))
         .withColumn("text_blocks", expr("""
             concat_ws('\n', transform(
                 parsed:document:elements,
@@ -155,7 +155,13 @@ def extracted_flat():
             expr("""
                 ai_extract(
                     text_blocks,
-                    '["invoice_number", "vendor_name", "issue_date", "total_amount", "tax_id"]',
+                    '{
+                        "invoice_number": {"type": "string"},
+                        "vendor_name":    {"type": "string"},
+                        "issue_date":     {"type": "string", "description": "dd/mm/yyyy"},
+                        "total_amount":   {"type": "number"},
+                        "tax_id":         {"type": "string"}
+                     }',
                     MAP('version', '2.0')
                 )
             """)

--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -13,12 +13,11 @@ When processing documents with AI Functions, apply this order of preference for 
 | Stage | Preferred function | Use `ai_query` when... |
 |---|---|---|
 | Parse binary docs (PDF, DOCX, images) | `ai_parse_document` | Need image-level reasoning |
-| Extract flat/typed fields | `ai_extract` | Schema exceeds 128 fields or 7 nesting levels |
-| Extract arrays of objects (e.g. line items) | `ai_extract` | Deeply nested arrays exceeding 7-level limit |
+| Extract fields from text (flat or nested) | `ai_extract` | Schema exceeds 128 fields or 7 nesting levels |
 | Classify document type or status | `ai_classify` | More than 20 categories |
 | Score item similarity / matching | `ai_similarity` | Need cross-document reasoning |
 | Summarize long sections | `ai_summarize` | — |
-| Extract complex nested JSON | `ai_query` with `responseFormat` | Schema exceeds v2 limits (128 fields, 7 levels) |
+| Extract deeply nested JSON | `ai_query` with `responseFormat` | Schema exceeds `ai_extract` limits (128 fields, 7 levels) |
 
 ---
 
@@ -81,7 +80,7 @@ Each logical step in your document workflow maps to a `@dlt.table` stage. Data f
 ```
 [Landing Volume]  →  Stage 1: ai_parse_document
                   →  Stage 2: ai_classify (document type)
-                  →  Stage 3: ai_extract v2 (typed fields + arrays) + ai_query (deeply nested JSON)
+                  →  Stage 3: ai_extract (flat fields) + ai_query (nested JSON)
                   →  Stage 4: ai_similarity (item matching)
                   →  Stage 5: Final Delta output table
 ```
@@ -136,10 +135,10 @@ def classified_docs():
     )
 
 
-# ── Stage 3a: Typed field extraction (ai_extract v2) ────────────────────────
-# Preferred: ai_extract v2 for typed fields (vendor, date, total)
+# ── Stage 3a: Flat field extraction ──────────────────────────────────────────
+# Preferred: ai_extract for flat fields (vendor, date, total)
 
-@dlt.table(comment="Typed header fields extracted from documents (ai_extract v2)")
+@dlt.table(comment="Flat header fields extracted from documents")
 def extracted_flat():
     return (
         dlt.read("classified_docs")
@@ -150,13 +149,7 @@ def extracted_flat():
             expr("""
                 ai_extract(
                     text_blocks,
-                    '{
-                      "invoice_number": {"type": "string"},
-                      "vendor_name": {"type": "string"},
-                      "issue_date": {"type": "string", "description": "Date in dd/mm/yyyy format"},
-                      "total_amount": {"type": "number"},
-                      "tax_id": {"type": "string", "description": "Vendor tax ID, digits only"}
-                    }',
+                    '["invoice_number", "vendor_name", "issue_date", "total_amount", "tax_id"]',
                     MAP('version', '2.0')
                 )
             """)
@@ -169,11 +162,10 @@ def extracted_flat():
     )
 
 
-# ── Stage 3b: Nested JSON extraction (ai_query fallback) ────────────────────
-# ai_extract v2 handles simple arrays of objects, but ai_query is used here
-# for deeply nested or complex schemas that may exceed v2's 7-level limit.
+# ── Stage 3b: Nested JSON extraction (last resort: ai_query) ─────────────────
+# Use ai_query only for deeply nested schemas that exceed ai_extract's 7-level limit
 
-@dlt.table(comment="Nested line items extracted — ai_query for complex nested arrays")
+@dlt.table(comment="Nested line items extracted — ai_query used for array schema only")
 def extracted_line_items():
     return (
         dlt.read("extracted_flat")
@@ -494,7 +486,7 @@ with mlflow.start_run():
 ## Tips
 
 1. **Parse first, enrich second** — always run `ai_parse_document` as the first stage. Feed its text output to task-specific functions; never pass raw binary to `ai_query`.
-2. **Typed fields + simple arrays → `ai_extract` v2; deeply nested JSON exceeding 7 levels → `ai_query`** — always pass `MAP('version', '2.0')` and access results through `:response`.
+2. **Flat or nested fields → `ai_extract`; deeply nested JSON exceeding 7 levels → `ai_query`** — pass `MAP('version', '2.0')` and access results through `:response`.
 3. **`failOnError => false` is mandatory in batch** — write errors to a sidecar `_errors` table rather than crashing the pipeline.
 4. **Truncate before sending to `ai_query`** — use `LEFT(text, 6000)` or chunk long documents to stay within context window limits.
 5. **Prompts belong in `config.yml`** — never hardcode prompt strings in pipeline code. A prompt change should be a config change, not a code change.

--- a/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
+++ b/databricks-skills/databricks-ai-functions/4-document-processing-pipeline.md
@@ -107,10 +107,16 @@ def raw_parsed():
     return (
         spark.read.format("binaryFile").load(VOL_IN)
         .withColumn("parsed", expr("ai_parse_document(content)"))
+        .withColumn("text_blocks", expr("""
+            concat_ws('\n', transform(
+                parsed:document:elements,
+                e -> e:content::STRING
+            ))
+        """))
         .selectExpr(
             "path",
-            "parsed:pages[*].elements[*].content AS text_blocks",
-            "parsed:error AS parse_error",
+            "text_blocks",
+            "parsed:error_status AS parse_error",
         )
         .filter("parse_error IS NULL")
     )
@@ -138,6 +144,7 @@ def extracted_flat():
     return (
         dlt.read("classified_docs")
         .filter("doc_type = 'invoice'")
+        .filter("text_blocks IS NOT NULL")
         .withColumn(
             "result",
             expr("""


### PR DESCRIPTION
Hello! Noticed that some of the references to ai functions within the document processing pipeline were outdated and using v1. Updated those to reflect the changes in syntax as per the new versions of ai_extract, ai_classify, etc. Added a typed extraction example as well following the documentation

https://docs.databricks.com/aws/en/sql/language-manual/functions/ai_extract
https://docs.databricks.com/aws/en/sql/language-manual/functions/ai_classify


