### PR TITLE
docs: add macOS workaround for killed install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ _Note: Project configuration files can be re-used in other projects. You find th
 bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh)
 ```
 
+> **macOS note:** If the process-substitution form above is killed by the shell (e.g. `zsh: killed bash`), download the script first and then run it:
+>
+> ```bash
+> curl -L https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh -o install.sh
+> chmod +x install.sh
+> ./install.sh
+> ```
+
 <details>
 <summary><strong>Advanced Options</strong> (click to expand)</summary>
 

--- a/README.md
+++ b/README.md
@@ -131,16 +131,18 @@ _Note: Project configuration files can be re-used in other projects. You find th
 bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh)
 ```
 
-> **macOS note:** If the process-substitution form above is killed by the shell (e.g. `zsh: killed bash`), download the script first and then run it:
->
-> ```bash
-> curl -L https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh -o install.sh
-> chmod +x install.sh
-> ./install.sh
-> ```
-
 <details>
 <summary><strong>Advanced Options</strong> (click to expand)</summary>
+
+**macOS workaround if the install command is killed**
+
+If the process-substitution form above is killed by the shell (e.g. `zsh: killed bash`), download the script first and then run it:
+
+```bash
+curl -L https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh -o install.sh
+chmod +x install.sh
+./install.sh
+```
 
 **Global installation with force reinstall**
 


### PR DESCRIPTION
## Summary
- Some macOS users (myself included) see the one-liner installer get killed by the shell:
  ```
  $ bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh)
  zsh: killed     bash
  ```
- Adds a short README note under the Mac / Linux basic install pointing users to a download-then-execute fallback that avoids process substitution.

## Test plan
- [ ] Render README on GitHub and confirm the note appears under the basic install snippet.
- [ ] Verify the fallback commands work end-to-end on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)