### PR TITLE
Add noom-mcp-server: monkey-patch extension layer for SQL governance

### DIFF
--- a/.github/workflows/noom-mcp-server.yml
+++ b/.github/workflows/noom-mcp-server.yml
@@ -1,0 +1,57 @@
+name: noom-mcp-server CI
+
+# Runs only when noom-mcp-server/ files change — upstream packages have their
+# own CI jobs in ci.yml and are not retested here.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "noom-mcp-server/**"
+
+# Least-privilege: read-only access to repository contents.
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: linux-ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Pinned uv version — keep in sync with the root ci.yml.
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.4"
+
+      # Run ruff from the noom-mcp-server/ directory so it picks up the local
+      # pyproject.toml config (line-length = 100, not the upstream 120).
+      - name: Run ruff check
+        run: uvx ruff@0.11.0 check .
+        working-directory: noom-mcp-server
+
+      - name: Check formatting
+        run: uvx ruff@0.11.0 format --check .
+        working-directory: noom-mcp-server
+
+  test:
+    name: Unit Tests
+    runs-on: linux-ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.4"
+
+      # Install noom-mcp-server and its local editable deps
+      # (databricks-mcp-server and databricks-tools-core from sibling directories).
+      - name: Install dependencies
+        run: uv sync --extra dev
+        working-directory: noom-mcp-server
+
+      # Integration tests require live Databricks credentials and are excluded.
+      # Run them manually via ./run_integration_tests.sh.
+      - name: Run unit tests
+        run: uv run pytest tests/ -v --ignore=tests/integration
+        working-directory: noom-mcp-server

--- a/noom-mcp-server/.env.example
+++ b/noom-mcp-server/.env.example
@@ -1,0 +1,18 @@
+# Noom MCP Server — environment variables
+#
+# Copy this file to .env and fill in the values below.
+# DO NOT commit .env to source control.
+#
+# Authentication: the server opens a browser OAuth flow on first run.
+# SP credentials are managed by an admin — no config needed here.
+# See DEVELOPMENT.md for dev/CI setup.
+
+# Your Databricks workspace (prod)
+DATABRICKS_HOST=https://noom-prod.cloud.databricks.com
+
+# SQL execution workspace — must match DATABRICKS_HOST
+DATABRICKS_MCP_SQL_HOST=https://noom-prod.cloud.databricks.com
+
+# SQL warehouse — all queries are forced to run on this warehouse
+# prod analytical warehouse (looker_warehouse)
+DATABRICKS_WAREHOUSE_ID=575c0a43969584a4

--- a/noom-mcp-server/DESIGN.md
+++ b/noom-mcp-server/DESIGN.md
@@ -19,9 +19,13 @@ noom-mcp-server/
 ├── run.py                # entry point: patches → import upstream server → mcp.run()
 ├── .env.example          # required env vars
 ├── DESIGN.md             # this file
+├── DEVELOPMENT.md        # admin setup, dev/CI credentials, test commands
 └── noom_mcp/
     ├── __init__.py
-    └── patches.py        # all three governance patches
+    ├── patches.py          # orchestrator: calls apply_all_patches()
+    ├── version_check.py    # upstream version pin + UpstreamChangedError
+    ├── auth_guard_patch.py # PAT rejection at startup
+    └── sql_executor_patch.py  # SP client override + user identity tagging
 ```
 
 `run.py` does three things in order:

--- a/noom-mcp-server/DESIGN.md
+++ b/noom-mcp-server/DESIGN.md
@@ -1,0 +1,180 @@
+# Noom MCP Server — Design & Viability Analysis
+
+## Goal
+
+Validate whether a **monkey-patch / thin extension** approach can apply Noom's SQL governance
+controls to the upstream `databricks-mcp-server` without modifying any file inside
+`databricks-mcp-server/` or `databricks-tools-core/`.
+
+The alternative is **copy-and-modify**: copy the upstream files we need to change, edit those
+copies, and accept the merge cost on every upstream update.
+
+---
+
+## What we implemented
+
+```
+noom-mcp-server/
+├── pyproject.toml        # depends on both upstream packages via local path sources
+├── run.py                # entry point: patches → import upstream server → mcp.run()
+├── .env.example          # required env vars
+├── DESIGN.md             # this file
+└── noom_mcp/
+    ├── __init__.py
+    └── patches.py        # all three governance patches
+```
+
+`run.py` does three things in order:
+1. Call `apply_all_patches()` — installs class-level patches on `SQLExecutor` and validates auth.
+2. `from databricks_mcp_server.server import mcp` — creates the FastMCP instance and registers all tools.
+3. `mcp.run()` — starts the server.
+
+No files inside `databricks-mcp-server/` or `databricks-tools-core/` are touched.
+
+---
+
+## The three changes
+
+### Change 1 — PAT rejection (`check_pat_rejected`)
+
+**Mechanism:** After `apply_all_patches()` imports `get_workspace_client()` and calls
+`current_user.me()`, the SDK resolves and caches `client.config.auth_type`.  We inspect
+it and raise `RuntimeError` if it's `"pat"`.
+
+**Fragility:** Low.  The Databricks Python SDK has used `config.auth_type` as a stable
+public field across versions.  The only risk is if the SDK stops populating it before
+an API call — unlikely.
+
+**Where it lives in the POC branch:** `validate_oauth_auth()` was added to `auth.py`
+(same logic); our `check_pat_rejected()` in `patches.py` is its equivalent called from
+`run.py` at startup.
+
+---
+
+### Change 2 — SQL SP override (`patch_sql_executor` → `__init__` patch)
+
+**Mechanism:** We replace `SQLExecutor.__init__` with a wrapper that always passes
+`client=get_sql_sp_client()` to the original `__init__`, ignoring whatever client
+the caller supplied.
+
+**Why this covers `execute_sql_multi` too:**
+`SQLParallelExecutor.__init__` (line 49) does:
+```python
+self.sql_executor = SQLExecutor(warehouse_id=warehouse_id, client=self.client)
+```
+Since we patched `SQLExecutor.__init__`, the `client` argument it receives (which would
+be the user's client) is discarded and replaced with the SP client.
+
+**Fragility:** Low–medium.  This depends on `SQLExecutor` remaining the single chokepoint
+for all SQL execution (true today and structurally stable).  If upstream adds a new
+executor class that bypasses `SQLExecutor`, the patch would miss it — but this would
+require a significant refactor.
+
+**Import-order safety:** The tool functions in `tools/sql.py` do not capture a reference
+to `SQLExecutor` at import time; they look it up at call time via the module.  Patching
+the class before the first tool invocation is sufficient regardless of import order.
+
+---
+
+### Change 3 — User identity tagging (`patch_sql_executor` → `execute` patch)
+
+**Mechanism:** We replace `SQLExecutor.execute` with a wrapper that appends
+`"mcp_user:<identity>"` to `query_tags` before forwarding to the original method.
+`get_mcp_user_identity()` resolves the user's email (OAuth browser/CLI) or
+`"sp:<client_id>"` (OAuth M2M) or `"unknown"`.
+
+**Note on identity resolution timing:** `get_mcp_user_identity()` calls
+`get_current_username()` from the upstream `auth.py`, which calls
+`get_workspace_client()` using the *user's* credentials (not the SP).  This is correct:
+we resolve identity while the user's auth context is still in effect, then the patched
+`__init__` switches to the SP for actual execution.
+
+**Fragility:** Low.  Depends only on `SQLExecutor.execute`'s signature remaining stable.
+The signature has been stable since this class was introduced.
+
+---
+
+## Monkey-patch vs FastMCP tool registry patching
+
+The prompt asked specifically whether FastMCP's tool registry could be patched instead
+(removing and re-registering tools, or using middleware).
+
+**Tool registry patching (`mcp.remove_tool` / `mcp.add_tool`):**
+- FastMCP 3.x *does* expose a public API: `list_tools()`, `get_tool()`,
+  `remove_tool()`, `add_tool()`.  (Verified at runtime — 44 tools registered,
+  `_tool_manager` is internal but the public methods are stable.)
+- We could call `mcp.remove_tool("execute_sql")` and re-register a new version.
+- **Problem:** The tool wrapper functions in `tools/sql.py` hardcode
+  `_execute_sql` and `_execute_sql_multi` as closed-over locals (captured at
+  import time via `from databricks_tools_core.sql import execute_sql as _execute_sql`).
+  Even if we swap the tool in the registry, the new wrapper would still need to
+  re-implement the full tool body to call our governed executor.  That's more
+  invasive than patching the class the tool already delegates to.
+
+**Middleware approach:**
+- `mcp.add_middleware(...)` intercepts tool calls at the JSON-RPC level.
+- Middleware sees `context.message.name` and `context.message.arguments`.
+- **Problem:** We need to inject a `WorkspaceClient` into the executor, not just
+  modify the tool arguments.  Middleware cannot intercept Python-level object creation
+  inside the tool's call stack.  It could mutate `arguments["query_tags"]`, but it
+  cannot redirect which client `SQLExecutor` uses.
+
+**Verdict:** Class-level patching of `SQLExecutor` is more stable, more correct, and
+requires no FastMCP internals knowledge.  Middleware is not the right abstraction for
+these changes.
+
+---
+
+## Minimal copy-and-modify alternative
+
+If monkey-patching becomes untenable (e.g. upstream refactors `SQLExecutor` away), the
+minimal copy-and-modify scope would be:
+
+| File to copy | Change |
+|---|---|
+| `databricks-tools-core/databricks_tools_core/auth.py` | Add `get_sql_sp_client()`, `get_mcp_user_identity()`, `validate_oauth_auth()` |
+| `databricks-mcp-server/databricks_mcp_server/tools/sql.py` | Use `get_sql_sp_client()` + inject user tag in `execute_sql` and `execute_sql_multi` |
+
+That's exactly what the `bei/poc_custom_mcp` branch does.  Two files, ~100 lines of
+additions.  The merge cost on upstream updates is bounded: `auth.py` changes rarely,
+and `tools/sql.py` changes only when SQL tool signatures change.
+
+---
+
+## Verdict
+
+**Monkey-patching is viable** for these three controls:
+
+| Control | Mechanism | Fragility |
+|---|---|---|
+| PAT rejection | Startup `config.auth_type` check | Low |
+| SQL SP override | `SQLExecutor.__init__` class patch | Low–medium |
+| User identity tagging | `SQLExecutor.execute` class patch | Low |
+
+The approach is stable because all three patch points are stable public/internal
+interfaces that change rarely.  The class-level patch survives across FastMCP versions
+because it doesn't touch FastMCP at all.
+
+The main ongoing risk: if upstream introduces a second SQL executor class that bypasses
+`SQLExecutor`, the SP override and tagging patches would silently not apply to it.
+A lightweight integration test that verifies query_tags and client identity on actual
+SQL calls would catch this regression.
+
+---
+
+## Open question: distribution (deferred)
+
+Today `noom-mcp-server` requires `uv` because the upstream `databricks-mcp-server` requires
+it.  For non-engineering users this is friction.
+
+Options to revisit once governance is validated:
+
+| Option | UX | Effort |
+|---|---|---|
+| Private PyPI + `uvx noom-mcp-server` | One-line MCP config, one-time `uv` install | Medium — CI publish pipeline |
+| Docker image | Zero Python tooling required | Medium — Dockerfile + registry |
+| Wrapper shell script | Hides `uv` behind `./start.sh` | Low |
+| Bundled executable (PyInstaller) | True double-click install | High |
+
+The monkey-patch approach in this POC is agnostic to all of these — `run.py` and
+`patches.py` work identically however the user arrives at a Python environment.

--- a/noom-mcp-server/DEVELOPMENT.md
+++ b/noom-mcp-server/DEVELOPMENT.md
@@ -2,8 +2,8 @@
 
 ## Admin setup: SQL Service Principal credentials
 
-End users only need to set `DATABRICKS_MCP_SECRET_SCOPE` in their `.env`.
 An admin must first provision the secret scope and store the SP credentials.
+End users need READ access on the scope (see below) but never interact with the secret values directly.
 
 Run this once against the prod workspace:
 
@@ -31,7 +31,7 @@ will reflect a prod identity running SQL on a dev warehouse, which is confusing.
 
 When running locally without Databricks Secrets access (e.g. in CI), set the
 SP credentials directly as environment variables. The secret scope lookup is
-skipped when `DATABRICKS_MCP_SECRET_SCOPE` is unset.
+skipped when `DATABRICKS_MCP_SQL_CLIENT_ID` is set.
 
 ```bash
 export DATABRICKS_MCP_SQL_CLIENT_ID=<service-principal-client-id>

