### PR TITLE
databricks-skills(install_genie_code_skills): add databricks-agent-skills as upstream source (experimental branch)

### DIFF
--- a/databricks-skills/install_genie_code_skills.py
+++ b/databricks-skills/install_genie_code_skills.py
@@ -49,6 +49,15 @@ from databricks.sdk.service.workspace import ImportFormat
 # Skills are auto-discovered: any subdirectory containing SKILL.md is a skill.
 
 SKILL_SOURCES = [
+    # databricks-agent-skills (DAS) is the canonical upstream. `skills/` holds
+    # stable, reviewed skills (including AppKit-aware `databricks-apps`);
+    # `experimental/` holds the verbatim a-d-k snapshot. Listed first so that on
+    # name collision DAS wins over the (deprecated) a-d-k source below.
+    {"owner": "databricks",           "repo": "databricks-agent-skills", "path": "skills"},
+    {"owner": "databricks",           "repo": "databricks-agent-skills", "path": "experimental"},
+    # ai-dev-kit is deprecated; DAS `experimental/` is a snapshot of this tree.
+    # Kept here until DAS-sync is verified end-to-end against Genie Code, then
+    # this entry can be removed.
     {"owner": "databricks-solutions", "repo": "ai-dev-kit", "path": "databricks-skills",
      "skip": {"TEMPLATE"}},
     {"owner": "mlflow",               "repo": "skills",      "path": ""},


### PR DESCRIPTION
## Summary

Same change as #552 (against `main`), applied to the `experimental` branch so the installer stays in lock-step with whichever branch Genie Code ramps against.

Adds two `SKILL_SOURCES` entries pointing at `databricks/databricks-agent-skills` (DAS) — the canonical upstream for Databricks skills:

- **`skills/`** — stable, reviewed (AppKit-aware `databricks-apps`, plus 7 others).
- **`experimental/`** — verbatim a-d-k snapshot now hosted in DAS.

See #552 for full rationale, caveats, and test plan — this PR is the mirror so both branches carry the fix.

## Test plan

- [x] `python -m py_compile databricks-skills/install_genie_code_skills.py` clean.
- [ ] Manual: run the notebook end-to-end against a Databricks workspace and confirm `databricks-apps` lands in `/Workspace/Users/{me}/.assistant/skills/`.

This pull request and its description were written by Claude.