### PR TITLE
fix(skill/databricks-genie): use jq for cross-workspace catalog remap

### DIFF
--- a/databricks-skills/databricks-genie/SKILL.md
+++ b/databricks-skills/databricks-genie/SKILL.md
@@ -169,10 +169,12 @@ Top-level keys are `version`, `config`, `data_sources`, `instructions`. Every it
 
 ## Cross-Workspace Migration
 
-When migrating between workspaces, catalog names often differ. Export the space, remap with `sed`, then import:
+When migrating between workspaces, catalog names often differ. Export the space, remap, then import. Use `jq` to rewrite identifiers — it's portable across macOS/Linux (unlike `sed -i`, whose in-place flag differs between BSD and GNU) and operates on JSON values directly:
 
 ```bash
-sed -i '' 's/source_catalog/target_catalog/g' genie_space.json
+jq --arg src source_catalog --arg dst target_catalog \
+   '(.. | strings) |= gsub($src; $dst)' genie_space.json \
+   > genie_space.tmp && mv genie_space.tmp genie_space.json
 ```
 
 Use `DATABRICKS_CONFIG_PROFILE=profile_name` to target different workspaces.


### PR DESCRIPTION
## Summary

`sed -i ''` in the Cross-Workspace Migration section is BSD/macOS-only — the
empty-string argument that's required by BSD sed is rejected by GNU sed on
Linux. Linux users running the documented snippet hit `sed: -e expression
#1, char 0: no previous regular expression`.

Replace with `jq`, which is portable across macOS and Linux, already used
throughout the skill, and operates on JSON values directly.

## Diff

```diff
-When migrating between workspaces, catalog names often differ. Export the space, remap with `sed`, then import:
+When migrating between workspaces, catalog names often differ. Export the space, remap, then import. Use `jq` to rewrite identifiers — it's portable across macOS/Linux (unlike `sed -i`, whose in-place flag differs between BSD and GNU) and operates on JSON values directly:

-sed -i '' 's/source_catalog/target_catalog/g' genie_space.json
+jq --arg src source_catalog --arg dst target_catalog \
+   '(.. | strings) |= gsub($src; $dst)' genie_space.json \
+   > genie_space.tmp && mv genie_space.tmp genie_space.json
```

## Evaluation

Ran `stf audit` (L3 — static SKILL.md quality audit) against both this branch
and `origin/experimental` via the Databricks AI Gateway:

| Dimension | Experimental | This PR | Δ |
|---|---|---|---|
| tool_accuracy | 10.0 | 10.0 | 0 |
| examples_valid | 10.0 | 10.0 | 0 |
| self_contained | 8.0 | 8.0 | 0 |
| no_conflicts | 9.0 | 9.0 | 0 |
| security | 8.0 | 8.0 | 0 |
| llm_navigable_structure | 9.0 | 9.0 | 0 |
| actionable_instructions | 9.0 | 9.0 | 0 |
| scoped_clearly | 8.0 | 8.0 | 0 |
| error_handling | 7.0 | 7.0 | 0 |
| no_hallucination_triggers | 7.0 | 7.0 | 0 |
| **Overall** | **0.85** | **0.85** | **0** |

NEUTRAL on L3 — the rubric doesn't grade for cross-platform shell portability,
so the actual fix isn't visible at this granularity. No regression introduced.
`stf lint` clean. No MCP refs in the skill, so L1 MCP-preflight is N/A.

## How to verify

```bash
# Smoke-test the new jq snippet
cat > /tmp/genie_space.json <<'EOF'
{"data_sources":{"tables":[{"identifier":"source_catalog.ops.t1"}]}}
EOF
jq --arg src source_catalog --arg dst target_catalog \
   '(.. | strings) |= gsub($src; $dst)' /tmp/genie_space.json \
   > /tmp/out.json && cat /tmp/out.json
# → identifier rewritten to target_catalog.ops.t1

# Reproduce the L3 audit
stf audit databricks-skills/databricks-genie
```

## Test plan

- [x] `stf lint databricks-skills/databricks-genie` clean
- [x] `stf audit` PASS on this branch (0.85)
- [x] `stf audit` PASS on origin/experimental (0.85) — no regression
- [x] `jq` snippet verified on a sample `genie_space.json` (rewrites both `identifier` fields and catalog names embedded in instruction text)