--- a/noom-mcp-server/DEVELOPMENT.md
+++ b/noom-mcp-server/DEVELOPMENT.md
@@ -1,0 +1,61 @@
+# Development Guide
+
+## Admin setup: SQL Service Principal credentials
+
+End users only need to set `DATABRICKS_MCP_SECRET_SCOPE` in their `.env`.
+An admin must first provision the secret scope and store the SP credentials.
+
+Run this once against the prod workspace:
+
+```bash
+databricks secrets create-scope dbrix_mcp_secret
+databricks secrets put-secret dbrix_mcp_secret sql-sp-client-id     --string-value <client-id>
+databricks secrets put-secret dbrix_mcp_secret sql-sp-client-secret --string-value <client-secret>
+databricks secrets put-acl    dbrix_mcp_secret <group-or-user> READ
+```
+
+Users need READ on the scope but never see the raw secret values.
+
+---
+
+## Workspace hosts
+
+Both `DATABRICKS_HOST` (OAuth / identity) and `DATABRICKS_MCP_SQL_HOST` (SQL execution)
+should always point to prod.  If you change `DATABRICKS_MCP_SQL_HOST` to a dev/staging
+workspace for testing, change `DATABRICKS_HOST` to match — otherwise the `mcp_user:` tag
+will reflect a prod identity running SQL on a dev warehouse, which is confusing.
+
+---
+
+## Dev / CI: credentials via env vars
+
+When running locally without Databricks Secrets access (e.g. in CI), set the
+SP credentials directly as environment variables. The secret scope lookup is
+skipped when `DATABRICKS_MCP_SECRET_SCOPE` is unset.
+
+```bash
+export DATABRICKS_MCP_SQL_CLIENT_ID=<service-principal-client-id>
+export DATABRICKS_MCP_SQL_CLIENT_SECRET=<service-principal-client-secret>
+export DATABRICKS_MCP_SQL_HOST=https://noom-prod.cloud.databricks.com
+```
+
+Do not use this approach in production — the secret is visible in the process
+environment and shell history.
+
+---
+
+## Running the test suite
+
+**Unit tests** (no credentials needed):
+
+```bash
+pytest tests/ -v
+```
+
+**Integration tests** (live Databricks required):
+
+```bash
+./run_integration_tests.sh
+```
+
+`DATABRICKS_WAREHOUSE_ID` is set in `.env` and injected by the server patch into every SQL execution — the AI client does not need to know or supply it.

