### PR TITLE
Feat/dashboards 12col grid

### DIFF
--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -44,14 +44,14 @@ Core widget types for AI/BI dashboards. For advanced visualizations (area, scatt
     "name": "title",
     "multilineTextboxSpec": {"lines": ["## Dashboard Title"]}
   },
-  "position": {"x": 0, "y": 0, "width": 6, "height": 1}
+  "position": {"x": 0, "y": 0, "width": 12, "height": 1}
 },
 {
   "widget": {
     "name": "subtitle",
     "multilineTextboxSpec": {"lines": ["Description text here"]}
   },
-  "position": {"x": 0, "y": 1, "width": 6, "height": 1}
+  "position": {"x": 0, "y": 1, "width": 12, "height": 1}
 }
 
 // WRONG: Multiple lines concatenate into one line!
@@ -62,7 +62,7 @@ Core widget types for AI/BI dashboards. For advanced visualizations (area, scatt
       "lines": ["## Dashboard Title", "Description text here"]  // Becomes "## Dashboard TitleDescription text here"
     }
   },
-  "position": {"x": 0, "y": 0, "width": 6, "height": 2}
+  "position": {"x": 0, "y": 0, "width": 12, "height": 2}
 }
 ```
 
@@ -117,7 +117,7 @@ Format types: `number`, `number-currency`, `number-percent`
       "frame": {"showTitle": true, "title": "Total Revenue"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 2, "height": 3}
+  "position": {"x": 0, "y": 0, "width": 4, "height": 3}
 }
 ```
 
@@ -147,7 +147,7 @@ Format types: `number`, `number-currency`, `number-percent`
       "frame": {"showTitle": true, "title": "Total Spend"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 2, "height": 3}
+  "position": {"x": 0, "y": 0, "width": 4, "height": 3}
 }
 ```
 
@@ -188,7 +188,7 @@ Format types: `number`, `number-currency`, `number-percent`
       "frame": {"showTitle": true, "title": "Details"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 6, "height": 6}
+  "position": {"x": 0, "y": 0, "width": 12, "height": 6}
 }
 ```
 

--- a/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
@@ -96,7 +96,7 @@ Combines bar and line visualizations on the same chart - useful for showing rela
       "frame": {"title": "Revenue & Growth Rate", "showTitle": true}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 6, "height": 5}
