### PR TITLE
Skip Lakebase deploy if project already exists

### DIFF
--- a/databricks-builder-app/scripts/deploy.sh
+++ b/databricks-builder-app/scripts/deploy.sh
@@ -177,6 +177,8 @@ echo -e "${YELLOW}[2/${TOTAL_STEPS}] Deploying Lakebase...${NC}"
 
 if [ "$SKIP_LAKEBASE" = true ]; then
   echo -e "  ${GREEN}✓${NC} Skipped (--skip-lakebase)"
+elif databricks postgres get-project "projects/${LAKEBASE_PROJECT_ID}" $CLI_ARGS &> /dev/null; then
+  echo -e "  ${GREEN}✓${NC} Lakebase project '${LAKEBASE_PROJECT_ID}' already exists — reusing"
 else
   cd "$PROJECT_DIR"
   BUNDLE_ARGS=""


### PR DESCRIPTION
## Summary
- `databricks-builder-app/scripts/deploy.sh` now checks `databricks postgres get-project` before running `bundle deploy`, so re-runs against a workspace where the Lakebase project already exists skip the deploy step instead of failing.
- Lets users reuse an existing Lakebase instance without passing `--skip-lakebase` every time.

## Test plan
- [ ] Run `./scripts/deploy.sh` in a workspace with no existing Lakebase project — step 2 deploys via DAB as before.
- [ ] Re-run against the same workspace — step 2 reports "already exists — reusing" and continues.
- [ ] Run with `--skip-lakebase` — still short-circuits to the skipped message.

This pull request and its description were written by Isaac.