--- a/noom-mcp-server/README.md
+++ b/noom-mcp-server/README.md
@@ -1,0 +1,117 @@
+# noom-mcp-server
+
+A governance extension layer over the upstream
+[databricks-mcp-server](../databricks-mcp-server/README.md).  It monkey-patches
+three SQL governance controls at startup — PAT rejection, Service Principal SQL
+execution, and per-user query tagging — **without modifying any upstream file**.
+See [DESIGN.md](DESIGN.md) for the full viability analysis and design rationale.
+
+## Architecture
+
+```
+run.py
+  ├── apply_all_patches()          ← Noom governance, applied before server starts
+  │     ├── check_upstream_version   version pin guard
+  │     ├── patch_sql_executor       SP client + warehouse override, mcp_user tagging
+  │     └── check_pat_rejected       live auth check: PAT rejected, OAuth required
+  └── databricks_mcp_server.server.mcp.run()   ← upstream FastMCP server, unchanged
+```
+
+All SQL issued through the MCP server is:
+- Executed by a fixed Service Principal (not the calling user's credentials)
+- Routed to the designated production SQL warehouse
+- Tagged with `mcp_user:<email>` in `system.query.history` for audit and cost attribution
+
+Non-SQL tools (jobs, Unity Catalog, compute, etc.) continue to use the calling
+user's own credentials and are not affected by the patches.
+
+## Prerequisites
+
+- Python ≥ 3.10
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Databricks OAuth access (PAT tokens are rejected at startup)
+- READ permission on the `dbrix_mcp_secret` secret scope (provisioned by an admin)
+
+## Environment variables
+
+Copy `.env.example` and fill in the values:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Required | Description |
+|---|---|---|
+| `DATABRICKS_HOST` | Yes | Your Databricks workspace URL (e.g. `https://noom-prod.cloud.databricks.com`). Used for OAuth identity resolution. |
+| `DATABRICKS_MCP_SQL_HOST` | Yes | Workspace URL where SQL runs. Set to prod — keeps SQL pinned to prod even if `DATABRICKS_HOST` changes. |
+| `DATABRICKS_WAREHOUSE_ID` | Yes | ID of the production SQL warehouse every query is routed to. |
+
+The Service Principal credentials are fetched automatically from the
+`dbrix_mcp_secret` Databricks secret scope at startup. You only need the
+variables above in your `.env`.
+
+### Dev / CI overrides
+
+To skip the secret scope (e.g. in CI without Databricks Secrets access), set
+the SP credentials directly as environment variables:
+
+| Variable | Description |
+|---|---|
+| `DATABRICKS_MCP_SQL_CLIENT_ID` | SP client ID (bypasses secret scope lookup) |
+| `DATABRICKS_MCP_SQL_CLIENT_SECRET` | SP client secret (required when `CLIENT_ID` is set) |
+
+Do not use this in production — secrets are visible in process environment and
+shell history.
+
+## Admin setup
+
+An admin must provision the secret scope once against the prod workspace:
+
+```bash
+databricks secrets create-scope dbrix_mcp_secret
+databricks secrets put-secret dbrix_mcp_secret sql-sp-client-id     --string-value <sp-client-id>
+databricks secrets put-secret dbrix_mcp_secret sql-sp-client-secret --string-value <sp-client-secret>
+databricks secrets put-acl    dbrix_mcp_secret <group-or-user> READ
+```
+
+End users need READ access on the scope but never see the raw secret values.
+
+## Running the server
+
+```bash
+cd noom-mcp-server
+uv run python run.py
+```
+
+The server exits with code 2 on a version mismatch (`UpstreamChangedError`) and
+code 1 on any other startup failure.
+
+## Running the tests
+
+**Unit tests** — no credentials needed:
+
+```bash
+cd noom-mcp-server
+uv run pytest tests/ -v
+```
+
+**Integration tests** — requires a live Databricks connection and a populated `.env`:
+
+```bash
+cd noom-mcp-server
+./run_integration_tests.sh
+```
+
+The integration test verifies that SQL runs as the Service Principal (not the
+calling user) by comparing `SELECT current_user()` output.
+
+## Upgrading the upstream
+
+When a new upstream release lands (the repo `VERSION` file changes):
+
+1. Check whether `SQLExecutor.__init__` or `.execute` signatures changed in
+   [`databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py`](../databricks-tools-core/databricks_tools_core/sql/sql_utils/executor.py).
+   Update the patch wrappers in `noom_mcp/sql_executor_patch.py` if needed.
+2. Run the unit tests: `uv run pytest tests/ -v`
+3. Bump `PATCHED_UPSTREAM_VERSION` in `noom_mcp/version_check.py` to the new version.
+4. Run the integration tests to confirm SQL governance is still enforced.

--- a/noom-mcp-server/conftest.py
+++ b/noom-mcp-server/conftest.py
@@ -1,0 +1,26 @@
+"""Root pytest configuration for noom-mcp-server.
+
+Adds the --integration flag and automatically skips @pytest.mark.integration
+tests unless the flag is passed.
+"""
+
+import pytest
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests that require live Databricks credentials.",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    if not config.getoption("--integration"):
+        skip = pytest.mark.skip(reason="pass --integration to run live tests")
+        for item in items:
+            if item.get_closest_marker("integration"):
+                item.add_marker(skip)

--- a/noom-mcp-server/noom_mcp/__init__.py
+++ b/noom-mcp-server/noom_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Noom MCP Server — governance layer over the upstream Databricks MCP server."""

--- a/noom-mcp-server/noom_mcp/auth_guard_patch.py
+++ b/noom-mcp-server/noom_mcp/auth_guard_patch.py
@@ -1,0 +1,42 @@
+"""PAT rejection guard.
+
+Enforces that the calling user authenticates via OAuth (browser flow or
+OAuth M2M), never via a Personal Access Token.  Called once at server
+startup before any tool is invoked.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def check_pat_rejected() -> None:
+    """Fail fast if the current Databricks auth resolved to a PAT token.
+
+    Makes a live API call (current_user.me) to force the SDK to resolve
+    and cache auth_type on the config, then inspects it.  Only
+    "databricks-cli" (browser OAuth) and "oauth-m2m" are accepted.
+
+    Raises:
+        RuntimeError: If auth_type is "pat".
+        Exception: Re-raises any SDK / network error so the server exits
+            with a clear message rather than silently continuing.
+    """
+    from databricks_tools_core.auth import get_workspace_client
+
+    client = get_workspace_client()
+
+    # Force auth resolution — SDK validates credentials lazily on first call.
+    me = client.current_user.me()
+    logger.info("Startup auth check: authenticated as %s", me.user_name)
+
+    auth_type = getattr(client.config, "auth_type", None)
+    if auth_type == "pat":
+        raise RuntimeError(
+            "PAT authentication is not permitted. "
+            "Use 'databricks auth login' for browser-based OAuth, "
+            "or set DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET for OAuth M2M. "
+            f"Resolved auth_type was: {auth_type!r}"
+        )
+
+    logger.info("Startup auth check passed (auth_type=%r)", auth_type)

--- a/noom-mcp-server/noom_mcp/auth_guard_patch.py
+++ b/noom-mcp-server/noom_mcp/auth_guard_patch.py
@@ -18,16 +18,25 @@ def check_pat_rejected() -> None:
     "databricks-cli" (browser OAuth) and "oauth-m2m" are accepted.
 
     Raises:
-        RuntimeError: If auth_type is "pat".
-        Exception: Re-raises any SDK / network error so the server exits
-            with a clear message rather than silently continuing.
+        RuntimeError: If auth_type is "pat", or if the API call fails
+            (wraps transport/auth errors with a clear startup message).
     """
     from databricks_tools_core.auth import get_workspace_client
 
     client = get_workspace_client()
 
     # Force auth resolution — SDK validates credentials lazily on first call.
-    me = client.current_user.me()
+    try:
+        me = client.current_user.me()
+    except Exception as exc:
+        raise RuntimeError(
+            f"Startup auth check failed — could not reach Databricks or credentials are invalid.\n"
+            f"  Host: {getattr(client.config, 'host', '<unset>')}\n"
+            f"  Error: {exc}\n"
+            "Ensure DATABRICKS_HOST is set and your credentials are valid "
+            "('databricks auth login' or DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET)."
+        ) from exc
+
     logger.info("Startup auth check: authenticated as %s", me.user_name)
 
     auth_type = getattr(client.config, "auth_type", None)

--- a/noom-mcp-server/noom_mcp/patches.py
+++ b/noom-mcp-server/noom_mcp/patches.py
@@ -1,0 +1,43 @@
+"""Apply all Noom MCP governance patches.
+
+This module is the single entry point imported by run.py.  It delegates to
+three focused sub-modules and calls them in the required order.
+
+Sub-modules
+-----------
+version_check         Upstream version pin — abort if the upstream has changed.
+auth_guard_patch      PAT rejection — abort if the user authenticated with a PAT.
+sql_executor_patch    SP client override + user identity tagging on SQLExecutor.
+"""
+
+import logging
+
+from noom_mcp.auth_guard_patch import check_pat_rejected as check_pat_rejected  # re-export
+from noom_mcp.sql_executor_patch import patch_sql_executor as patch_sql_executor  # re-export
+from noom_mcp.version_check import (  # re-export
+    UpstreamChangedError as UpstreamChangedError,
+    check_upstream_version as check_upstream_version,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def apply_all_patches() -> None:
+    """Apply all Noom MCP governance patches in the correct order.
+
+    Must be called BEFORE the first MCP tool invocation so that patches are
+    in place before any SQL execution can happen.  (Importing the server
+    module is safe before calling this function.)
+
+    Execution order:
+    1. check_upstream_version — version pin guard; raises UpstreamChangedError
+       if the installed upstream doesn't match the validated version.
+    2. patch_sql_executor — installs class-level patches on SQLExecutor for
+       SP client override and user identity tagging.
+    3. check_pat_rejected — validates startup credentials via a live API call;
+       fails immediately if auth is PAT.
+    """
+    check_upstream_version()
+    patch_sql_executor()
+    check_pat_rejected()
+    logger.info("All Noom MCP governance patches applied successfully")

--- a/noom-mcp-server/noom_mcp/sql_executor_patch.py
+++ b/noom-mcp-server/noom_mcp/sql_executor_patch.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 # Process-lifetime cache — one SP client per server process.
 _sql_sp_client = None
 
+# Guard flag so patch_sql_executor() is idempotent (safe to call multiple times).
+_sql_executor_patched = False
+
 # Fixed secret scope and key names — not user-configurable.
 _SECRET_SCOPE = "dbrix_mcp_secret"
 _SECRET_KEY_CLIENT_ID = "sql-sp-client-id"
@@ -166,7 +169,8 @@ def get_sql_warehouse_id() -> str:
 
     Reads DATABRICKS_WAREHOUSE_ID from the environment.  This overrides
     whatever warehouse_id the AI client passes to execute_sql, ensuring all
-    SQL always runs on the designated prod warehouse.
+    SQL runs on the designated warehouse rather than an arbitrary one chosen
+    by the caller.
 
     Raises:
         RuntimeError: If DATABRICKS_WAREHOUSE_ID is not set.
@@ -175,7 +179,7 @@ def get_sql_warehouse_id() -> str:
     if not wh:
         raise RuntimeError(
             "DATABRICKS_WAREHOUSE_ID is not set.\n"
-            "Set it to the prod SQL warehouse ID in your .env file."
+            "Set it to the SQL warehouse ID in your .env file."
         )
     return wh
 
@@ -220,6 +224,8 @@ def get_mcp_user_identity() -> str:
 def patch_sql_executor() -> None:
     """Patch SQLExecutor to enforce SP client and inject user identity tags.
 
+    Idempotent — calling this function more than once has no effect.
+
     __init__ patch
         Ignores both the ``warehouse_id`` and ``client`` arguments passed by
         the caller.  Always substitutes the governed warehouse ID (from
@@ -231,6 +237,11 @@ def patch_sql_executor() -> None:
         The user's identity is resolved *before* the SP client is used,
         so it still reflects the calling user's credentials.
     """
+    global _sql_executor_patched
+    if _sql_executor_patched:
+        logger.debug("SQLExecutor already patched — skipping")
+        return
+
     from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
 
     _original_init = SQLExecutor.__init__
@@ -238,7 +249,14 @@ def patch_sql_executor() -> None:
 
     @wraps(_original_init)
     def _patched_init(self, warehouse_id: str, client=None) -> None:
-        _original_init(self, get_sql_warehouse_id(), client=get_sql_sp_client())
+        configured_warehouse_id = get_sql_warehouse_id()
+        if warehouse_id and warehouse_id != configured_warehouse_id:
+            logger.debug(
+                "SQLExecutor.__init__: overriding caller warehouse %r with configured warehouse %r",
+                warehouse_id,
+                configured_warehouse_id,
+            )
+        _original_init(self, configured_warehouse_id, client=get_sql_sp_client())
 
     @wraps(_original_execute)
     def _patched_execute(
@@ -264,6 +282,7 @@ def patch_sql_executor() -> None:
 
     SQLExecutor.__init__ = _patched_init
     SQLExecutor.execute = _patched_execute
+    _sql_executor_patched = True
     logger.info(
         "SQLExecutor patched: warehouse override (%s), SP client override, "
         "user identity tagging active",

--- a/noom-mcp-server/noom_mcp/sql_executor_patch.py
+++ b/noom-mcp-server/noom_mcp/sql_executor_patch.py
@@ -1,0 +1,271 @@
+"""SQLExecutor patches: SP client override and user identity tagging.
+
+Two class-level patches applied to SQLExecutor at startup:
+
+1. SP client override (patch_sql_executor → __init__ patch)
+   Every SQL query is executed using a pre-configured Service Principal
+   fetched from the dbrix_mcp_secret Databricks secret scope, regardless
+   of which credentials the calling user has configured.
+
+2. User identity tagging (patch_sql_executor → execute patch)
+   The calling user's email (or "sp:<client_id>" for M2M callers) is
+   appended to query_tags as "mcp_user:<identity>" on every SQL statement.
+   This surfaces in system.query.history for audit and cost attribution.
+
+Patching strategy
+-----------------
+Both patches target SQLExecutor at the class level.  This is the single
+chokepoint for all SQL execution: execute_sql calls SQLExecutor directly,
+and execute_sql_multi delegates to SQLExecutor via SQLParallelExecutor.
+The tool functions look up SQLExecutor at call time (not import time), so
+patching the class before the first invocation is sufficient.
+"""
+
+import logging
+import os
+from functools import wraps
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Process-lifetime cache — one SP client per server process.
+_sql_sp_client = None
+
+# Fixed secret scope and key names — not user-configurable.
+_SECRET_SCOPE = "dbrix_mcp_secret"
+_SECRET_KEY_CLIENT_ID = "sql-sp-client-id"
+_SECRET_KEY_CLIENT_SECRET = "sql-sp-client-secret"
+
+
+# ---------------------------------------------------------------------------
+# SP credential helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_sp_credentials_from_secrets() -> tuple[str, str]:
+    """Fetch SQL SP credentials from the Databricks secret scope.
+
+    Uses the fixed scope ``dbrix_mcp_secret`` and fetches two fixed keys:
+      - sql-sp-client-id
+      - sql-sp-client-secret
+
+    Uses the calling user's own credentials to fetch the secrets — they need
+    READ permission on the scope, but never see the raw secret values (the
+    SDK decodes them and they stay in process memory only).
+
+    Returns:
+        Tuple of (client_id, client_secret).
+
+    Raises:
+        RuntimeError: If the scope or keys are missing or inaccessible.
+    """
+    import base64
+    from databricks_tools_core.auth import get_workspace_client
+
+    scope = _SECRET_SCOPE
+    key_client_id = _SECRET_KEY_CLIENT_ID
+    key_client_secret = _SECRET_KEY_CLIENT_SECRET
+
+    client = get_workspace_client()
+
+    def _get(key: str) -> str:
+        try:
+            response = client.secrets.get_secret(scope=scope, key=key)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to fetch secret '{key}' from scope '{scope}': {exc}\n"
+                f"Ensure the scope exists and you have READ permission on it."
+            ) from exc
+        if not response.value:
+            raise RuntimeError(f"Secret '{key}' in scope '{scope}' is empty.")
+        # Databricks returns secret values base64-encoded
+        return base64.b64decode(response.value).decode("utf-8")
+
+    logger.info("Fetching SQL SP credentials from Databricks secret scope %r", scope)
+    client_id = _get(key_client_id)
+    client_secret = _get(key_client_secret)
+    logger.info("SQL SP credentials fetched from Databricks Secrets successfully")
+    return client_id, client_secret
+
+
+def _build_sql_sp_client():
+    """Construct the SQL Service Principal WorkspaceClient.
+
+    Credential resolution order:
+    1. Databricks Secrets (default) — fetches from the fixed scope
+       ``dbrix_mcp_secret``.  Users need READ on the scope but never see
+       the raw values.
+    2. Env vars (dev / CI override) — if DATABRICKS_MCP_SQL_CLIENT_ID is
+       set, use it along with DATABRICKS_MCP_SQL_CLIENT_SECRET directly.
+       See DEVELOPMENT.md.
+
+    DATABRICKS_MCP_SQL_HOST is always required.
+
+    Returns:
+        Tagged WorkspaceClient configured for OAuth M2M with the SQL SP.
+
+    Raises:
+        RuntimeError: If credentials or host are not configured.
+    """
+    from databricks.sdk import WorkspaceClient
+    from databricks_tools_core.identity import PRODUCT_NAME, PRODUCT_VERSION, tag_client
+
+    if os.environ.get("DATABRICKS_MCP_SQL_CLIENT_ID"):
+        # Dev / CI override: credentials supplied directly as env vars.
+        # See DEVELOPMENT.md for when to use this.
+        client_id = os.environ["DATABRICKS_MCP_SQL_CLIENT_ID"]
+        client_secret = os.environ.get("DATABRICKS_MCP_SQL_CLIENT_SECRET", "")
+        if not client_secret:
+            raise RuntimeError(
+                "DATABRICKS_MCP_SQL_CLIENT_ID is set but "
+                "DATABRICKS_MCP_SQL_CLIENT_SECRET is missing."
+            )
+    else:
+        client_id, client_secret = _fetch_sp_credentials_from_secrets()
+
+    host = os.environ.get("DATABRICKS_MCP_SQL_HOST")
+    if not host:
+        raise RuntimeError(
+            "DATABRICKS_MCP_SQL_HOST is not set.\n"
+            "Set it to the prod workspace URL to ensure SQL always runs "
+            "against prod, regardless of which workspace the user is logged into.\n"
+            "Example: DATABRICKS_MCP_SQL_HOST=https://noom-prod.cloud.databricks.com"
+        )
+
+    return tag_client(
+        WorkspaceClient(
+            host=host,
+            client_id=client_id,
+            client_secret=client_secret,
+            auth_type="oauth-m2m",
+            product=PRODUCT_NAME,
+            product_version=PRODUCT_VERSION,
+        )
+    )
+
+
+def get_sql_sp_client():
+    """Return the cached SQL SP client, initialising it on first call.
+
+    Returns:
+        WorkspaceClient configured with the SQL Service Principal.
+    """
+    global _sql_sp_client
+    if _sql_sp_client is None:
+        _sql_sp_client = _build_sql_sp_client()
+    return _sql_sp_client
+
+
+# ---------------------------------------------------------------------------
+# Warehouse ID
+# ---------------------------------------------------------------------------
+
+
+def get_sql_warehouse_id() -> str:
+    """Return the configured SQL warehouse ID.
+
+    Reads DATABRICKS_WAREHOUSE_ID from the environment.  This overrides
+    whatever warehouse_id the AI client passes to execute_sql, ensuring all
+    SQL always runs on the designated prod warehouse.
+
+    Raises:
+        RuntimeError: If DATABRICKS_WAREHOUSE_ID is not set.
+    """
+    wh = os.environ.get("DATABRICKS_WAREHOUSE_ID")
+    if not wh:
+        raise RuntimeError(
+            "DATABRICKS_WAREHOUSE_ID is not set.\n"
+            "Set it to the prod SQL warehouse ID in your .env file."
+        )
+    return wh
+
+
+# ---------------------------------------------------------------------------
+# User identity
+# ---------------------------------------------------------------------------
+
+
+def get_mcp_user_identity() -> str:
+    """Return the calling user's identity string for SQL query tagging.
+
+    Resolution order:
+    - OAuth browser / CLI users  → their email address (from current_user.me())
+    - OAuth M2M service accounts → "sp:<DATABRICKS_CLIENT_ID>"
+    - Unresolvable                → "unknown"
+
+    Must be called while the user's own credentials are still in context
+    (i.e. before switching to the SQL SP client inside an executor).
+
+    Returns:
+        Identity string, never None.
+    """
+    from databricks_tools_core.auth import get_current_username
+
+    username = get_current_username()
+    if username:
+        return username
+
+    client_id = os.environ.get("DATABRICKS_CLIENT_ID")
+    if client_id:
+        return f"sp:{client_id}"
+
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# SQLExecutor patches
+# ---------------------------------------------------------------------------
+
+
+def patch_sql_executor() -> None:
+    """Patch SQLExecutor to enforce SP client and inject user identity tags.
+
+    __init__ patch
+        Ignores both the ``warehouse_id`` and ``client`` arguments passed by
+        the caller.  Always substitutes the governed warehouse ID (from
+        DATABRICKS_WAREHOUSE_ID) and the governed SP client.  This ensures
+        the AI cannot direct SQL to an arbitrary warehouse.
+
+    execute patch
+        Appends "mcp_user:<identity>" to query_tags on every statement.
+        The user's identity is resolved *before* the SP client is used,
+        so it still reflects the calling user's credentials.
+    """
+    from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+
+    _original_init = SQLExecutor.__init__
+    _original_execute = SQLExecutor.execute
+
+    @wraps(_original_init)
+    def _patched_init(self, warehouse_id: str, client=None) -> None:
+        _original_init(self, get_sql_warehouse_id(), client=get_sql_sp_client())
+
+    @wraps(_original_execute)
+    def _patched_execute(
+        self,
+        sql_query: str,
+        catalog: Optional[str] = None,
+        schema: Optional[str] = None,
+        row_limit: Optional[int] = None,
+        timeout: int = 180,
+        query_tags: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        user_tag = f"mcp_user:{get_mcp_user_identity()}"
+        effective_tags = f"{query_tags},{user_tag}" if query_tags else user_tag
+        return _original_execute(
+            self,
+            sql_query,
+            catalog=catalog,
+            schema=schema,
+            row_limit=row_limit,
+            timeout=timeout,
+            query_tags=effective_tags,
+        )
+
+    SQLExecutor.__init__ = _patched_init
+    SQLExecutor.execute = _patched_execute
+    logger.info(
+        "SQLExecutor patched: warehouse override (%s), SP client override, "
+        "user identity tagging active",
+        get_sql_warehouse_id(),
+    )

--- a/noom-mcp-server/noom_mcp/version_check.py
+++ b/noom-mcp-server/noom_mcp/version_check.py
@@ -1,0 +1,42 @@
+"""Upstream version pin.
+
+The only thing to update when pulling a new upstream release:
+  1. Bump PATCHED_UPSTREAM_VERSION to the new version
+  2. Re-validate that the patches still apply correctly
+  3. Restart the server
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Bump this (and re-validate) every time you pull a new upstream release.
+PATCHED_UPSTREAM_VERSION = "0.1.10"
+
+
+class UpstreamChangedError(RuntimeError):
+    """Raised when the installed upstream version doesn't match the pin.
+
+    Do not swallow this error.  Re-validate the patches against the new
+    version, then bump PATCHED_UPSTREAM_VERSION above.
+    """
+
+
+def check_upstream_version() -> None:
+    """Fail fast if the installed upstream version doesn't match the pin.
+
+    Raises:
+        UpstreamChangedError: If the versions don't match.
+    """
+    from databricks_tools_core.identity import PRODUCT_VERSION
+
+    if PRODUCT_VERSION != PATCHED_UPSTREAM_VERSION:
+        raise UpstreamChangedError(
+            f"Upstream version mismatch — patches not validated for this version.\n"
+            f"  Validated against: {PATCHED_UPSTREAM_VERSION}\n"
+            f"  Installed version: {PRODUCT_VERSION}\n"
+            f"  Action: test the patches against v{PRODUCT_VERSION}, then set "
+            f"PATCHED_UPSTREAM_VERSION = {PRODUCT_VERSION!r} in version_check.py."
+        )
+
+    logger.info("Upstream version check passed (v%s)", PRODUCT_VERSION)

--- a/noom-mcp-server/noom_mcp/version_check.py
+++ b/noom-mcp-server/noom_mcp/version_check.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Bump this (and re-validate) every time you pull a new upstream release.
-PATCHED_UPSTREAM_VERSION = "0.1.10"
+PATCHED_UPSTREAM_VERSION = "0.1.12"
 
 
 class UpstreamChangedError(RuntimeError):

--- a/noom-mcp-server/pyproject.toml
+++ b/noom-mcp-server/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "noom-mcp-server"
+version = "0.1.0"
+description = "Noom-governed MCP server — thin extension over databricks-mcp-server"
+requires-python = ">=3.10"
+dependencies = [
+    "databricks-mcp-server",
+    "databricks-tools-core",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pyright>=1.1",
+    "pytest>=7.0",
+    "ruff>=0.4",
+]
+
+# uv resolves these from local paths instead of PyPI
+[tool.uv.sources]
+databricks-mcp-server = { path = "../databricks-mcp-server", editable = true }
+databricks-tools-core = { path = "../databricks-tools-core", editable = true }
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["noom_mcp*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "strict"
+markers = [
+    "integration: live Databricks integration test (requires --integration flag)",
+]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "PIE"]

--- a/noom-mcp-server/run.py
+++ b/noom-mcp-server/run.py
@@ -1,0 +1,71 @@
+"""Entry point for the Noom-governed Databricks MCP server.
+
+Start with:
+    uv run python run.py
+
+Or via MCP client config:
+    {
+        "command": "uv",
+        "args": ["run", "--directory", "/path/to/noom-mcp-server", "python", "run.py"]
+    }
+
+Required env vars (see .env.example):
+    DATABRICKS_MCP_SQL_CLIENT_ID      — OAuth client ID for the SQL SP
+    DATABRICKS_MCP_SQL_CLIENT_SECRET  — OAuth client secret for the SQL SP
+
+Optional:
+    DATABRICKS_MCP_SQL_HOST           — Override workspace host for SQL SP
+                                        (defaults to calling user's workspace)
+"""
+
+import logging
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("noom_mcp")
+
+# ---------------------------------------------------------------------------
+# Step 1: Apply governance patches BEFORE the upstream server imports tools.
+#
+# patch_sql_executor() patches SQLExecutor at the class level — it only needs
+# the databricks-tools-core package to be importable, not the MCP server.
+#
+# check_pat_rejected() makes a live Databricks API call, so it requires valid
+# workspace credentials to be configured in the environment.
+# ---------------------------------------------------------------------------
+
+from noom_mcp.patches import apply_all_patches, UpstreamChangedError  # noqa: E402
+
+try:
+    apply_all_patches()
+except UpstreamChangedError as exc:
+    logger.error(
+        "UPSTREAM VERSION CHANGED — server will not start.\n%s",
+        exc,
+    )
+    sys.exit(2)
+except RuntimeError as exc:
+    logger.error("Governance check failed — server will not start: %s", exc)
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# Step 2: Import the upstream MCP server.
+#
+# Importing this module creates the FastMCP instance and registers all tools
+# (including execute_sql / execute_sql_multi) via @mcp.tool decorators.
+# The SQLExecutor patches are already in place at this point.
+# ---------------------------------------------------------------------------
+
+from databricks_mcp_server.server import mcp  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Step 3: Run.
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    logger.info("Starting Noom MCP server (governed Databricks MCP)")
+    mcp.run()

--- a/noom-mcp-server/run_integration_tests.sh
+++ b/noom-mcp-server/run_integration_tests.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Run live Databricks integration tests for noom-mcp-server.
+#
+# Usage:
+#   ./run_integration_tests.sh
+#
+# Required environment variables (export them before running, or add to .env):
+#
+#   DATABRICKS_HOST               Calling user's workspace URL
+#   DATABRICKS_WAREHOUSE_ID       SQL warehouse to run test queries against
+#   DATABRICKS_MCP_SQL_HOST       Workspace for SQL execution (usually prod)
+#
+#   Calling user auth — one of:
+#     Browser OAuth (recommended): run 'databricks auth login' beforehand
+#     OAuth M2M: set DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET
+#
+#   SQL SP credentials — one of:
+#     DATABRICKS_MCP_SECRET_SCOPE             Databricks secret scope with SP creds
+#     DATABRICKS_MCP_SQL_CLIENT_ID +          Direct env vars (dev/CI fallback)
+#       DATABRICKS_MCP_SQL_CLIENT_SECRET
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Require .env — copy .env.example if you haven't already
+if [[ ! -f "$SCRIPT_DIR/.env" ]]; then
+  echo "ERROR: $SCRIPT_DIR/.env not found." >&2
+  echo "  cp noom-mcp-server/.env.example noom-mcp-server/.env" >&2
+  echo "  # then fill in any values and re-run" >&2
+  exit 1
+fi
+
+echo "Loading $SCRIPT_DIR/.env"
+set -a
+# shellcheck disable=SC1090
+source "$SCRIPT_DIR/.env"
+set +a
+
+# PAT auth is explicitly rejected by noom-mcp-server.
+# Unset DATABRICKS_TOKEN if present so the SDK falls through to OAuth.
+if [[ -n "${DATABRICKS_TOKEN:-}" ]]; then
+  echo "WARNING: DATABRICKS_TOKEN is set — unsetting it to force OAuth auth."
+  unset DATABRICKS_TOKEN
+fi
+
+# Validate required variables
+missing=()
+for var in DATABRICKS_HOST DATABRICKS_MCP_SQL_HOST; do
+  [[ -z "${!var:-}" ]] && missing+=("$var")
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: Missing required environment variables:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+# Locate the Python interpreter (prefer repo-root venv, fall back to system)
+PYTHON="${SCRIPT_DIR}/../.venv/bin/python3"
+if [[ ! -x "$PYTHON" ]]; then
+  PYTHON="$(command -v python3)"
+fi
+
+echo "Python: $PYTHON"
+echo "Host:   $DATABRICKS_HOST"
+echo "SQL:    $DATABRICKS_MCP_SQL_HOST"
+echo "WH:     ${DATABRICKS_WAREHOUSE_ID:-<not set — tests will skip>}"
+echo ""
+
+"$PYTHON" -m pytest \
+  "$SCRIPT_DIR/tests/integration/" \
+  --integration \
+  -v \
+  "$@"

--- a/noom-mcp-server/tests/integration/conftest.py
+++ b/noom-mcp-server/tests/integration/conftest.py
@@ -1,0 +1,32 @@
+"""Fixtures for live Databricks integration tests."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def warehouse_id() -> str:
+    """SQL warehouse to run test queries against.
+
+    Set DATABRICKS_WAREHOUSE_ID in your environment before running.
+    """
+    wh = os.environ.get("DATABRICKS_WAREHOUSE_ID")
+    if not wh:
+        pytest.skip("Set DATABRICKS_WAREHOUSE_ID to run integration tests")
+    return wh
+
+
+@pytest.fixture(scope="session")
+def patches_applied() -> None:
+    """Apply all Noom governance patches once for the integration test session.
+
+    This also validates:
+    - The upstream version pin (UpstreamChangedError if mismatched)
+    - PAT rejection (RuntimeError if the calling user authenticated with a PAT)
+
+    So the test session itself only succeeds under valid OAuth credentials.
+    """
+    from noom_mcp.patches import apply_all_patches
+
+    apply_all_patches()

--- a/noom-mcp-server/tests/integration/test_live_sql.py
+++ b/noom-mcp-server/tests/integration/test_live_sql.py
@@ -1,0 +1,66 @@
+"""Live SQL integration test.
+
+Verifies that the SP client override is actually in effect by running
+SELECT current_user() and asserting the result is the SP's identity,
+not the calling user's identity.
+
+Run with:
+    pytest tests/integration/ --integration -v
+
+Required environment variables
+-------------------------------
+DATABRICKS_HOST             Calling user's workspace (for OAuth + PAT check)
+DATABRICKS_WAREHOUSE_ID     SQL warehouse to run queries against
+
+Calling user auth (OAuth — PAT is rejected by the patch):
+    Browser: run 'databricks auth login' beforehand, no env vars needed
+    M2M:     set DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET
+
+SQL SP credentials (one of):
+    DATABRICKS_MCP_SECRET_SCOPE              Databricks secret scope with SP creds
+    DATABRICKS_MCP_SQL_CLIENT_ID +           Direct env vars (dev/CI fallback)
+      DATABRICKS_MCP_SQL_CLIENT_SECRET
+
+    DATABRICKS_MCP_SQL_HOST                  Workspace for SQL execution
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+def test_sql_runs_as_sp_not_calling_user(patches_applied) -> None:
+    """SELECT current_user() must return the SP identity, not the calling user.
+
+    This is the core assertion for the SP client override patch:
+    if patching is in effect, all SQL runs as the pre-configured Service
+    Principal regardless of who the MCP client is authenticated as.
+
+    The warehouse ID is injected by the patch (from DATABRICKS_WAREHOUSE_ID)
+    so no warehouse_id fixture is needed here.
+    """
+    from databricks_tools_core.auth import get_current_username
+    from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+
+    # get_current_username() uses the end user's OAuth client (DATABRICKS_HOST),
+    # which the patch does NOT replace — it only overrides the client inside
+    # SQLExecutor.  So this returns the human user's identity (e.g. bei@noom.com).
+    calling_user = get_current_username()
+
+    # SQLExecutor.__init__ is patched to use the SP client and the configured
+    # warehouse — whatever arguments we pass here are overridden at runtime.
+    executor = SQLExecutor(warehouse_id="any")
+
+    # current_user() in SQL reflects who executed the query on Databricks.
+    # If the SP override is in effect, this returns the SP's identity, not
+    # the calling user's — which is what the assertion below verifies.
+    rows = executor.execute("SELECT current_user() AS running_as")
+
+    assert rows, "Query returned no rows"
+    running_as = rows[0]["running_as"]
+    assert running_as, "current_user() returned an empty value"
+
+    assert running_as != calling_user, (
+        f"SQL executed as the calling user ({calling_user!r}) instead of the SP.\n"
+        f"  current_user() = {running_as!r}\n"
+        "The SP client override patch does not appear to be in effect."
+    )

--- a/noom-mcp-server/tests/test_auth_guard_patch.py
+++ b/noom-mcp-server/tests/test_auth_guard_patch.py
@@ -1,0 +1,64 @@
+"""Unit tests for noom_mcp.auth_guard_patch.
+
+get_workspace_client is imported lazily inside check_pat_rejected, so
+patch at the source module:
+  - databricks_tools_core.auth.get_workspace_client
+"""
+
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCheckPatRejected:
+    def _mock_client(self, auth_type: Optional[str]) -> MagicMock:
+        client = MagicMock()
+        client.config.auth_type = auth_type
+        client.current_user.me.return_value = MagicMock(user_name="test@noom.com")
+        return client
+
+    def test_pat_raises_runtime_error(self):
+        """PAT auth_type triggers RuntimeError with clear message."""
+        from noom_mcp.auth_guard_patch import check_pat_rejected
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=self._mock_client("pat"),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                check_pat_rejected()
+            assert "PAT authentication is not permitted" in str(exc_info.value)
+
+    def test_oauth_browser_passes(self):
+        """databricks-cli (browser OAuth) is accepted."""
+        from noom_mcp.auth_guard_patch import check_pat_rejected
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=self._mock_client("databricks-cli"),
+        ):
+            check_pat_rejected()  # must not raise
+
+    def test_oauth_m2m_passes(self):
+        """oauth-m2m is accepted."""
+        from noom_mcp.auth_guard_patch import check_pat_rejected
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=self._mock_client("oauth-m2m"),
+        ):
+            check_pat_rejected()  # must not raise
+
+    def test_api_failure_propagates(self):
+        """SDK errors during the auth check re-raise so the server won't start."""
+        from noom_mcp.auth_guard_patch import check_pat_rejected
+
+        mock_client = MagicMock()
+        mock_client.current_user.me.side_effect = Exception("network error")
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=mock_client,
+        ):
+            with pytest.raises(Exception, match="network error"):
+                check_pat_rejected()

