### PR TITLE
Fix --experimental flag to actually install experimental-branch skills

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -36,8 +36,10 @@ $Owner = "databricks-solutions"
 $Repo  = "ai-dev-kit"
 
 # Determine branch/tag to use
+$script:BranchExplicit = $false
 if ($env:AIDEVKIT_BRANCH) {
     $Branch = $env:AIDEVKIT_BRANCH
+    $script:BranchExplicit = $true
 } else {
     try {
         $latestReleaseUri = "https://api.github.com/repos/$Owner/$Repo/releases/latest"
@@ -49,7 +51,7 @@ if ($env:AIDEVKIT_BRANCH) {
 }
 
 $RepoUrl   = "https://github.com/$Owner/$Repo.git"
-$RawUrl    = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"
+# $RawUrl is set after argument parsing so --branch / --experimental can affect it
 $InstallDir = if ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $env:USERPROFILE ".ai-dev-kit" }
 $RepoDir   = Join-Path $InstallDir "repo"
 $VenvDir   = Join-Path $InstallDir ".venv"
@@ -222,6 +224,7 @@ while ($i -lt $args.Count) {
         { $_ -in "--skills", "-Skills" }       { $script:UserSkills = $args[$i + 1]; $i += 2 }
         { $_ -in "--list-skills", "-ListSkills" } { $script:ListSkills = $true; $i++ }
         { $_ -in "--experimental", "-Experimental" } { $script:Channel = "experimental"; $i++ }
+        { $_ -in "-b", "--branch", "-Branch" }  { $Branch = $args[$i + 1]; $script:BranchExplicit = $true; $i += 2 }
         { $_ -in "-f", "--force", "-Force" }   { $script:Force = $true; $i++ }
         { $_ -in "-h", "--help", "-Help" } {
             Write-Host "Databricks AI Dev Kit Installer (Windows)"
@@ -242,6 +245,7 @@ while ($i -lt $args.Count) {
             Write-Host "  --skills LIST         Comma-separated skill names to install (overrides profile)"
             Write-Host "  --list-skills         List available skills and profiles, then exit"
             Write-Host "  --experimental        Install from experimental branch (early access features)"
+            Write-Host "  -b, --branch NAME     Git branch/tag to install (default: latest release)"
             Write-Host "  -f, --force           Force reinstall"
             Write-Host "  -h, --help            Show this help"
             Write-Host ""
@@ -265,6 +269,15 @@ while ($i -lt $args.Count) {
         default { Write-Err "Unknown option: $($args[$i]) (use -h for help)"; $i++ }
     }
 }
+
+# If experimental channel is selected and branch wasn't explicitly overridden,
+# install skills from the experimental branch instead of the latest release.
+if ($script:Channel -eq "experimental" -and -not $script:BranchExplicit) {
+    $Branch = "experimental"
+}
+
+# Set raw URL after branch resolution
+$RawUrl = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"
 
 # ─── Interactive helpers ──────────────────────────────────────
 
@@ -1982,6 +1995,7 @@ function Invoke-PromptChannel {
         if ($script:Profile_ -ne "DEFAULT") { $newArgs += "--profile"; $newArgs += $script:Profile_ }
         if ($script:InstallMcp)          { $newArgs += "--mcp" }
         if (-not $script:InstallSkills)  { $newArgs += "--mcp-only" }
+        if ($script:BranchExplicit)      { $newArgs += "--branch"; $newArgs += $Branch }
 
         # Download experimental installer to a temp file and execute
         $expUrl = "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.ps1"

--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,10 @@ CHANNEL="${DEVKIT_CHANNEL:-stable}"  # stable or experimental
 OWNER="databricks-solutions"
 REPO="ai-dev-kit"
 
+BRANCH_EXPLICIT=false
 if [ -n "${DEVKIT_BRANCH:-}" ]; then
   BRANCH="$DEVKIT_BRANCH"
+  BRANCH_EXPLICIT=true
 else
   BRANCH="$(
     curl -s "https://api.github.com/repos/${OWNER}/${REPO}/releases/latest" \
@@ -136,7 +138,7 @@ while [ $# -gt 0 ]; do
     case $1 in
         -p|--profile)     PROFILE="$2"; shift 2 ;;
         -g|--global)      SCOPE="global"; SCOPE_EXPLICIT=true; shift ;;
-        -b|--branch)      BRANCH="$2"; shift 2 ;;
+        -b|--branch)      BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
         --skills-only)    INSTALL_MCP=false; shift ;;
         --mcp-only)       INSTALL_SKILLS=false; shift ;;
         --mcp-path)       USER_MCP_PATH="$2"; MCP_INSTALL_PATH="$2"; INSTALL_MCP=true; shift 2 ;;
