### PR TITLE
Fix async MCP tool execution in Builder App wrapper

### DIFF
--- a/databricks-builder-app/server/services/databricks_tools.py
+++ b/databricks-builder-app/server/services/databricks_tools.py
@@ -9,6 +9,7 @@ execution continues in background and returns an operation ID for polling.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import threading
@@ -289,15 +290,30 @@ def _make_wrapper(name: str, description: str, schema: dict, fn):
                 else:
                     parsed_args[key] = value
 
-            # FastMCP tools are sync - run in thread pool with heartbeat
+            # FastMCP tools may be sync OR async — the mcp-server patches @mcp.tool
+            # to convert sync functions to async (via _wrap_sync_in_thread). If we
+            # just call ctx.run(fn, **args) on an async function we get back a
+            # coroutine object instead of the result. Detect and dispatch.
             print(f'[MCP TOOL] Running {name} in thread pool with heartbeat...', file=sys.stderr, flush=True)
 
             # Copy context to propagate Databricks auth contextvars to the thread
             ctx = copy_context()
 
-            def run_in_context():
-                """Run the tool function within the copied context."""
-                return ctx.run(fn, **parsed_args)
+            if inspect.iscoroutinefunction(fn):
+                def run_in_context():
+                    """Run the async tool function in a fresh event loop inside the thread."""
+                    def runner():
+                        new_loop = asyncio.new_event_loop()
+                        asyncio.set_event_loop(new_loop)
+                        try:
+                            return new_loop.run_until_complete(fn(**parsed_args))
+                        finally:
+                            new_loop.close()
+                    return ctx.run(runner)
+            else:
+                def run_in_context():
+                    """Run the sync tool function within the copied context."""
+                    return ctx.run(fn, **parsed_args)
 
             # Run tool in executor so we can poll for completion with heartbeat
             # Use executor.submit() to get a concurrent.futures.Future (thread-safe)


### PR DESCRIPTION
## Summary

The Builder App's MCP tool wrapper at `databricks-builder-app/server/services/databricks_tools.py:292` assumed all FastMCP tools were sync. But the mcp-server's `_patch_tool_decorator_for_async()` (in `databricks-mcp-server/databricks_mcp_server/server.py`) intercepts `@mcp.tool` registration and converts every sync function to async via `_wrap_sync_in_thread`. After that patch, every tool is async.

The Builder App's wrapper called `ctx.run(fn, **parsed_args)` inside a thread pool. For an async `fn`, that returns the coroutine object instead of awaiting it. The thread completes immediately with the coroutine object as its result. The agent receives the stringified coroutine repr (~50 bytes) as the tool output, doesn't know what to make of it, and either loops or stalls.

## Reproduction

Deploy `databricks-builder-app` from `main` against any workspace. Open a project and ask the agent to do anything that touches an MCP tool — e.g. "What tables are in catalog X?". You'll see in the app logs:

```
[MCP TOOL] execute_sql called with args: {...}
[MCP TOOL] Running execute_sql in thread pool with heartbeat...
[MCP TOOL] execute_sql completed in 0.00s, result length: 50
RuntimeWarning: coroutine 'execute_sql' was never awaited
```

`result length: 50` is the length of `str(<coroutine object execute_sql at 0x...>)`. The agent then has no useful tool output to act on, and downstream behavior is unpredictable.

## Fix

Detect async functions with `inspect.iscoroutinefunction()` and run them inside a fresh event loop inside the thread — same isolation pattern `EVENT_LOOP_FIX.md` already uses for the agent itself. Sync functions follow the original path.

```python
if inspect.iscoroutinefunction(fn):
    def run_in_context():
        def runner():
            new_loop = asyncio.new_event_loop()
            asyncio.set_event_loop(new_loop)
            try:
                return new_loop.run_until_complete(fn(**parsed_args))
            finally:
                new_loop.close()
        return ctx.run(runner)
else:
    def run_in_context():
        return ctx.run(fn, **parsed_args)
```

## Test plan

- [x] Verified the bug on a fresh deploy from `main` against an internal workspace — every MCP tool call returns 50 bytes with the coroutine-not-awaited warning, and the agent stalls.
- [x] Applied the patch and redeployed. MCP tool calls now return real results; the agent completes tasks end-to-end.
- [ ] (Maintainers) CI / unit tests, if applicable for `databricks_tools.py`.

## Related

- Root cause is the mismatch with the `_patch_tool_decorator_for_async` introduced in `databricks-mcp-server/databricks_mcp_server/server.py`.
- Comment on line 292 ("FastMCP tools are sync") is now outdated and is replaced.

This pull request and its description were written by Isaac.