--- a/noom-mcp-server/tests/test_sql_executor_patch.py
+++ b/noom-mcp-server/tests/test_sql_executor_patch.py
@@ -1,0 +1,433 @@
+"""Unit tests for noom_mcp.sql_executor_patch.
+
+All tests mock Databricks SDK calls so no live workspace is needed.
+The SQLExecutor class-level patches are restored after each test that
+applies them, so tests are fully isolated.
+
+Patching strategy
+-----------------
+sql_executor_patch.py imports helpers lazily inside functions.  This means
+``patch("noom_mcp.sql_executor_patch.X")`` only works for names that are
+defined at module level (e.g. ``get_sql_sp_client``, ``get_mcp_user_identity``,
+``_fetch_sp_credentials_from_secrets``).
+
+For names imported inside functions, patch at the source module instead:
+  - databricks_tools_core.auth.get_workspace_client
+  - databricks_tools_core.auth.get_current_username
+  - databricks_tools_core.identity.tag_client
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_sp_client_cache() -> None:
+    """Reset the process-level SP client cache between tests."""
+    import noom_mcp.sql_executor_patch as m
+
+    m._sql_sp_client = None
+
+
+def _save_executor_methods() -> tuple:
+    """Return current (orig_init, orig_execute) for later restoration."""
+    from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+
+    return SQLExecutor.__init__, SQLExecutor.execute
+
+
+def _restore_executor_methods(orig_init, orig_execute) -> None:
+    from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+
+    SQLExecutor.__init__ = orig_init
+    SQLExecutor.execute = orig_execute
+
+
+# ---------------------------------------------------------------------------
+# get_mcp_user_identity
+# ---------------------------------------------------------------------------
+
+
+class TestGetMcpUserIdentity:
+    def test_returns_username_when_available(self):
+        """Email address is preferred when get_current_username() resolves."""
+        with patch(
+            "databricks_tools_core.auth.get_current_username",
+            return_value="alice@noom.com",
+        ):
+            from noom_mcp.sql_executor_patch import get_mcp_user_identity
+
+            assert get_mcp_user_identity() == "alice@noom.com"
+
+    def test_falls_back_to_sp_client_id(self, monkeypatch):
+        """sp:<client_id> returned when username is None but CLIENT_ID is set."""
+        monkeypatch.setenv("DATABRICKS_CLIENT_ID", "my-sp-id")
+        with patch(
+            "databricks_tools_core.auth.get_current_username",
+            return_value=None,
+        ):
+            from noom_mcp.sql_executor_patch import get_mcp_user_identity
+
+            assert get_mcp_user_identity() == "sp:my-sp-id"
+
+    def test_falls_back_to_unknown(self, monkeypatch):
+        """'unknown' when both username and CLIENT_ID are absent."""
+        monkeypatch.delenv("DATABRICKS_CLIENT_ID", raising=False)
+        with patch(
+            "databricks_tools_core.auth.get_current_username",
+            return_value=None,
+        ):
+            from noom_mcp.sql_executor_patch import get_mcp_user_identity
+
+            assert get_mcp_user_identity() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# patch_sql_executor: SP client injection
+# ---------------------------------------------------------------------------
+
+
+class TestPatchSqlExecutorWarehouseId:
+    @pytest.fixture(autouse=True)
+    def isolate(self):
+        orig = _save_executor_methods()
+        yield
+        _restore_executor_methods(*orig)
+        _reset_sp_client_cache()
+
+    def test_patched_init_uses_configured_warehouse(self):
+        """After patching, SQLExecutor always uses the configured warehouse ID."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        mock_sp = MagicMock()
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=mock_sp), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"):
+            patch_sql_executor()
+            executor = SQLExecutor.__new__(SQLExecutor)
+            SQLExecutor.__init__(executor, "wh-caller-supplied", client=None)
+            assert executor.warehouse_id == "wh-prod"
+
+    def test_patched_init_ignores_caller_supplied_warehouse(self):
+        """Configured warehouse overrides whatever warehouse the AI passes in."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        mock_sp = MagicMock()
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=mock_sp), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"):
+            patch_sql_executor()
+            executor = SQLExecutor.__new__(SQLExecutor)
+            SQLExecutor.__init__(executor, "wh-some-random-id", client=None)
+            assert executor.warehouse_id == "wh-prod"
+            assert executor.warehouse_id != "wh-some-random-id"
+
+    def test_get_sql_warehouse_id_reads_env(self, monkeypatch):
+        """get_sql_warehouse_id returns the env var value."""
+        monkeypatch.setenv("DATABRICKS_WAREHOUSE_ID", "wh-abc123")
+        from noom_mcp.sql_executor_patch import get_sql_warehouse_id
+        assert get_sql_warehouse_id() == "wh-abc123"
+
+    def test_get_sql_warehouse_id_raises_when_unset(self, monkeypatch):
+        """get_sql_warehouse_id raises RuntimeError when env var is missing."""
+        monkeypatch.delenv("DATABRICKS_WAREHOUSE_ID", raising=False)
+        from noom_mcp.sql_executor_patch import get_sql_warehouse_id
+        with pytest.raises(RuntimeError, match="DATABRICKS_WAREHOUSE_ID is not set"):
+            get_sql_warehouse_id()
+
+
+class TestPatchSqlExecutorSpClient:
+    @pytest.fixture(autouse=True)
+    def isolate(self):
+        orig = _save_executor_methods()
+        yield
+        _restore_executor_methods(*orig)
+        _reset_sp_client_cache()
+
+    def test_patched_init_uses_sp_client(self):
+        """After patching, SQLExecutor always uses the SP client."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        mock_sp = MagicMock()
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=mock_sp), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"):
+            patch_sql_executor()
+            executor = SQLExecutor.__new__(SQLExecutor)
+            SQLExecutor.__init__(executor, "wh-123", client=None)
+            assert executor.client is mock_sp
+
+    def test_patched_init_ignores_caller_supplied_client(self):
+        """SP client overrides any client the caller passes in."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        caller_client = MagicMock(name="caller_client")
+        sp_client = MagicMock(name="sp_client")
+
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=sp_client), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"):
+            patch_sql_executor()
+            executor = SQLExecutor.__new__(SQLExecutor)
+            SQLExecutor.__init__(executor, "wh-123", client=caller_client)
+            assert executor.client is sp_client
+            assert executor.client is not caller_client
+
+
+# ---------------------------------------------------------------------------
+# patch_sql_executor: user identity tagging
+# ---------------------------------------------------------------------------
+
+
+class TestPatchSqlExecutorIdentityTagging:
+    @pytest.fixture(autouse=True)
+    def isolate(self):
+        orig = _save_executor_methods()
+        yield
+        _restore_executor_methods(*orig)
+        _reset_sp_client_cache()
+
+    def test_user_tag_injected_when_no_existing_tags(self):
+        """mcp_user:<identity> is the sole tag when query_tags is None."""
+        identity = "alice@noom.com"
+        query_tags = None
+        user_tag = f"mcp_user:{identity}"
+        effective = f"{query_tags},{user_tag}" if query_tags else user_tag
+        assert effective == "mcp_user:alice@noom.com"
+
+    def test_user_tag_appended_to_existing_tags(self):
+        """mcp_user tag is appended after existing tags with comma separator."""
+        identity = "alice@noom.com"
+        existing = "team:eng,cost_center:701"
+        user_tag = f"mcp_user:{identity}"
+        effective = f"{existing},{user_tag}" if existing else user_tag
+        assert effective == "team:eng,cost_center:701,mcp_user:alice@noom.com"
+
+    def test_sp_identity_tagged_for_m2m_caller(self):
+        """sp:<client_id> format used when caller is a service principal."""
+        assert "mcp_user:sp:my-client-id" == "mcp_user:sp:my-client-id"
+
+    def test_unknown_identity_tagged_gracefully(self):
+        """'unknown' identity still produces a valid tag."""
+        assert "mcp_user:unknown" == "mcp_user:unknown"
+
+    def test_patched_execute_injects_tag_and_calls_through(self):
+        """End-to-end: patched execute injects tag and calls original."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        received: dict = {}
+        mock_sp = MagicMock()
+
+        # Install a recording spy as the "original" before applying the patch.
+        def _spy(
+            self, sql_query, catalog=None, schema=None,
+            row_limit=None, timeout=180, query_tags=None,
+        ):
+            received["query_tags"] = query_tags
+            received["sql_query"] = sql_query
+            return []
+
+        SQLExecutor.execute = _spy
+
+        # Keep mocks active for the actual call — get_mcp_user_identity is
+        # resolved at call time, not at patch-install time.
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=mock_sp), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"), \
+             patch("noom_mcp.sql_executor_patch.get_mcp_user_identity", return_value="bob@noom.com"):
+            patch_sql_executor()
+
+            executor = SQLExecutor.__new__(SQLExecutor)
+            executor.warehouse_id = "wh-1"
+            executor.client = mock_sp
+            SQLExecutor.execute(executor, "SELECT 1", query_tags="team:data")
+
+        assert received["sql_query"] == "SELECT 1"
+        assert received["query_tags"] == "team:data,mcp_user:bob@noom.com"
+
+    def test_patched_execute_no_existing_tags(self):
+        """Patched execute produces only the mcp_user tag when none given."""
+        from databricks_tools_core.sql.sql_utils.executor import SQLExecutor
+        from noom_mcp.sql_executor_patch import patch_sql_executor
+
+        received: dict = {}
+        mock_sp = MagicMock()
+
+        def _spy(
+            self, sql_query, catalog=None, schema=None,
+            row_limit=None, timeout=180, query_tags=None,
+        ):
+            received["query_tags"] = query_tags
+            return []
+
+        SQLExecutor.execute = _spy
+
+        with patch("noom_mcp.sql_executor_patch.get_sql_sp_client", return_value=mock_sp), \
+             patch("noom_mcp.sql_executor_patch.get_sql_warehouse_id", return_value="wh-prod"), \
+             patch("noom_mcp.sql_executor_patch.get_mcp_user_identity", return_value="carol@noom.com"):
+            patch_sql_executor()
+
+            executor = SQLExecutor.__new__(SQLExecutor)
+            executor.warehouse_id = "wh-1"
+            executor.client = mock_sp
+            SQLExecutor.execute(executor, "SELECT 2")
+
+        assert received["query_tags"] == "mcp_user:carol@noom.com"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_sp_credentials_from_secrets
+# ---------------------------------------------------------------------------
+
+
+class TestFetchSpCredentialsFromSecrets:
+    def _secret_response(self, plaintext: str) -> MagicMock:
+        import base64
+
+        resp = MagicMock()
+        resp.value = base64.b64encode(plaintext.encode()).decode()
+        return resp
+
+    def test_returns_decoded_credentials(self, monkeypatch):
+        """Credentials are base64-decoded and returned as (client_id, secret)."""
+
+        mock_client = MagicMock()
+        mock_client.secrets.get_secret.side_effect = [
+            self._secret_response("my-client-id"),
+            self._secret_response("my-client-secret"),
+        ]
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=mock_client,
+        ):
+            from noom_mcp.sql_executor_patch import _fetch_sp_credentials_from_secrets
+
+            client_id, client_secret = _fetch_sp_credentials_from_secrets()
+
+        assert client_id == "my-client-id"
+        assert client_secret == "my-client-secret"
+
+    def test_uses_fixed_key_names(self, monkeypatch):
+        """Fixed keys sql-sp-client-id and sql-sp-client-secret are always used."""
+
+        mock_client = MagicMock()
+        mock_client.secrets.get_secret.side_effect = [
+            self._secret_response("id"),
+            self._secret_response("secret"),
+        ]
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=mock_client,
+        ):
+            from noom_mcp.sql_executor_patch import _fetch_sp_credentials_from_secrets
+
+            _fetch_sp_credentials_from_secrets()
+
+        calls = mock_client.secrets.get_secret.call_args_list
+        assert calls[0] == call(scope="dbrix_mcp_secret", key="sql-sp-client-id")
+        assert calls[1] == call(scope="dbrix_mcp_secret", key="sql-sp-client-secret")
+
+    def test_sdk_error_raises_runtime_error(self, monkeypatch):
+        """SDK failure fetching a secret raises RuntimeError with context."""
+
+        mock_client = MagicMock()
+        mock_client.secrets.get_secret.side_effect = Exception("permission denied")
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=mock_client,
+        ):
+            from noom_mcp.sql_executor_patch import _fetch_sp_credentials_from_secrets
+
+            with pytest.raises(RuntimeError, match="Failed to fetch secret"):
+                _fetch_sp_credentials_from_secrets()
+
+    def test_empty_secret_raises_runtime_error(self, monkeypatch):
+        """Empty secret value raises RuntimeError."""
+
+        mock_client = MagicMock()
+        empty = MagicMock()
+        empty.value = None
+        mock_client.secrets.get_secret.return_value = empty
+
+        with patch(
+            "databricks_tools_core.auth.get_workspace_client",
+            return_value=mock_client,
+        ):
+            from noom_mcp.sql_executor_patch import _fetch_sp_credentials_from_secrets
+
+            with pytest.raises(RuntimeError, match="is empty"):
+                _fetch_sp_credentials_from_secrets()
+
+
+# ---------------------------------------------------------------------------
+# _build_sql_sp_client: credential resolution order
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSqlSpClient:
+    @pytest.fixture(autouse=True)
+    def reset_cache(self):
+        yield
+        _reset_sp_client_cache()
+
+    def test_uses_secrets_by_default(self, monkeypatch):
+        """Secrets are used when DATABRICKS_MCP_SQL_CLIENT_ID is not set."""
+        monkeypatch.delenv("DATABRICKS_MCP_SQL_CLIENT_ID", raising=False)
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_HOST", "https://noom-prod.cloud.databricks.com")
+
+        with patch(
+            "noom_mcp.sql_executor_patch._fetch_sp_credentials_from_secrets",
+            return_value=("secrets-id", "secrets-secret"),
+        ) as mock_fetch, \
+             patch("databricks_tools_core.identity.tag_client", side_effect=lambda c: c), \
+             patch("databricks.sdk.WorkspaceClient", return_value=MagicMock()):
+            from noom_mcp.sql_executor_patch import _build_sql_sp_client
+
+            _build_sql_sp_client()
+            mock_fetch.assert_called_once()
+
+    def test_env_vars_override_secrets(self, monkeypatch):
+        """Env vars are used as a dev/CI override when CLIENT_ID is set."""
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_CLIENT_ID", "env-id")
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_CLIENT_SECRET", "env-secret")
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_HOST", "https://noom-prod.cloud.databricks.com")
+
+        with patch(
+            "noom_mcp.sql_executor_patch._fetch_sp_credentials_from_secrets",
+        ) as mock_fetch, \
+             patch("databricks_tools_core.identity.tag_client", side_effect=lambda c: c), \
+             patch("databricks.sdk.WorkspaceClient", return_value=MagicMock()):
+            from noom_mcp.sql_executor_patch import _build_sql_sp_client
+
+            _build_sql_sp_client()
+            mock_fetch.assert_not_called()
+
+    def test_raises_when_client_id_set_but_secret_missing(self, monkeypatch):
+        """RuntimeError when CLIENT_ID is set but CLIENT_SECRET is missing."""
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_CLIENT_ID", "env-id")
+        monkeypatch.delenv("DATABRICKS_MCP_SQL_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_HOST", "https://noom-prod.cloud.databricks.com")
+
+        from noom_mcp.sql_executor_patch import _build_sql_sp_client
+
+        with pytest.raises(RuntimeError, match="DATABRICKS_MCP_SQL_CLIENT_SECRET is missing"):
+            _build_sql_sp_client()
+
+    def test_raises_when_host_not_configured(self, monkeypatch):
+        """RuntimeError when DATABRICKS_MCP_SQL_HOST is not set."""
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_CLIENT_ID", "env-id")
+        monkeypatch.setenv("DATABRICKS_MCP_SQL_CLIENT_SECRET", "env-secret")
+        monkeypatch.delenv("DATABRICKS_MCP_SQL_HOST", raising=False)
+
+        from noom_mcp.sql_executor_patch import _build_sql_sp_client
+
+        with pytest.raises(RuntimeError, match="DATABRICKS_MCP_SQL_HOST is not set"):
+            _build_sql_sp_client()

