### PR TITLE
Bump critical/high-severity dependencies for security fixes

### DIFF
--- a/databricks-builder-app/pyproject.toml
+++ b/databricks-builder-app/pyproject.toml
@@ -28,14 +28,15 @@ dependencies = [
   "psycopg2-binary>=2.9.11",  # For alembic migrations (sync)
   # Claude Agent SDK (successor to claude-code-sdk)
   "claude-agent-sdk>=0.1.19",
-  "anthropic>=0.42.0",
+  "anthropic>=0.94.1",
   # Databricks MCP tools (databricks-mcp-server installed from sibling dir in dev)
   "mcp>=1.0.0",
-  "fastmcp==3.1.1",
+  "fastmcp>=3.2.4,<4",
   # databricks-tools-core and databricks-mcp-server are bundled in packages/ directory
   "requests>=2.31.0",
   # MLflow 3+ for Claude Code tracing (not mlflow[databricks] to avoid litellm)
-  "mlflow>=3.9.0",
+  # Cap at <3.11 to avoid pre-release resolution via tool.uv.prerelease=allow
+  "mlflow>=3.9.0,<3.11",
   "sqlglot>=20.0.0",
   "sqlfluff>=3.0.0",
   "plutoprint==0.19.0",
@@ -48,8 +49,8 @@ dependencies = [
   "rich==14.0.0",
   "protobuf>=3.12.0,<5",
   "pandas==2.3.0",
-  "flask==3.1.0",
-  "werkzeug==3.1.3",
+  "flask==3.1.3",
+  "werkzeug==3.1.8",
 ]
 
 [dependency-groups]

--- a/databricks-builder-app/requirements.txt
+++ b/databricks-builder-app/requirements.txt
@@ -2,7 +2,7 @@ aiofile==3.9.0
     # via py-key-value-aio
 alembic==1.18.4
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   mlflow
 annotated-doc==0.0.4
     # via
@@ -10,9 +10,9 @@ annotated-doc==0.0.4
     #   typer
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.86.0
-    # via databricks-builder-app (pyproject.toml)
-anyio==4.12.1
+anthropic==0.96.0
+    # via databricks-builder-app
+anyio==4.13.0
     # via
     #   anthropic
     #   claude-agent-sdk
@@ -29,6 +29,8 @@ attrs==26.1.0
     #   referencing
 authlib==1.6.9
     # via fastmcp
+backports-tarfile==1.2.0 ; python_full_version < '3.12'
+    # via jaraco-context
 beartype==0.22.9
     # via py-key-value-aio
 blinker==1.9.0
@@ -46,17 +48,17 @@ certifi==2026.2.25
     #   httpx
     #   requests
     #   sentry-sdk
-cffi==2.0.0
+cffi==2.0.0 ; platform_python_implementation != 'PyPy'
     # via cryptography
-chardet==7.2.0
+chardet==7.4.0.post2
     # via
     #   diff-cover
     #   sqlfluff
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
-claude-agent-sdk==0.1.50
-    # via databricks-builder-app (pyproject.toml)
-click==8.3.1
+claude-agent-sdk==0.1.56
+    # via databricks-builder-app
+click==8.3.2
     # via
     #   flask
     #   mlflow-skinny
@@ -67,22 +69,28 @@ click==8.3.1
 cloudpickle==3.1.2
     # via mlflow-skinny
 colorama==0.4.6
-    # via sqlfluff
+    # via
+    #   click
+    #   pytest
+    #   sqlfluff
+    #   tqdm
+    #   uvicorn
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.5
+cryptography==46.0.6
     # via
     #   authlib
     #   google-auth
     #   mlflow
     #   pyjwt
+    #   secretstorage
 cycler==0.12.1
     # via matplotlib
-cyclopts==5.0.0a5
+cyclopts==5.0.0a6
     # via fastmcp
 databricks-sdk==0.102.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   mlflow-skinny
     #   mlflow-tracing
 diff-cover==10.2.0
@@ -103,21 +111,21 @@ email-validator==2.3.0
     #   pydantic
 exceptiongroup==1.3.1
     # via fastmcp
-fastapi==0.135.1
+fastapi==0.135.3
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   mlflow-skinny
 fastapi-cli==0.0.24
     # via fastapi
-fastapi-cloud-cli==0.15.0
+fastapi-cloud-cli==0.15.1
     # via fastapi-cli
 fastar==0.9.0
     # via fastapi-cloud-cli
-fastmcp==3.1.1
-    # via databricks-builder-app (pyproject.toml)
-flask==3.1.0
+fastmcp==3.2.4
+    # via databricks-builder-app
+flask==3.1.3
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   flask-cors
     #   mlflow
 flask-cors==6.0.2
@@ -140,9 +148,11 @@ graphql-relay==3.2.0
     # via graphene
 greenlet==3.3.2
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   sqlalchemy
-gunicorn==25.1.0
+griffelib==2.0.2
+    # via fastmcp
+gunicorn==25.3.0 ; sys_platform != 'win32'
     # via mlflow
 h11==0.16.0
     # via
@@ -154,8 +164,8 @@ httptools==0.7.1
     # via uvicorn
 httpx==0.28.1
     # via
-    #   databricks-builder-app (pyproject.toml)
     #   anthropic
+    #   databricks-builder-app
     #   fastapi
     #   fastapi-cloud-cli
     #   fastmcp
@@ -172,6 +182,7 @@ idna==3.11
     #   requests
 importlib-metadata==8.7.1
     # via
+    #   keyring
     #   mlflow-skinny
     #   opentelemetry-api
 iniconfig==2.3.0
@@ -184,6 +195,10 @@ jaraco-context==6.1.2
     # via keyring
 jaraco-functools==4.4.0
     # via keyring
+jeepney==0.9.0 ; sys_platform == 'linux'
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   diff-cover
@@ -212,30 +227,31 @@ markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.2
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
+    #   flask
     #   jinja2
     #   mako
     #   werkzeug
 matplotlib==3.10.8
     # via mlflow
-mcp==1.26.0
+mcp==1.27.0
     # via
-    #   databricks-builder-app (pyproject.toml)
     #   claude-agent-sdk
+    #   databricks-builder-app
     #   fastmcp
 mdurl==0.1.2
     # via markdown-it-py
 mlflow==3.10.1
-    # via databricks-builder-app (pyproject.toml)
+    # via databricks-builder-app
 mlflow-skinny==3.10.1
     # via mlflow
 mlflow-tracing==3.10.1
     # via mlflow
-more-itertools==10.8.0
+more-itertools==11.0.1
     # via
     #   jaraco-classes
     #   jaraco-functools
-numpy==2.4.3
+numpy==2.4.4
     # via
     #   contourpy
     #   matplotlib
@@ -275,7 +291,7 @@ packaging==26.0
     #   skops
 pandas==2.3.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   mlflow
 pathable==0.5.0
     # via jsonschema-path
@@ -283,7 +299,7 @@ pathspec==1.0.4
     # via sqlfluff
 pillow==11.1.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   matplotlib
 platformdirs==4.9.4
     # via
@@ -294,38 +310,38 @@ pluggy==1.6.0
     #   diff-cover
     #   pytest
 plutoprint==0.19.0
-    # via databricks-builder-app (pyproject.toml)
+    # via databricks-builder-app
 prettytable==3.17.0
     # via skops
-protobuf==4.25.8
+protobuf==4.25.9
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   databricks-sdk
     #   mlflow-skinny
     #   mlflow-tracing
     #   opentelemetry-proto
 psycopg==3.3.3
-    # via databricks-builder-app (pyproject.toml)
-psycopg-binary==3.3.3
+    # via databricks-builder-app
+psycopg-binary==3.3.3 ; implementation_name != 'pypy'
     # via psycopg
 psycopg2-binary==2.9.11
-    # via databricks-builder-app (pyproject.toml)
+    # via databricks-builder-app
 py-key-value-aio==0.4.4
     # via fastmcp
 pyarrow==18.1.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   mlflow
 pyasn1==0.6.3
     # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
-pycparser==3.0
+pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'
     # via cffi
-pydantic==2.13.0b2
+pydantic==2.13.0b3
     # via
-    #   databricks-builder-app (pyproject.toml)
     #   anthropic
+    #   databricks-builder-app
     #   fastapi
     #   fastapi-cloud-cli
     #   fastmcp
@@ -335,7 +351,7 @@ pydantic==2.13.0b2
     #   openapi-pydantic
     #   pydantic-extra-types
     #   pydantic-settings
-pydantic-core==2.42.0
+pydantic-core==2.45.0
     # via pydantic
 pydantic-extra-types==2.11.1
     # via fastapi
@@ -343,7 +359,7 @@ pydantic-settings==2.13.1
     # via
     #   fastapi
     #   mcp
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   diff-cover
     #   pytest
@@ -363,17 +379,23 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.2.2
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   fastmcp
     #   mlflow-skinny
     #   pydantic-settings
     #   uvicorn
-python-multipart==0.0.22
+python-multipart==0.0.24
     # via
     #   fastapi
     #   mcp
 pytz==2026.1.post1
     # via pandas
+pywin32==311 ; sys_platform == 'win32'
+    # via
+    #   docker
+    #   mcp
+pywin32-ctypes==0.2.3 ; sys_platform == 'win32'
+    # via keyring
 pyyaml==6.0.3
     # via
     #   fastmcp
@@ -386,18 +408,18 @@ referencing==0.37.0
     #   jsonschema
     #   jsonschema-path
     #   jsonschema-specifications
-regex==2026.2.28
+regex==2026.4.4
     # via sqlfluff
-requests==2.32.5
+requests==2.33.1
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   databricks-sdk
     #   docker
     #   mlflow-skinny
 rich==14.0.0
     # via
-    #   databricks-builder-app (pyproject.toml)
     #   cyclopts
+    #   databricks-builder-app
     #   fastmcp
     #   rich-toolkit
     #   typer
@@ -420,6 +442,8 @@ scipy==1.17.1
     #   mlflow
     #   scikit-learn
     #   skops
+secretstorage==3.5.0 ; sys_platform == 'linux'
+    # via keyring
 sentry-sdk==3.0.0a7
     # via fastapi-cloud-cli
 shellingham==1.5.4
@@ -434,16 +458,16 @@ sniffio==1.3.1
     # via anthropic
 sqlalchemy==2.1.0b1
     # via
-    #   databricks-builder-app (pyproject.toml)
     #   alembic
+    #   databricks-builder-app
     #   mlflow
-sqlfluff==4.0.4
-    # via databricks-builder-app (pyproject.toml)
-sqlglot==30.0.3
-    # via databricks-builder-app (pyproject.toml)
+sqlfluff==4.1.0
+    # via databricks-builder-app
+sqlglot==30.2.1
+    # via databricks-builder-app
 sqlparse==0.5.5
     # via mlflow-skinny
-sse-starlette==3.3.3
+sse-starlette==3.3.4
     # via mcp
 starlette==1.0.0
     # via
@@ -453,7 +477,7 @@ starlette==1.0.0
 tblib==3.2.2
     # via sqlfluff
 tenacity==9.0.0
-    # via databricks-builder-app (pyproject.toml)
+    # via databricks-builder-app
 threadpoolctl==3.6.0
     # via scikit-learn
 tqdm==4.67.3
@@ -491,8 +515,10 @@ typing-inspection==0.4.2
     #   mcp
     #   pydantic
     #   pydantic-settings
-tzdata==2025.3
-    # via pandas
+tzdata==2026.1
+    # via
+    #   pandas
+    #   psycopg
 uncalled-for==0.2.0
     # via fastmcp
 urllib3==2.6.3
@@ -500,17 +526,19 @@ urllib3==2.6.3
     #   docker
     #   requests
     #   sentry-sdk
-uvicorn==0.42.0
+uvicorn==0.44.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
     #   fastmcp
     #   mcp
     #   mlflow-skinny
-uvloop==0.22.1
+uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
     # via uvicorn
+waitress==3.0.2 ; sys_platform == 'win32'
+    # via mlflow
 watchfiles==1.1.1
     # via
     #   fastmcp
@@ -519,12 +547,12 @@ wcwidth==0.6.0
     # via prettytable
 websockets==16.0
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   fastmcp
     #   uvicorn
-werkzeug==3.1.3
+werkzeug==3.1.8
     # via
-    #   databricks-builder-app (pyproject.toml)
+    #   databricks-builder-app
     #   flask
     #   flask-cors
 zipp==3.23.0

--- a/databricks-mcp-server/pyproject.toml
+++ b/databricks-mcp-server/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "databricks-tools-core",
-    "fastmcp==3.1.1",
+    "fastmcp>=3.2.4,<4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- fastmcp 3.1.1 → 3.2.4 (CRITICAL: SSRF/path-traversal CVE-2026-32871, command injection, missing OAuth consent verification)
- anthropic 0.86.0 → 0.96.0 (MEDIUM: CVE-2026-34452 TOCTOU race, CVE-2026-34450 insecure default permissions)
- werkzeug 3.1.3 → 3.1.8 (HIGH: CVE-2026-27199 DoS via Windows device names)
- flask 3.1.0 → 3.1.3 (MEDIUM: CVE-2026-27205 info disclosure, CVE-2025-47278)

Transitive: requests 2.32.5 → 2.33.1, cryptography 46.0.5 → 46.0.6 (also pulls in security patches).

Capped mlflow <3.11 to stop tool.uv.prerelease=allow from pulling 3.11.0rc1.

fastmcp 3.2 breaking changes are limited to FastMCPApp tool routing, which this project does not use. The FastMCP/Middleware/ToolResult surface used in databricks-mcp-server is unchanged — verified by importing in a fresh venv.

CI runs only lint, not pytest, so the mcp-server startup and builder-app deploy path need manual smoke verification before merge.

Co-authored-by: Isaac