+  "position": {"x": 0, "y": 0, "width": 12, "height": 5}
 }
 ```
 

--- a/databricks-skills/databricks-aibi-dashboards/3-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-examples.md
@@ -48,6 +48,7 @@ dashboard = {
         "name": "overview",
         "displayName": "NYC Taxi Overview",
         "pageType": "PAGE_TYPE_CANVAS",
+        "layoutVersion": "GRID_V1",
         "layout": [
             # Text header - NO spec block! Use SEPARATE widgets for title and subtitle!
             {
@@ -229,6 +230,7 @@ dashboard_with_filters = {
             "name": "overview",
             "displayName": "Sales Overview",
             "pageType": "PAGE_TYPE_CANVAS",
+            "layoutVersion": "GRID_V1",
             "layout": [
                 {
                     "widget": {
@@ -258,6 +260,7 @@ dashboard_with_filters = {
             "name": "filters",
             "displayName": "Filters",
             "pageType": "PAGE_TYPE_GLOBAL_FILTERS",  # Required for global filter page!
+            "layoutVersion": "GRID_V1",
             "layout": [
                 {
                     "widget": {

--- a/databricks-skills/databricks-aibi-dashboards/3-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-examples.md
@@ -57,7 +57,7 @@ dashboard = {
                         "lines": ["## NYC Taxi Dashboard"]
                     }
                 },
-                "position": {"x": 0, "y": 0, "width": 6, "height": 1}
+                "position": {"x": 0, "y": 0, "width": 12, "height": 1}
             },
             {
                 "widget": {
@@ -66,9 +66,9 @@ dashboard = {
                         "lines": ["Trip statistics and analysis"]
                     }
                 },
-                "position": {"x": 0, "y": 1, "width": 6, "height": 1}
+                "position": {"x": 0, "y": 1, "width": 12, "height": 1}
             },
-            # Counter - version 2, width 2!
+            # Counter - version 2, width 4!
             {
                 "widget": {
                     "name": "total-trips",
@@ -89,7 +89,7 @@ dashboard = {
                         "frame": {"title": "Total Trips", "showTitle": True}
                     }
                 },
-                "position": {"x": 0, "y": 2, "width": 2, "height": 3}
+                "position": {"x": 0, "y": 2, "width": 4, "height": 3}
             },
             {
                 "widget": {
@@ -111,7 +111,7 @@ dashboard = {
                         "frame": {"title": "Average Fare", "showTitle": True}
                     }
                 },
-                "position": {"x": 2, "y": 2, "width": 2, "height": 3}
+                "position": {"x": 4, "y": 2, "width": 4, "height": 3}
             },
             {
                 "widget": {
@@ -133,7 +133,7 @@ dashboard = {
                         "frame": {"title": "Average Distance", "showTitle": True}
                     }
                 },
-                "position": {"x": 4, "y": 2, "width": 2, "height": 3}
+                "position": {"x": 8, "y": 2, "width": 4, "height": 3}
             },
             # Bar chart - version 3
             {
@@ -160,7 +160,7 @@ dashboard = {
                         "frame": {"title": "Trips by Pickup ZIP", "showTitle": True}
                     }
                 },
-                "position": {"x": 0, "y": 5, "width": 6, "height": 5}
+                "position": {"x": 0, "y": 5, "width": 12, "height": 5}
             },
             # Table - version 2, minimal column props!
             {
@@ -189,7 +189,7 @@ dashboard = {
                         "frame": {"title": "Top ZIP Codes", "showTitle": True}
                     }
                 },
-                "position": {"x": 0, "y": 10, "width": 6, "height": 5}
+                "position": {"x": 0, "y": 10, "width": 12, "height": 5}
             }
         ]
     }]
@@ -250,7 +250,7 @@ dashboard_with_filters = {
                             "frame": {"title": "Total Revenue", "showTitle": True}
                         }
                     },
-                    "position": {"x": 0, "y": 0, "width": 6, "height": 3}
+                    "position": {"x": 0, "y": 0, "width": 12, "height": 3}
                 }
             ]
         },
@@ -286,7 +286,7 @@ dashboard_with_filters = {
                             "frame": {"showTitle": True, "title": "Region"}  # Always show title!
                         }
                     },
-                    "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+                    "position": {"x": 0, "y": 0, "width": 4, "height": 2}
                 }
             ]
         }

--- a/databricks-skills/databricks-aibi-dashboards/3-filters.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-filters.md
@@ -75,6 +75,7 @@ Place on a dedicated filter page:
   "name": "filters",
   "displayName": "Filters",
   "pageType": "PAGE_TYPE_GLOBAL_FILTERS",
+  "layoutVersion": "GRID_V1",
   "layout": [
     {
       "widget": {
@@ -117,6 +118,7 @@ Place filter widget directly on a `PAGE_TYPE_CANVAS` page (same widget structure
   "name": "platform_breakdown",
   "displayName": "Platform Breakdown",
   "pageType": "PAGE_TYPE_CANVAS",
+  "layoutVersion": "GRID_V1",
   "layout": [
     {"widget": {...}, "position": {...}},
     {

--- a/databricks-skills/databricks-aibi-dashboards/3-filters.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-filters.md
@@ -60,7 +60,7 @@
       "frame": {"showTitle": true, "title": "Region"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+  "position": {"x": 0, "y": 0, "width": 4, "height": 2}
 }
 ```
 
@@ -100,7 +100,7 @@ Place on a dedicated filter page:
           "frame": {"showTitle": true, "title": "Campaign"}
         }
       },
