### PR TITLE
databricks-skills(install_genie_code_skills): add databricks-agent-skills as upstream source

### DIFF
--- a/databricks-skills/install_genie_code_skills.py
+++ b/databricks-skills/install_genie_code_skills.py
@@ -49,6 +49,15 @@ from databricks.sdk.service.workspace import ImportFormat
 # Skills are auto-discovered: any subdirectory containing SKILL.md is a skill.
 
 SKILL_SOURCES = [
+    # databricks-agent-skills (DAS) is the canonical upstream. `skills/` holds
+    # stable, reviewed skills (including AppKit-aware `databricks-apps`);
+    # `experimental/` holds the verbatim a-d-k snapshot. Listed first so that on
+    # name collision DAS wins over the (deprecated) a-d-k source below.
+    {"owner": "databricks",           "repo": "databricks-agent-skills", "path": "skills"},
+    {"owner": "databricks",           "repo": "databricks-agent-skills", "path": "experimental"},
+    # ai-dev-kit is deprecated; DAS `experimental/` is a snapshot of this tree.
+    # Kept here until DAS-sync is verified end-to-end against Genie Code, then
+    # this entry can be removed.
     {"owner": "databricks-solutions", "repo": "ai-dev-kit", "path": "databricks-skills",
      "skip": {"TEMPLATE"}},
     {"owner": "mlflow",               "repo": "skills",      "path": ""},


### PR DESCRIPTION
## Summary

Adds two `SKILL_SOURCES` entries pointing at `databricks/databricks-agent-skills` (DAS) — the canonical upstream for Databricks skills:

- **`skills/`** — stable, reviewed skills. Includes AppKit-aware `databricks-apps`, plus `databricks-core`, `databricks-dabs`, `databricks-jobs`, `databricks-lakebase`, `databricks-model-serving`, `databricks-pipelines`, `databricks-serverless-migration`.
- **`experimental/`** — verbatim a-d-k snapshot now hosted in DAS.

## Why

`install_genie_code_skills.py` is the path by which Genie Code users get their `.assistant/skills/` populated. Today it only pulls from a-d-k, `mlflow/skills`, and `databricks-solutions/apx` — so customers running Genie Code never see DAS's `databricks-apps` skill (the canonical AppKit-aware one) nor any of the other reviewed stable skills.

a-d-k is deprecated overall, but the installer lives here and DAS doesn't yet ship a `databricks aitools install --target genie-code` equivalent, so this is the right place to land the fix.

## Caveats

- DAS entries are listed **first** so DAS wins on skill-name collision.
- The a-d-k entry is kept (with a deprecation comment) until DAS-sync is verified end-to-end against Genie Code. Once that's confirmed, the a-d-k entry can come out — DAS `experimental/` is functionally the same snapshot, so the duplicate only matters during the verification window.

## Test plan

- [x] `python -m py_compile databricks-skills/install_genie_code_skills.py` clean.
- [ ] Manual: run the notebook end-to-end against a Databricks workspace and confirm `databricks-apps` and the other DAS stable skills land in `/Workspace/Users/{me}/.assistant/skills/`.

## Companion PR

Same change on the `experimental` branch: #553.

This pull request and its description were written by Claude.