--- a/noom-mcp-server/tests/test_version_check.py
+++ b/noom-mcp-server/tests/test_version_check.py
@@ -1,0 +1,28 @@
+"""Unit tests for noom_mcp.version_check."""
+
+import pytest
+
+
+class TestCheckUpstreamVersion:
+    def test_happy_path(self):
+        """Current installed version matches the pin — no error."""
+        from noom_mcp.version_check import check_upstream_version
+
+        check_upstream_version()  # must not raise
+
+    def test_version_mismatch_raises(self):
+        """Stale pin triggers UpstreamChangedError with actionable message."""
+        import noom_mcp.version_check as m
+        from noom_mcp.version_check import UpstreamChangedError, check_upstream_version
+
+        original = m.PATCHED_UPSTREAM_VERSION
+        m.PATCHED_UPSTREAM_VERSION = "0.0.0"
+        try:
+            with pytest.raises(UpstreamChangedError) as exc_info:
+                check_upstream_version()
+            msg = str(exc_info.value)
+            assert "version mismatch" in msg.lower()
+            assert "0.0.0" in msg
+            assert "PATCHED_UPSTREAM_VERSION" in msg
+        finally:
+            m.PATCHED_UPSTREAM_VERSION = original


### PR DESCRIPTION
## Summary

Adds `noom-mcp-server/` — a thin extension layer over the upstream `databricks-mcp-server` that applies Noom SQL governance controls at startup without modifying any upstream files.

### Governance controls
- **PAT rejection** — startup fails if the user authenticated with a PAT;
  only OAuth (browser or M2M) is permitted
- **SQL SP override** — all SQL runs as a pre-configured Service Principal
  (credentials from `dbrix_mcp_secret` Databricks secret scope), not the calling user
- **Warehouse override** — `DATABRICKS_WAREHOUSE_ID` is injected into every
  `SQLExecutor` call; the AI cannot direct SQL to an arbitrary warehouse
- **User identity tagging** — `mcp_user:<email>` appended to `query_tags`
  on every SQL statement for audit and cost attribution in `system.query.history`
- **Upstream version pin** — fails fast if the installed upstream version
  doesn't match `PATCHED_UPSTREAM_VERSION`

### Mechanism

Class-level patching of `SQLExecutor.__init__` and `.execute`.
No files inside `databricks-mcp-server/` or `databricks-tools-core/` are modified.

### Getting started

```bash
cp noom-mcp-server/.env.example noom-mcp-server/.env
# fill in DATABRICKS_HOST and confirm the other values
databricks auth login --host https://noom-prod.cloud.databricks.com
python noom-mcp-server/run.py