-      "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+      "position": {"x": 0, "y": 0, "width": 4, "height": 2}
     }
   ]
 }
@@ -130,7 +130,7 @@ Place filter widget directly on a `PAGE_TYPE_CANVAS` page (same widget structure
           "frame": {"showTitle": true, "title": "Platform"}
         }
       },
-      "position": {"x": 4, "y": 0, "width": 2, "height": 2}
+      "position": {"x": 8, "y": 0, "width": 4, "height": 2}
     }
   ]
 }
@@ -181,7 +181,7 @@ Place filter widget directly on a `PAGE_TYPE_CANVAS` page (same widget structure
       "frame": {"showTitle": true, "title": "Date Range"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+  "position": {"x": 0, "y": 0, "width": 4, "height": 2}
 }
 ```
 
@@ -225,7 +225,7 @@ When a filter should affect multiple datasets (e.g., "Region" filter for both sa
       "frame": {"showTitle": true, "title": "Region"}
     }
   },
-  "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+  "position": {"x": 0, "y": 0, "width": 4, "height": 2}
 }
 ```
 
@@ -237,4 +237,4 @@ Each `queryName` in `encodings.fields` binds the filter to that specific dataset
 
 - Global filters: Position on dedicated filter page, stack vertically at `x=0`
 - Page-level filters: Position in header area of page (e.g., top-right corner)
-- Typical sizing: `width: 2, height: 2`
+- Typical sizing: `width: 4, height: 2`

--- a/databricks-skills/databricks-aibi-dashboards/4-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/4-examples.md
@@ -34,14 +34,14 @@ Each filter query binds the filter to one dataset. Add multiple queries to filte
 ]
 ```
 
-### 5. Layout Grid (6 columns)
+### 5. Layout Grid (12 columns)
 ```
