### PR TITLE
Auto-force refresh and isolate experimental repo dir

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -69,6 +69,7 @@ $script:ScopeExplicit = $false  # Track if --global was explicitly passed
 $script:InstallMcp   = $false
 $script:InstallSkills = $true
 $script:Force        = $false
+$script:ForceExplicit = $false
 $script:Silent       = $false
 $script:UserTools    = ""
 $script:Tools        = ""
@@ -225,7 +226,7 @@ while ($i -lt $args.Count) {
         { $_ -in "--list-skills", "-ListSkills" } { $script:ListSkills = $true; $i++ }
         { $_ -in "--experimental", "-Experimental" } { $script:Channel = "experimental"; $i++ }
         { $_ -in "-b", "--branch", "-Branch" }  { $Branch = $args[$i + 1]; $script:BranchExplicit = $true; $i += 2 }
-        { $_ -in "-f", "--force", "-Force" }   { $script:Force = $true; $i++ }
+        { $_ -in "-f", "--force", "-Force" }   { $script:Force = $true; $script:ForceExplicit = $true; $i++ }
         { $_ -in "-h", "--help", "-Help" } {
             Write-Host "Databricks AI Dev Kit Installer (Windows)"
             Write-Host ""
@@ -276,8 +277,20 @@ if ($script:Channel -eq "experimental" -and -not $script:BranchExplicit) {
     $Branch = "experimental"
 }
 
+# Experimental installs default to Force=true (always refresh the cached repo)
+# unless the user explicitly passed --force.
+if ($script:Channel -eq "experimental" -and -not $script:ForceExplicit) {
+    $script:Force = $true
+}
+
 # Set raw URL after branch resolution
 $RawUrl = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"
+
+# Keep stable and experimental clones in separate directories so they don't clobber each other
+if ($script:Channel -eq "experimental") {
+    $RepoDir  = Join-Path $InstallDir "experimental-repo"
+    $McpEntry = Join-Path $RepoDir "databricks-mcp-server\run_server.py"
+}
 
 # ─── Interactive helpers ──────────────────────────────────────
 
@@ -702,7 +715,8 @@ function Invoke-PromptMcpPath {
     }
 
     # Update derived paths
-    $script:RepoDir    = Join-Path $script:InstallDir "repo"
+    $repoSubdir = if ($script:Channel -eq "experimental") { "experimental-repo" } else { "repo" }
+    $script:RepoDir    = Join-Path $script:InstallDir $repoSubdir
     $script:VenvDir    = Join-Path $script:InstallDir ".venv"
     $script:VenvPython = Join-Path $script:VenvDir "Scripts\python.exe"
     $script:McpEntry   = Join-Path $script:RepoDir "databricks-mcp-server\run_server.py"
@@ -2121,7 +2135,21 @@ function Invoke-Main {
     # Setup MCP server
     if ($script:InstallMcp) {
         Install-McpServer
-    } elseif (-not (Test-Path $script:RepoDir)) {
+    } elseif (Test-Path (Join-Path $script:RepoDir ".git")) {
+        # Repo already exists — refresh it when Force is true, otherwise leave as-is
+        if ($script:Force) {
+            Write-Step "Refreshing sources"
+            $prevEAP = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+            & git -C $script:RepoDir fetch -q --depth 1 origin $Branch 2>&1 | Out-Null
+            & git -C $script:RepoDir reset --hard FETCH_HEAD 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item -Recurse -Force $script:RepoDir -ErrorAction SilentlyContinue
+                & git -c advice.detachedHead=false clone -q --depth 1 --branch $Branch $RepoUrl $script:RepoDir 2>&1 | Out-Null
+            }
+            $ErrorActionPreference = $prevEAP
+            Write-Ok "Repository refreshed ($Branch)"
+        }
+    } else {
         Write-Step "Downloading sources"
         if (-not (Test-Path $script:InstallDir)) {
             New-Item -ItemType Directory -Path $script:InstallDir -Force | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,8 @@ PROFILE="${DEVKIT_PROFILE:-DEFAULT}"
 SCOPE="${DEVKIT_SCOPE:-project}"
 SCOPE_EXPLICIT=false  # Track if --global was explicitly passed
 FORCE="${DEVKIT_FORCE:-false}"
+FORCE_EXPLICIT=false
+[ -n "${DEVKIT_FORCE:-}" ] && FORCE_EXPLICIT=true
 IS_UPDATE=false
 SILENT="${DEVKIT_SILENT:-false}"
 TOOLS="${DEVKIT_TOOLS:-}"
@@ -149,7 +151,7 @@ while [ $# -gt 0 ]; do
         --mcp)            INSTALL_MCP=true; shift ;;
         --tools)          USER_TOOLS="$2"; shift 2 ;;
         --experimental)   CHANNEL="experimental"; shift ;;
-        -f|--force)       FORCE=true; shift ;;
+        -f|--force)       FORCE=true; FORCE_EXPLICIT=true; shift ;;
         -h|--help)        
             echo "Databricks AI Dev Kit Installer"
             echo ""
@@ -267,11 +269,22 @@ if [ "$CHANNEL" = "experimental" ] && [ "$BRANCH_EXPLICIT" != true ]; then
     BRANCH="experimental"
 fi
 
