### PR TITLE
fix: handle HTTP-date string in get_volume_file_metadata

### DIFF
--- a/databricks-tools-core/databricks_tools_core/unity_catalog/volume_files.py
+++ b/databricks-tools-core/databricks_tools_core/unity_catalog/volume_files.py
@@ -11,6 +11,7 @@ import glob as glob_module
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import List, Optional
 
@@ -681,10 +682,20 @@ def get_volume_file_metadata(volume_path: str) -> VolumeFileInfo:
     w = get_workspace_client()
     metadata = w.files.get_metadata(volume_path)
 
+    # files.get_metadata() returns last_modified as an HTTP-date (RFC 7231) string,
+    # e.g. "Wed, 21 Oct 2015 07:28:00 GMT". Normalize to ISO 8601 for parity with
+    # list_volume_files. Fall back to the raw value if the SDK ever changes shape.
+    last_modified: Optional[str] = None
+    if metadata.last_modified is not None:
+        try:
+            last_modified = parsedate_to_datetime(metadata.last_modified).isoformat()
+        except (TypeError, ValueError):
+            last_modified = str(metadata.last_modified)
+
     return VolumeFileInfo(
         name=Path(volume_path).name,
         path=volume_path,
         is_directory=False,
         file_size=metadata.content_length,
-        last_modified=metadata.last_modified.isoformat() if metadata.last_modified else None,
+        last_modified=last_modified,
     )

--- a/databricks-tools-core/tests/unit/test_volume_files.py
+++ b/databricks-tools-core/tests/unit/test_volume_files.py
@@ -9,6 +9,7 @@ import pytest
 from databricks_tools_core.unity_catalog.volume_files import (
     upload_to_volume,
     delete_from_volume,
+    get_volume_file_metadata,
     _collect_local_files,
     _collect_local_directories,
     VolumeUploadResult,
@@ -399,3 +400,58 @@ class TestDeleteFromVolume:
         result = delete_from_volume("/Volumes/catalog/schema/volume/file.csv/")
 
         assert result.volume_path == "/Volumes/catalog/schema/volume/file.csv"
+
+
+class TestGetVolumeFileMetadata:
+    """Tests for get_volume_file_metadata.
+
+    files.get_metadata() returns last_modified as an HTTP-date (RFC 7231) string,
+    not a datetime — see databricks.sdk.service.files.GetMetadataResponse.
+    Regression coverage for the AttributeError fixed in #536.
+    """
+
+    @mock.patch("databricks_tools_core.unity_catalog.volume_files.get_workspace_client")
+    def test_http_date_string_is_normalized_to_iso8601(self, mock_get_client):
+        """RFC 7231 string from the SDK should be converted to ISO 8601."""
+        mock_client = mock.Mock()
+        mock_client.files.get_metadata.return_value = mock.Mock(
+            content_length=1234,
+            last_modified="Wed, 21 Oct 2015 07:28:00 GMT",
+        )
+        mock_get_client.return_value = mock_client
+
+        info = get_volume_file_metadata("/Volumes/c/s/v/data.csv")
+
+        assert info.name == "data.csv"
+        assert info.path == "/Volumes/c/s/v/data.csv"
+        assert info.is_directory is False
+        assert info.file_size == 1234
+        assert info.last_modified == "2015-10-21T07:28:00+00:00"
+
+    @mock.patch("databricks_tools_core.unity_catalog.volume_files.get_workspace_client")
+    def test_none_last_modified_is_preserved(self, mock_get_client):
+        """None last_modified must not raise and must round-trip as None."""
+        mock_client = mock.Mock()
+        mock_client.files.get_metadata.return_value = mock.Mock(
+            content_length=0,
+            last_modified=None,
+        )
+        mock_get_client.return_value = mock_client
+
+        info = get_volume_file_metadata("/Volumes/c/s/v/empty")
+
+        assert info.last_modified is None
+
+    @mock.patch("databricks_tools_core.unity_catalog.volume_files.get_workspace_client")
+    def test_unparseable_string_falls_back_to_raw_value(self, mock_get_client):
+        """If the SDK ever returns an unexpected string, we keep the raw value rather than crashing."""
+        mock_client = mock.Mock()
+        mock_client.files.get_metadata.return_value = mock.Mock(
+            content_length=42,
+            last_modified="not-a-date",
+        )
+        mock_get_client.return_value = mock_client
+
+        info = get_volume_file_metadata("/Volumes/c/s/v/odd.bin")
+
+        assert info.last_modified == "not-a-date"


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'str' object has no attribute 'isoformat'` in `get_volume_file_metadata` by parsing the SDK's HTTP-date string into ISO 8601.
- Add a `TestGetVolumeFileMetadata` unit-test class covering the real SDK string, `None`, and an unparseable string.

Fixes #536.

## Root cause

The Databricks SDK exposes `last_modified` with different types across two file APIs:

| SDK call | Return type | `last_modified` type |
|---|---|---|
| `files.list_directory_contents()` | `DirectoryEntry` | `Optional[int]` (Unix ms epoch) |
| `files.get_metadata()` | `GetMetadataResponse` | `Optional[str]` (RFC 7231 HTTP-date, e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`) |

Commit 3d1de62 (#142) handled the int case for `list_volume_files`. `get_volume_file_metadata` calls `files.get_metadata()` whose `last_modified` is a string, but the code at `volume_files.py:689` still called `.isoformat()` on it as if it were a `datetime`, raising `AttributeError`.

## Fix

Parse the HTTP-date with `email.utils.parsedate_to_datetime` and normalize to ISO 8601, matching the shape `list_volume_files` returns. Defensive fallback to the raw value if the SDK ever changes shape.

```python
# files.get_metadata() returns last_modified as an HTTP-date (RFC 7231) string,
# e.g. "Wed, 21 Oct 2015 07:28:00 GMT". Normalize to ISO 8601 for parity with
# list_volume_files. Fall back to the raw value if the SDK ever changes shape.
last_modified: Optional[str] = None
if metadata.last_modified is not None:
    try:
        last_modified = parsedate_to_datetime(metadata.last_modified).isoformat()
    except (TypeError, ValueError):
        last_modified = str(metadata.last_modified)
```

## Test plan

- [x] `pytest databricks-tools-core/tests/unit/test_volume_files.py -v` — 25 passed (22 existing + 3 new)
- [x] `ruff check` on touched files — clean
- [x] `ruff format --check` on touched files — clean (pre-existing formatting drift elsewhere in the test file is not addressed in this PR to keep the diff scoped)
- [x] Live smoke against a real workspace volume:
  - Raw SDK on a real UC volume file returned `last_modified='Mon, 18 May 2026 15:43:23 GMT'` (str) — confirming the SDK contract this PR is built on.
  - Old code path (`metadata.last_modified.isoformat()`) reproduced `AttributeError: 'str' object has no attribute 'isoformat'` against the real workspace.
  - Patched `get_volume_file_metadata` returned `last_modified='2026-05-18T15:43:23+00:00'` (ISO 8601) — fix verified end-to-end.