-y=0:  Header with title + description (w=6, h=2)
-y=2:  KPI(w=2,h=3) | KPI(w=2,h=3) | KPI(w=2,h=3)  ← fills 6
-y=5:  Section header (w=6, h=1)
-y=6:  Area chart (w=6, h=5)
-y=11: Section header (w=6, h=1)
-y=12: Pie(w=2,h=5) | Bar chart(w=4,h=5)           ← fills 6
+y=0:  Header with title + description (w=12, h=2)
+y=2:  KPI(w=4,h=3) | KPI(w=4,h=3) | KPI(w=4,h=3)  ← fills 12
+y=5:  Section header (w=12, h=1)
+y=6:  Area chart (w=12, h=5)
+y=11: Section header (w=12, h=1)
+y=12: Pie(w=4,h=5) | Bar chart(w=8,h=5)           ← fills 12
 ```
 
 Use `\n\n` in text widget lines array to create line breaks within a single widget.
@@ -93,7 +93,7 @@ This example shows a complete dashboard with:
               "lines": ["# Sales Dashboard\n\nMonitor daily sales, revenue, and profit margins across regions and departments."]
             }
           },
-          "position": {"x": 0, "y": 0, "width": 6, "height": 2}
+          "position": {"x": 0, "y": 0, "width": 12, "height": 2}
         },
         {
           "widget": {
@@ -124,7 +124,7 @@ This example shows a complete dashboard with:
               "frame": {"title": "Total Revenue", "showTitle": true, "description": "For the selected period", "showDescription": true}
             }
           },
-          "position": {"x": 0, "y": 2, "width": 2, "height": 3}
+          "position": {"x": 0, "y": 2, "width": 4, "height": 3}
         },
         {
           "widget": {
@@ -154,7 +154,7 @@ This example shows a complete dashboard with:
               "frame": {"title": "Total Orders", "showTitle": true, "description": "For the selected period", "showDescription": true}
             }
           },
-          "position": {"x": 2, "y": 2, "width": 2, "height": 3}
+          "position": {"x": 4, "y": 2, "width": 4, "height": 3}
         },
         {
           "widget": {
@@ -183,7 +183,7 @@ This example shows a complete dashboard with:
               "frame": {"title": "Profit Margin", "showTitle": true, "description": "Average for period", "showDescription": true}
             }
           },
-          "position": {"x": 4, "y": 2, "width": 2, "height": 3}
+          "position": {"x": 8, "y": 2, "width": 4, "height": 3}
         },
         {
           "widget": {
@@ -192,7 +192,7 @@ This example shows a complete dashboard with:
               "lines": ["## Revenue Trend"]
             }
           },
-          "position": {"x": 0, "y": 5, "width": 6, "height": 1}
+          "position": {"x": 0, "y": 5, "width": 12, "height": 1}
         },
         {
           "widget": {
@@ -237,7 +237,7 @@ This example shows a complete dashboard with:
               }
             }
           },
-          "position": {"x": 0, "y": 6, "width": 6, "height": 5}
+          "position": {"x": 0, "y": 6, "width": 12, "height": 5}
         },
         {
           "widget": {
@@ -246,7 +246,7 @@ This example shows a complete dashboard with:
               "lines": ["## Breakdown"]
             }
           },
-          "position": {"x": 0, "y": 11, "width": 6, "height": 1}
+          "position": {"x": 0, "y": 11, "width": 12, "height": 1}
         },
         {
           "widget": {
@@ -281,7 +281,7 @@ This example shows a complete dashboard with:
               "frame": {"title": "Revenue by Department", "showTitle": true}
             }
           },
-          "position": {"x": 0, "y": 12, "width": 2, "height": 5}
+          "position": {"x": 0, "y": 12, "width": 4, "height": 5}
         },
         {
           "widget": {
@@ -328,7 +328,7 @@ This example shows a complete dashboard with:
               "frame": {"title": "Revenue by Region", "showTitle": true}
             }
           },
-          "position": {"x": 2, "y": 12, "width": 4, "height": 5}
+          "position": {"x": 4, "y": 12, "width": 8, "height": 5}
         },
         {
           "widget": {
@@ -337,7 +337,7 @@ This example shows a complete dashboard with:
               "lines": ["## Top Products"]
             }
           },
-          "position": {"x": 0, "y": 17, "width": 6, "height": 1}
+          "position": {"x": 0, "y": 17, "width": 12, "height": 1}
         },
         {
           "widget": {
@@ -375,7 +375,7 @@ This example shows a complete dashboard with:
               }
             }
           },
-          "position": {"x": 0, "y": 18, "width": 6, "height": 6}
+          "position": {"x": 0, "y": 18, "width": 12, "height": 6}
         }
       ]
     },
@@ -417,7 +417,7 @@ This example shows a complete dashboard with:
               "frame": {"showTitle": true, "title": "Date Range"}
             }
           },
-          "position": {"x": 0, "y": 0, "width": 2, "height": 2}
+          "position": {"x": 0, "y": 0, "width": 4, "height": 2}
         },
         {
           "widget": {
@@ -452,7 +452,7 @@ This example shows a complete dashboard with:
               "frame": {"showTitle": true, "title": "Region"}
             }
           },
-          "position": {"x": 2, "y": 0, "width": 2, "height": 2}
+          "position": {"x": 4, "y": 0, "width": 4, "height": 2}
         },
         {
           "widget": {
@@ -487,7 +487,7 @@ This example shows a complete dashboard with:
               "frame": {"showTitle": true, "title": "Department"}
             }
           },
-          "position": {"x": 4, "y": 0, "width": 2, "height": 2}
+          "position": {"x": 8, "y": 0, "width": 4, "height": 2}
         }
       ]
     }

--- a/databricks-skills/databricks-aibi-dashboards/4-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/4-examples.md
@@ -85,6 +85,7 @@ This example shows a complete dashboard with:
       "name": "sales_overview",
       "displayName": "Sales Overview",
       "pageType": "PAGE_TYPE_CANVAS",
+      "layoutVersion": "GRID_V1",
       "layout": [
         {
           "widget": {
@@ -383,6 +384,7 @@ This example shows a complete dashboard with:
       "name": "global_filters",
       "displayName": "Filters",
       "pageType": "PAGE_TYPE_GLOBAL_FILTERS",
+      "layoutVersion": "GRID_V1",
       "layout": [
         {
           "widget": {

--- a/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
+++ b/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
@@ -63,7 +63,7 @@ These errors occur when the JSON structure is wrong:
 
 ## Layout has gaps
 
-- Ensure each row sums to width=6
+- Ensure each row sums to width=12
 - Check that y positions don't skip values
 
 ## Filter shows "Invalid widget definition"

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -149,6 +149,18 @@ If you need conditional logic or multi-field formulas, compute a derived column 
 
 ### 4) LAYOUT (12-Column Grid, NO GAPS)
 
+**Every page must include `"layoutVersion": "GRID_V1"`** alongside `pageType`.
+
+```json
+{
+  "name": "overview",
+  "displayName": "Overview",
+  "pageType": "PAGE_TYPE_CANVAS",
+  "layoutVersion": "GRID_V1",
+  "layout": [...]
+}
+```
+
 Each widget has a position: `{"x": 0, "y": 0, "width": 4, "height": 4}`
 
 **CRITICAL**: Each row must fill width=12 exactly. No gaps allowed.
@@ -194,15 +206,16 @@ y=12: Table (w=12, h=6) - Detailed data
 
 Before deploying, verify:
 1. All widget names use only alphanumeric + hyphens + underscores
-2. All rows sum to width=12 with no gaps
-3. KPIs use height 3-4, charts use height 5-6
-4. Chart dimensions have ≤8 distinct values
-5. All widget fieldNames match dataset columns exactly
-6. **Field `name` in query.fields matches `fieldName` in encodings exactly** (e.g., both `"sum(spend)"`)
-7. Counter datasets: use `disaggregated: true` for 1-row datasets, `disaggregated: false` with aggregation for multi-row
-8. Percent values are 0-1 (not 0-100)
-9. SQL uses Spark syntax (date_sub, not INTERVAL)
-10. **All SQL queries tested via `execute_sql` and return expected data**
+2. **Every page has `"layoutVersion": "GRID_V1"`**
+3. All rows sum to width=12 with no gaps
+4. KPIs use height 3-4, charts use height 5-6
+5. Chart dimensions have ≤8 distinct values
+6. All widget fieldNames match dataset columns exactly
+7. **Field `name` in query.fields matches `fieldName` in encodings exactly** (e.g., both `"sum(spend)"`)
+8. Counter datasets: use `disaggregated: true` for 1-row datasets, `disaggregated: false` with aggregation for multi-row
+9. Percent values are 0-1 (not 0-100)
+10. SQL uses Spark syntax (date_sub, not INTERVAL)
+11. **All SQL queries tested via `execute_sql` and return expected data**
 
 ---
 

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -147,32 +147,32 @@ If you need conditional logic or multi-field formulas, compute a derived column 
 - Date truncation: `DATE_TRUNC('DAY'|'WEEK'|'MONTH'|'QUARTER'|'YEAR', column)`
 - **AVOID** `INTERVAL` syntax - use functions instead
 
-### 4) LAYOUT (6-Column Grid, NO GAPS)
+### 4) LAYOUT (12-Column Grid, NO GAPS)
 
-Each widget has a position: `{"x": 0, "y": 0, "width": 2, "height": 4}`
+Each widget has a position: `{"x": 0, "y": 0, "width": 4, "height": 4}`
 
-**CRITICAL**: Each row must fill width=6 exactly. No gaps allowed.
+**CRITICAL**: Each row must fill width=12 exactly. No gaps allowed.
 
 **Recommended widget sizes:**
 
 | Widget Type | Width | Height | Notes |
 |-------------|-------|--------|-------|
-| Text header | 6 | 1 | Full width; use SEPARATE widgets for title and subtitle |
-| Counter/KPI | 2 | **3-4** | **NEVER height=2** - too cramped! |
-| Line/Bar chart | 3 | **5-6** | Pair side-by-side to fill row |
-| Pie chart | 3 | **5-6** | Needs space for legend |
-| Full-width chart | 6 | 5-7 | For detailed time series |
-| Table | 6 | 5-8 | Full width for readability |
+| Text header | 12 | 1 | Full width; use SEPARATE widgets for title and subtitle |
+| Counter/KPI | 4 | **3-4** | **NEVER height=2** - too cramped! |
+| Line/Bar chart | 6 | **5-6** | Pair side-by-side to fill row |
+| Pie chart | 6 | **5-6** | Needs space for legend |
+| Full-width chart | 12 | 5-7 | For detailed time series |
+| Table | 12 | 5-8 | Full width for readability |
 
 **Standard dashboard structure:**
 ```text