+# Experimental installs default to FORCE=true (always refresh the cached repo)
+# unless the user explicitly set DEVKIT_FORCE or passed --force.
+if [ "$CHANNEL" = "experimental" ] && [ "$FORCE_EXPLICIT" != true ]; then
+    FORCE=true
+fi
+
 # Set configuration URLs after parsing branch argument
 REPO_URL="https://github.com/databricks-solutions/ai-dev-kit.git"
 RAW_URL="https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/${BRANCH}"
 INSTALL_DIR="${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}"
-REPO_DIR="$INSTALL_DIR/repo"
+# Keep stable and experimental clones in separate directories so they don't clobber each other
+if [ "$CHANNEL" = "experimental" ]; then
+    REPO_DIR="$INSTALL_DIR/experimental-repo"
+else
+    REPO_DIR="$INSTALL_DIR/repo"
+fi
 VENV_DIR="$INSTALL_DIR/.venv"
 VENV_PYTHON="$VENV_DIR/bin/python"
 MCP_ENTRY="$REPO_DIR/databricks-mcp-server/run_server.py"
@@ -861,7 +874,11 @@ prompt_mcp_path() {
     fi
 
     # Update derived paths
-    REPO_DIR="$INSTALL_DIR/repo"
+    if [ "$CHANNEL" = "experimental" ]; then
+        REPO_DIR="$INSTALL_DIR/experimental-repo"
+    else
+        REPO_DIR="$INSTALL_DIR/repo"
+    fi
     VENV_DIR="$INSTALL_DIR/.venv"
     VENV_PYTHON="$VENV_DIR/bin/python"
     MCP_ENTRY="$REPO_DIR/databricks-mcp-server/run_server.py"
@@ -2164,7 +2181,18 @@ main() {
     # Setup MCP server
     if [ "$INSTALL_MCP" = true ]; then
         setup_mcp
-    elif [ ! -d "$REPO_DIR" ]; then
+    elif [ -d "$REPO_DIR/.git" ]; then
+        # Repo already exists — refresh it when FORCE is true, otherwise leave as-is
+        if [ "$FORCE" = true ]; then
+            step "Refreshing sources"
+            git -C "$REPO_DIR" fetch -q --depth 1 origin "$BRANCH" 2>/dev/null || true
+            git -C "$REPO_DIR" reset --hard FETCH_HEAD 2>/dev/null || {
+                rm -rf "$REPO_DIR"
+                git -c advice.detachedHead=false clone -q --depth 1 --branch "$BRANCH" "$REPO_URL" "$REPO_DIR"
+            }
+            ok "Repository refreshed ($BRANCH)"
+        fi
+    else
         step "Downloading sources"
         mkdir -p "$INSTALL_DIR"
         git -c advice.detachedHead=false clone -q --depth 1 --branch "$BRANCH" "$REPO_URL" "$REPO_DIR"


### PR DESCRIPTION
## Summary

Two related changes so experimental installs always pick up the latest skills without clobbering the stable install:

1. **Separate clone directory for experimental** — experimental installs now clone into `~/.ai-dev-kit/experimental-repo` instead of `~/.ai-dev-kit/repo`. Stable and experimental installs no longer fight over the same checkout, so a user can have both side-by-side.

2. **Default `FORCE=true` on experimental installs** — only when the user did not explicitly pass `--force` or set `DEVKIT_FORCE`. Previously, the skills-only code path only cloned when the repo dir was missing, so reruns kept stale skill content. Now when `FORCE=true`, that path also refreshes via `git fetch` + `reset --hard FETCH_HEAD`, falling back to delete + re-clone if reset fails. Stable installs are unchanged.

## Behavior matrix

| Invocation | `REPO_DIR` | `FORCE` |
|---|---|---|
| `install.sh` (stable) | `~/.ai-dev-kit/repo` | `false` |
| `install.sh --experimental` | `~/.ai-dev-kit/experimental-repo` | `true` (auto) |
| `install.sh --force` | `~/.ai-dev-kit/repo` | `true` (explicit) |
| `DEVKIT_FORCE=false install.sh --experimental` | `~/.ai-dev-kit/experimental-repo` | `false` (explicit env wins) |
| `install.ps1 --experimental` (Windows) | `%USERPROFILE%\.ai-dev-kit\experimental-repo` | `true` (auto) |

## Test plan

- [ ] Fresh `install.sh --experimental` clones into `~/.ai-dev-kit/experimental-repo`
- [ ] Rerunning `install.sh --experimental` refreshes the existing `experimental-repo` (not silently using stale content)
- [ ] `install.sh` (stable) still uses `~/.ai-dev-kit/repo` and does not auto-force
- [ ] `DEVKIT_FORCE=false install.sh --experimental` does NOT refresh the cached repo (explicit env wins)
- [ ] `install.ps1 --experimental` clones into `%USERPROFILE%\.ai-dev-kit\experimental-repo`
- [ ] Rerunning `install.ps1 --experimental` refreshes the existing experimental-repo
- [ ] Both paths still clone fresh when the repo dir doesn't exist

This pull request and its description were written by Isaac.