@@ -257,6 +259,12 @@ if [ "${LIST_SKILLS:-false}" = true ]; then
     echo -e "${D}       bash install.sh --skills databricks-jobs,databricks-dbsql${N}"
     echo ""
     exit 0
+fi
+
+# If experimental channel is selected and branch wasn't explicitly overridden,
+# install skills from the experimental branch instead of the latest release.
+if [ "$CHANNEL" = "experimental" ] && [ "$BRANCH_EXPLICIT" != true ]; then
+    BRANCH="experimental"
 fi
 
 # Set configuration URLs after parsing branch argument
@@ -1966,6 +1974,7 @@ prompt_channel() {
         [ "$PROFILE" != "DEFAULT" ] && args="$args --profile $PROFILE"
         [ "$INSTALL_MCP" = false ] && args="$args --skills-only"
         [ "$INSTALL_SKILLS" = false ] && args="$args --mcp-only"
+        [ "$BRANCH_EXPLICIT" = true ] && args="$args --branch $BRANCH"
 
         # Download and execute the experimental installer
         exec bash <(curl -fsSL "https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/experimental/install.sh") $args


### PR DESCRIPTION
## Summary

The `--experimental` flag previously only changed the channel display/banner — it did **not** affect which branch the repo (and thus skills) were cloned from. The skills installer copies Databricks skills from a local clone of the ai-dev-kit repo, and `$Branch` / `$BRANCH` defaulted to the latest release tag, not `experimental`. As a result, things like `databricks-dbsql` were coming from the latest stable release and still contained references to the (now-deprecated) MCP tools.

This PR fixes both `install.sh` and `install.ps1` so that `--experimental` actually pulls skills from the experimental branch:

- When `$Channel == "experimental"` and the branch wasn't explicitly set (via `-b/--branch` flag or `DEVKIT_BRANCH`/`AIDEVKIT_BRANCH` env var), default `$Branch` to `experimental`.
- Track `BRANCH_EXPLICIT` / `$script:BranchExplicit` so explicit overrides always win.
- Preserve `--branch` across the channel-prompt re-exec.

Also:
- Adds the missing `-b/--branch` flag to `install.ps1` (only `install.sh` had it).
- Moves `$RawUrl` construction in `install.ps1` to after argument parsing so the override takes effect.

## Behavior matrix

| Invocation | Resulting branch |
|---|---|
| `install.ps1` (no flags) | latest release tag |
| `install.ps1 --experimental` | `experimental` |
| `install.ps1 --branch foo` | `foo` |
| `install.ps1 --experimental --branch foo` | `foo` (explicit wins) |
| `$env:AIDEVKIT_BRANCH=foo; install.ps1 --experimental` | `foo` (env wins) |
| Run from main, pick "Experimental" interactively | re-execs to experimental's installer, which then resolves to `experimental` |

## Test plan

- [ ] `bash install.sh --experimental` clones experimental branch, skills come from experimental
- [ ] `bash install.sh --experimental --branch some-feature` uses `some-feature` (explicit override wins)
- [ ] `pwsh install.ps1 --experimental` clones experimental branch on Windows
- [ ] `pwsh install.ps1 --branch some-feature` uses the new `--branch` flag
- [ ] Interactive: run from main, pick "Experimental" in radio prompt → re-execed installer correctly clones experimental
- [ ] `$env:AIDEVKIT_BRANCH=foo; pwsh install.ps1 --experimental` honors the env var (no override)
- [ ] No infinite loop: passing `--experimental` to an already-experimental install.ps1 returns from `Invoke-PromptChannel` early