-y=0:  Title (w=6, h=1) - Dashboard title (use separate widget!)
-y=1:  Subtitle (w=6, h=1) - Description (use separate widget!)
-y=2:  KPIs (w=2 each, h=3) - 3 key metrics side-by-side
-y=5:  Section header (w=6, h=1) - "Trends" or similar
-y=6:  Charts (w=3 each, h=5) - Two charts side-by-side
-y=11: Section header (w=6, h=1) - "Details"
-y=12: Table (w=6, h=6) - Detailed data
+y=0:  Title (w=12, h=1) - Dashboard title (use separate widget!)
+y=1:  Subtitle (w=12, h=1) - Description (use separate widget!)
+y=2:  KPIs (w=4 each, h=3) - 3 key metrics side-by-side
+y=5:  Section header (w=12, h=1) - "Trends" or similar
+y=6:  Charts (w=6 each, h=5) - Two charts side-by-side
+y=11: Section header (w=12, h=1) - "Details"
+y=12: Table (w=12, h=6) - Detailed data
 ```
 
 ### 5) CARDINALITY & READABILITY (CRITICAL)
@@ -194,7 +194,7 @@ y=12: Table (w=6, h=6) - Detailed data
 
 Before deploying, verify:
 1. All widget names use only alphanumeric + hyphens + underscores
-2. All rows sum to width=6 with no gaps
+2. All rows sum to width=12 with no gaps
 3. KPIs use height 3-4, charts use height 5-6
 4. Chart dimensions have ≤8 distinct values
 5. All widget fieldNames match dataset columns exactly


### PR DESCRIPTION
## Summary

- **Updates the AI/BI Dashboards skill from a 6-column to a 12-column grid.** Lakeview moved to a higher-density 12-column canvas in [February 2026](https://www.databricks.com/blog/whats-new-aibi-february-2026-roundup). Verified against UI-fresh dashboards in `e2-field-eng-demo` (they emit `max(x+w)=12` per row). Following the skill verbatim today produces tiles at half their intended width.
- **Adds `"layoutVersion": "GRID_V1"` as a required field on every page.** Without it, dashboards still render but interactive editing in the canvas breaks (the drag/resize cursor doesn't track the actual tile position). Verified in isolation: same 12-col JSON without `layoutVersion` → broken; with it → works.
- **Scales every example position block.** Width and x doubled (full 6→12, half 3→6, third 2→4); y and height unchanged. 7 page examples updated across `3-examples.md`, `4-examples.md`, `3-filters.md`.

### Context

Surfaced while debugging a demo over the weekend. Dashboard widgets were rendering at half size and the canvas editor cursor was offset. Both root causes confirmed by inspecting UI-fresh and existing production dashboards in the workspace.

## Test plan

- [x] Audited every `position` block. All 36 row sums verified to total 12.
- [x] Deployed the post-edit NYC Taxi example from `3-examples.md` verbatim against `e2-field-eng-demo`. Rendered correctly with no cursor offset.
- [x] Ran isolation tests confirming `layoutVersion: GRID_V1` is the field that fixes the cursor bug.