### PR TITLE
Dashboard skill: widget index + dataset measures + new widgets + forecast partial-bucket fix

### DIFF
--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -70,32 +70,71 @@ Core widget types for AI/BI dashboards. For advanced visualizations (area, scatt
 
 ## Counter (KPI)
 
-- `version`: **2** (NOT 3!)
+- `version`: **2** (current — confirmed against latest dashboard examples; NOT 3)
 - `widgetType`: "counter"
 - Percent values must be 0-1 in the data (not 0-100)
 
-### Number Formatting
+**Two strongly-recommended defaults:**
 
-```json
-"encodings": {
-  "value": {
-    "fieldName": "revenue",
-    "displayName": "Total Revenue",
-    "format": {
-      "type": "number-currency",
-      "currencyCode": "USD",
-      "abbreviation": "compact",
-      "decimalPlaces": {"type": "max", "places": 2}
-    }
-  }
-}
-```
-
-Format types: `number`, `number-currency`, `number-percent`
+1. **Add a sparkline** (`period` encoding) when the dataset has a temporal column. A bare number is context-free; the small trend line behind the value tells the user "rising / falling / flat" at a glance. Skip it only if the KPI is truly time-invariant (snapshot count with no historical column available).
+   > For the sparkline to render, the dataset query must **keep the temporal dimension** — i.e., return one row per period (`GROUP BY DATE_TRUNC(...)`), not a single fully-aggregated row. The counter's `value` then re-aggregates those rows; the `period` field drives the line behind it.
+2. **Set a `format`** when the value has a unit — dollars, percent, large counts. "Revenue: 1287394.55" without `number-currency` formatting reads as noise. The only counters where `format` is fine to omit are unit-less small counts (e.g., "Open Tickets: 12") where the raw integer is already legible. See "Value formatting" below.
 
 ### Counter Patterns
 
-**Pre-aggregated dataset (1 row)** - use `disaggregated: true`:
+**Multi-row dataset with aggregation — the recommended default (supports filters + sparkline)** — use `disaggregated: false`:
+- Dataset query returns one row per period (`GROUP BY DATE_TRUNC(...)`) — keeps the temporal dimension so the counter can both re-aggregate to the headline value AND render the sparkline.
+- **CRITICAL**: Field `name` MUST match `fieldName` exactly (e.g., `"sum(spend)"`).
+- Include the `period` field in `query.fields` AND the `period` encoding in the spec.
+
+```json
+{
+  "widget": {
+    "name": "weekly-spend",
+    "queries": [{
+      "name": "main_query",
+      "query": {
+        "datasetName": "spend_ds",
+        "fields": [
+          {"name": "sum(spend)",       "expression": "SUM(`spend`)"},
+          {"name": "weekly(spend_at)", "expression": "DATE_TRUNC(\"WEEK\", `spend_at`)"}
+        ],
+        "disaggregated": false
+      }
+    }],
+    "spec": {
+      "version": 2,
+      "widgetType": "counter",
+      "encodings": {
+        "value":  {
+          "fieldName": "sum(spend)",
+          "displayName": "Total Spend",
+          "format": {"type": "number-currency", "currencyCode": "USD",
+                     "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 2}}
+        },
+        "period": {"fieldName": "weekly(spend_at)"}
+      },
+      "frame": {"showTitle": true, "title": "Total Spend"}
+    }
+  },
+  "position": {"x": 0, "y": 0, "width": 4, "height": 3}
+}
+```
+
+Dataset SQL for the example above:
+
+```sql
+-- One row per week — the counter re-aggregates rows into the headline value
+-- AND uses the temporal column to draw the sparkline.
+SELECT DATE_TRUNC('WEEK', spend_at) AS spend_at, SUM(spend) AS spend
+FROM spend_table
+GROUP BY 1
+```
+
+> **`MEASURE()` works here too.** If the dataset defines measures via `dataset.columns[]` or is sourced from a metric view, use `{"expression": "MEASURE(\`Total Cases\`)"}` as the field expression — same pattern, no duplication. See SKILL.md "Dataset-level measures + MEASURE()".
+
+**Pre-aggregated dataset (1 row, no sparkline)** — use `disaggregated: true`. Fallback shape when the metric is truly time-invariant or the data is already collapsed and no temporal column is available:
+
 ```json
 {
   "widget": {
@@ -112,7 +151,12 @@ Format types: `number`, `number-currency`, `number-percent`
       "version": 2,
       "widgetType": "counter",
       "encodings": {
-        "value": {"fieldName": "revenue", "displayName": "Total Revenue"}
+        "value": {
+          "fieldName": "revenue",
+          "displayName": "Total Revenue",
+          "format": {"type": "number-currency", "currencyCode": "USD",
+                     "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 2}}
+        }
       },
       "frame": {"showTitle": true, "title": "Total Revenue"}
     }
@@ -121,50 +165,41 @@ Format types: `number`, `number-currency`, `number-percent`
 }
 ```
 
-**Multi-row dataset with aggregation (supports filters)** - use `disaggregated: false`:
-- Dataset returns multiple rows (e.g., grouped by a filter dimension)
-- Use `"disaggregated": false` and aggregation expression
-- **CRITICAL**: Field `name` MUST match `fieldName` exactly (e.g., `"sum(spend)"`)
+### Sparkline (period encoding)
+
+The `period` field must be a temporal expression also present in `query.fields` — typically a `DATE_TRUNC(...)` over the dataset's timestamp column. Granularity choices:
+
+| Use | Why |
+|---|---|
+| `DATE_TRUNC("DAY", col)` | Short window (1-4 weeks), high-frequency metric |
+| `DATE_TRUNC("WEEK", col)` | Standard default for ops metrics over a quarter |
+| `DATE_TRUNC("MONTH", col)` | Long window (>1 year) or low-volume metric |
+
+Match the sparkline grain to whatever the surrounding charts use — consistent grain across the page makes the dashboard easier to read.
+
+### Value formatting
+
+Format types: `number`, `number-currency`, `number-percent`.
+
+| Field type | Format | Why |
+|---|---|---|
+| Money | `number-currency` + `currencyCode` + `abbreviation: "compact"` | "$1.2M" is readable, "1287394.55" isn't |
+| Percentage | `number-percent` (data must be 0-1) | Renders "12.5%" from 0.125 |
+| Large count | `number` + `abbreviation: "compact"` | Renders "1.5K" / "2.3M" |
+| Small count (under ~1K) | `number` (no abbreviation) or omit `format` | Raw integer is fine |
 
 ```json
-{
-  "widget": {
-    "name": "total-spend",
-    "queries": [{
-      "name": "main_query",
-      "query": {
-        "datasetName": "by_category",
-        "fields": [{"name": "sum(spend)", "expression": "SUM(`spend`)"}],
-        "disaggregated": false
-      }
-    }],
-    "spec": {
-      "version": 2,
-      "widgetType": "counter",
-      "encodings": {
-        "value": {"fieldName": "sum(spend)", "displayName": "Total Spend"}
-      },
-      "frame": {"showTitle": true, "title": "Total Spend"}
-    }
-  },
-  "position": {"x": 0, "y": 0, "width": 4, "height": 3}
+"value": {
+  "fieldName": "revenue",
+  "displayName": "Total Revenue",
+  "format": {
+    "type": "number-currency",
+    "currencyCode": "USD",
+    "abbreviation": "compact",
+    "decimalPlaces": {"type": "max", "places": 2}
+  }
 }
 ```
-
-> **`MEASURE()` works here too.** If the dataset defines measures via `dataset.columns[]` or is sourced from a metric view, use `{"expression": "MEASURE(\`Total Cases\`)"}` as the field expression — same pattern, no duplication. See SKILL.md "Dataset-level measures + MEASURE()".
-
-### Counter sparkline (background trend)
-
-Add a `period` encoding to draw a small time-series line behind the KPI value — gives context for whether the metric is rising or falling.
-
-```json
-"encodings": {
-  "value":  {"fieldName": "measure(Cases Open)", "displayName": "Total Cases"},
-  "period": {"fieldName": "weekly(opened_at)"}
-}
-```
-
-The `period` field must be a temporal expression also present in `query.fields` (e.g., `{"name": "weekly(opened_at)", "expression": "DATE_TRUNC(\"WEEK\", \`opened_at\`)"}`). Common granularities: `DATE_TRUNC("DAY"|"WEEK"|"MONTH", ...)`.
 
 ### Counter comparison (delta vs previous period)
 

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -487,7 +487,7 @@ Use `:param` syntax in SQL for dynamic filtering. Parameters can be bound to fil
 
 **Parameter types:**
 - Single value: `"dataType": "INTEGER"` / `"DECIMAL"` / `"STRING"`
-- Multi-select: Add `"complexType": "MULTI"`
+- Multi-select: `"complexType": "MULTI"` — binds as a SQL `ARRAY`, filter with `array_contains(:p, col)`, not `col IN (:p)`. Full pattern in [3-filters.md](3-filters.md#multi-select-parameters-multi).
 - Range: `"dataType": "DATE", "complexType": "RANGE"` - use `:param.min` / `:param.max`
 
 ---

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -423,9 +423,9 @@ Multiple annotations are allowed — add more objects to the array. For non-date
 
 - `version`: **3**
 - `widgetType`: "pie"
-- `angle`: quantitative field
-- `color`: categorical dimension
-- **Limit to 3-8 categories for readability**
+- **`angle` is REQUIRED** — quantitative field (the slice size). Omitting it produces an "Invalid widget definition" error; `color` alone is not enough.
+- **`color` is REQUIRED** — categorical dimension (the slice grouping).
+- **Limit to 3-8 categories for readability.**
 
 ```json
 "spec": {

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -70,7 +70,7 @@ Core widget types for AI/BI dashboards. For advanced visualizations (area, scatt
 
 ## Counter (KPI)
 
-- `version`: **2** (current — confirmed against latest dashboard examples; NOT 3)
+- `version`: **2** (NOT 3!)
 - `widgetType`: "counter"
 - Percent values must be 0-1 in the data (not 0-100)
 

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -151,6 +151,48 @@ Format types: `number`, `number-currency`, `number-percent`
 }
 ```
 
+> **`MEASURE()` works here too.** If the dataset defines measures via `dataset.columns[]` or is sourced from a metric view, use `{"expression": "MEASURE(\`Total Cases\`)"}` as the field expression — same pattern, no duplication. See SKILL.md "Dataset-level measures + MEASURE()".
+
+### Counter sparkline (background trend)
+
+Add a `period` encoding to draw a small time-series line behind the KPI value — gives context for whether the metric is rising or falling.
+
+```json
+"encodings": {
+  "value":  {"fieldName": "measure(Cases Open)", "displayName": "Total Cases"},
+  "period": {"fieldName": "weekly(opened_at)"}
+}
+```
+
+The `period` field must be a temporal expression also present in `query.fields` (e.g., `{"name": "weekly(opened_at)", "expression": "DATE_TRUNC(\"WEEK\", \`opened_at\`)"}`). Common granularities: `DATE_TRUNC("DAY"|"WEEK"|"MONTH", ...)`.
+
+### Counter comparison (delta vs previous period)
+
+Show the current value AND the change vs a previous period. Use a second field in `query.fields` whose expression filters/aggregates the comparison value, and reference it via the `target` encoding:
+
+```json
+"fields": [
+  {"name": "current",  "expression": "SUM(CASE WHEN week=:this_week THEN amount END)"},
+  {"name": "previous", "expression": "SUM(CASE WHEN week=:last_week THEN amount END)"}
+],
+"encodings": {
+  "value":  {"fieldName": "current",  "displayName": "This Week"},
+  "target": {"fieldName": "previous", "displayName": "vs Last Week"}
+}
+```
+
+### Counter format template (custom prefix/suffix text)
+
+Wrap the value with surrounding text. Use `{{@}}` for the raw value and `{{@formatted}}` for the formatted one. Reference other dataset fields with `{{FieldName}}`.
+
+```json
+"value": {
+  "fieldName": "sum(revenue)",
+  "format": {"type": "number-currency", "currencyCode": "USD", "abbreviation": "compact"},
+  "formatTemplate": "{{@formatted}} (in {{Region}})"
+}
+```
+
 ---
 
 ## Table
@@ -192,6 +234,40 @@ Format types: `number`, `number-currency`, `number-percent`
 }
 ```
 
+### Column-level options
+
+Each column object supports format, conditional styling, links, and tooltips. Common patterns:
+
+```json
+{
+  "fieldName": "amount",
+  "displayName": "Amount",
+  "format": {"type": "number-currency", "currencyCode": "USD",
+             "abbreviation": "compact", "decimalPlaces": {"type": "max", "places": 2}},
+
+  // Conditional background color (heat-map style)
+  "style": {
+    "type": "basic",
+    "rules": [
+      {"condition": {"operand": {"type": "data-value", "value": "10000"}, "operator": ">="},
+       "backgroundColor": {"themeColorType": "visualizationColors", "position": 4}},
+      {"condition": {"operand": {"type": "data-value", "value": "5000"},  "operator": ">="},
+       "backgroundColor": {"themeColorType": "visualizationColors", "position": 3}}
+    ]
+  },
+
+  // Make the cell a clickable link. {{@}} is the cell value, {{Field}} pulls another column.
+  "link": {"templatedURL": "/sql/dashboardsv3/{{@}}"},
+
+  // Hover tooltip
+  "tooltip": {"templatedText": "Customer ID: {{customer_id}}"}
+}
+```
+
+Other display types: `"image"` (renders base64 strings as images), `"html"` (sanitized HTML), `"json"` (collapsible JSON tree), `"color-scale"` (continuous color gradient on numeric values without explicit thresholds).
+
+> Same `style.rules` and `link`/`tooltip` patterns work on **pivot** cells — see pivot in [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md).
+
 ---
 
 ## Line / Bar Charts
@@ -227,6 +303,7 @@ Format types: `number`, `number-currency`, `number-percent`
 |------|---------------|
 | Stacked (default) | No `mark` field |
 | Grouped | `"mark": {"layout": "group"}` |
+| 100% stacked | `"mark": {"layout": "stack-100"}` |
 
 ### Horizontal Bar Chart
 
@@ -238,10 +315,66 @@ Swap `x` and `y` - put quantitative on `x`, categorical/temporal on `y`:
 }
 ```
 
-### Color Scale
+### Categorical sort with a custom order
 
-> **CRITICAL**: For bar/line/pie, color scale ONLY supports `type` and `sort`.
-> Do NOT use `scheme`, `colorRamp`, or `mappings` (only for choropleth-map).
+When the dimension has natural ordering that ASC/DESC won't capture (priority levels, weekdays, named tiers), pin the order explicitly:
+
+```json
+"x": {
+  "fieldName": "channel",
+  "scale": {
+    "type": "categorical",
+    "sort": {"by": "custom-order", "orderedValues": ["Chat", "Email", "In-App", "Phone"]}
+  }
+}
+```
+
+Other `sort.by` values: `"alphabetical"`, `"value"` (sort by the y measure), `"cell"` / `"cell-reversed"` (pivot only).
+
+### Color Scale + per-value mappings
+
+Default behaviour: theme colors are assigned to categories in order. To pin specific values (e.g., "Critical" must always be red), use `mappings`:
+
+```json
+"color": {
+  "fieldName": "Priority Level",
+  "scale": {
+    "type": "categorical",
+    "mappings": [
+      {"value": "1-Critical", "color": {"themeColorType": "visualizationColors", "position": 6}},
+      {"value": "4-Low",      "color": {"themeColorType": "visualizationColors", "position": 1}}
+    ]
+  }
+}
+```
+
+`themeColorType: "visualizationColors"` + `position: 1..N` selects from the dashboard's theme palette. For an exact hex, use `{"hex": "#FF0000"}` instead of `themeColorType`.
+
+> For continuous color ramps on quantitative encodings (e.g., choropleth, symbol-map, heatmap), use `colorRamp` — see [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md).
+
+### Annotations (event markers)
+
+Mark an event on a time-series chart — release, holiday, incident — with a vertical line. Works on `line`, `area`, `bar`, `combo`, and `forecast-line`.
+
+```json
+"spec": {
+  "version": 3,
+  "widgetType": "line",
+  "encodings": { /* ... x, y, color ... */ },
+  "annotations": [
+    {
+      "type": "vertical-line",
+      "encodings": {
+        "x":     {"dataValue": "2024-11-28T12:00:00.000", "dataType": "DATETIME"},
+        "label": {"value": "Thanksgiving"},
+        "color": {"value": {"themeColorType": "visualizationColors", "position": 3}}
+      }
+    }
+  ]
+}
+```
+
+Multiple annotations are allowed — add more objects to the array. For non-datetime axes, use `"dataType": "STRING"` or `"NUMBER"` and set `dataValue` accordingly.
 
 ---
 

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -131,6 +131,8 @@ FROM spend_table
 GROUP BY 1
 ```
 
+In this example the headline number is the **total spend across the trend window** (the counter's `SUM(spend)` re-aggregates the weekly rows), and the sparkline shows the **per-week values** that make up that total. If you instead want the headline to be the **latest week's spend** (not the cumulative total), expose it as its own column in the dataset SQL (e.g., `MAX_BY(spend, spend_at) AS latest_weekly_spend`) and point `value.fieldName` at that column, while keeping the period rows for the sparkline.
+
 > **`MEASURE()` works here too.** If the dataset defines measures via `dataset.columns[]` or is sourced from a metric view, use `{"expression": "MEASURE(\`Total Cases\`)"}` as the field expression — same pattern, no duplication. See SKILL.md "Dataset-level measures + MEASURE()".
 
 **Pre-aggregated dataset (1 row, no sparkline)** — use `disaggregated: true`. Fallback shape when the metric is truly time-invariant or the data is already collapsed and no temporal column is available:

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -315,6 +315,10 @@ Other display types: `"image"` (renders base64 strings as images), `"html"` (san
 - `scale.type`: `"temporal"` (dates), `"quantitative"` (numbers), `"categorical"` (strings)
 - Use `"disaggregated": true` with pre-aggregated dataset data
 
+> **Two recommended defaults for time-series charts:**
+> - **Mark meaningful events with an annotation.** A single `vertical-line` for a product launch, incident, holiday, or campaign turns a generic trend into a readable story. See [Annotations](#annotations-event-markers) below.
+> - **For trend lines on time-series data, consider `forecast-line` with `AI_FORECAST`** instead of a plain `line`. Projects future values + confidence bands and makes a dashboard noticeably more compelling for demos. See [forecast-line in 2-advanced-widget-specifications.md](2-advanced-widget-specifications.md#forecast-line-with-ai_forecast).
+
 **Multiple series - two approaches:**
 
 1. **Multi-Y Fields** (different metrics):

--- a/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/1-widget-specifications.md
@@ -423,7 +423,7 @@ Multiple annotations are allowed — add more objects to the array. For non-date
 
 - `version`: **3**
 - `widgetType`: "pie"
-- **`angle` is REQUIRED** — quantitative field (the slice size). Omitting it produces an "Invalid widget definition" error; `color` alone is not enough.
+- **`angle` is REQUIRED** — quantitative field (the slice size). Omitting it renders all slices the same size, which is meaningless: the pie no longer encodes any quantity.
 - **`color` is REQUIRED** — categorical dimension (the slice grouping).
 - **Limit to 3-8 categories for readability.**
 

--- a/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
@@ -313,7 +313,7 @@ Frequency distribution. The bin width is set in the **widget's field expression*
     "datasetName": "ds_cases",
     "fields": [
       {"name": "bin(time_to_resolution_hours, binWidth=2)",
-       "expression": "bin(`time_to_resolution_hours`, binWidth=2)"},
+       "expression": "BIN_FLOOR(`time_to_resolution_hours`, 2)"},
       {"name": "count(*)", "expression": "COUNT(`*`)"}
     ],
     "disaggregated": false
@@ -331,7 +331,7 @@ Frequency distribution. The bin width is set in the **widget's field expression*
 }
 ```
 
-`binWidth` is in the same units as the underlying column (hours, dollars, etc.). For a fixed bin count instead, use `bin(col, bins=N)`.
+The field `name` (and the widget's `fieldName`) is the readable `bin(col, binWidth=N)` label; the actual SQL expression is `BIN_FLOOR(\`col\`, N)`.
 
 ---
 

--- a/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
@@ -159,19 +159,339 @@ Displays geographic regions colored by aggregate values. Requires a field with g
 
 ---
 
-## Other Visualization Types
+## Forecast Line (with `AI_FORECAST`)
 
-The following visualization types are available in Databricks AI/BI dashboards but are less commonly used. Refer to [Databricks documentation](https://docs.databricks.com/aws/en/visualizations/visualization-types) for details:
+Overlays a model prediction on top of historical data — historical line continues into a future band with upper/lower confidence bounds.
 
-| Widget Type | Description |
+- `version`: **1**
+- `widgetType`: "forecast-line"
+- The dataset SQL produces the original series **plus** three forecast columns: a point forecast, upper band, lower band. Spark's built-in `AI_FORECAST` table function generates them.
+
+### Dataset SQL pattern
+
+> **Always exclude the current (in-progress) bucket from the historical series.** If you aggregate weekly and today is Tuesday, the current week's bucket is only 2 days of data — the line drops off a cliff right before the forecast starts. Filter with `WHERE bucket_start < DATE_TRUNC('<grain>', current_date())` using the **same grain as the aggregation**.
+
+```sql
+WITH original AS (
+  SELECT DATE_TRUNC('WEEK', opened_at) AS opened_at, COUNT(*) AS count
+  FROM support_cases
+  -- Drop the partial-elapsed bucket. Grain MUST match the DATE_TRUNC above —
+  -- weekly aggregation → exclude current week; monthly → exclude current month.
+  WHERE DATE_TRUNC('WEEK', opened_at) < DATE_TRUNC('WEEK', current_date())
+  GROUP BY 1
+),
+dates AS (
+  SELECT MAX(opened_at) AS max_d, MIN(opened_at) AS min_d FROM original
+),
+forecast AS (
+  SELECT opened_at, count_forecast, count_upper, count_lower, NULL AS count
+  FROM AI_FORECAST(
+    TABLE(original),
+    horizon   => (SELECT max_d + MAKE_DT_INTERVAL(
+                    CAST(FLOOR(DATEDIFF(max_d, min_d) * 0.5) AS INT), 0, 0, 0) FROM dates),
+    time_col  => 'opened_at',
+    value_col => 'count'
+  )
+)
+SELECT * FROM forecast
+UNION ALL
+SELECT opened_at, NULL, NULL, NULL, count FROM original
+```
+
+The `horizon` expression above projects forward 50% of the historical range. Tune the multiplier (0.5 → 1.0 for "predict as far as we've seen") to taste.
+
+**If you switch the aggregation grain, update both `DATE_TRUNC` calls.** They must match — a daily x-axis with a weekly cutoff filter would still show the cliff. Common pairings:
+
+| Aggregation `DATE_TRUNC` | Cutoff filter |
+|---|---|
+| `'DAY'` | `WHERE event_ts < DATE_TRUNC('DAY', current_timestamp())` — drops today |
+| `'WEEK'` | `WHERE DATE_TRUNC('WEEK', event_ts) < DATE_TRUNC('WEEK', current_date())` — drops current week |
+| `'MONTH'` | `WHERE DATE_TRUNC('MONTH', event_ts) < DATE_TRUNC('MONTH', current_date())` — drops current month |
+| `'QUARTER'` / `'YEAR'` | same shape with that grain |
+
+### Widget spec
+
+```json
+"spec": {
+  "version": 1,
+  "widgetType": "forecast-line",
+  "encodings": {
+    "x": {"fieldName": "opened_at", "scale": {"type": "temporal"}},
+    "y": {
+      "scale":           {"type": "quantitative"},
+      "original":        {"fieldName": "count",          "displayName": "Cases"},
+      "prediction":      {"fieldName": "count_forecast", "displayName": "Forecast"},
+      "predictionUpper": {"fieldName": "count_upper"},
+      "predictionLower": {"fieldName": "count_lower"}
+    }
+  },
+  "annotations": [ /* vertical-line for known events — same shape as in 1-widget */ ],
+  "frame": {"showTitle": true, "title": "Case Volume Forecast"}
+}
+```
+
+> Annotations (`vertical-line`) work on forecast-line — useful for marking known seasonal events (holidays, releases) inside both the historical window and the prediction band. Shape documented in [1-widget-specifications.md](1-widget-specifications.md#annotations-event-markers).
+
+---
+
+## Pivot
+
+A cross-tab — dimensions on rows AND columns, measures in cells. Supports per-cell conditional styling (heat-map-style).
+
+- `version`: **3**
+- `widgetType`: "pivot"
+- For multi-dimensional aggregations like "category × priority", supports drill-down totals, and is the right widget for cohort retention (see end of section).
+
+```json
+"spec": {
+  "version": 3,
+  "widgetType": "pivot",
+  "encodings": {
+    "rows": [
+      {"fieldName": "industry"},
+      {"fieldName": "customer_segment", "total": {"show": true}}
+    ],
+    "columns": [
+      {"fieldName": "category"},
+      {"fieldName": "Priority Level", "total": {"show": true}}
+    ],
+    "cell": {
+      "type": "multi-cell",
+      "fields": [
+        {
+          "fieldName": "count(*)",
+          "cellType": "text",
+          "style": {
+            "type": "basic",
+            "rules": [
+              {"condition": {"operand": {"type": "data-value", "value": "30"}, "operator": ">="},
+               "backgroundColor": {"themeColorType": "visualizationColors", "position": 4}},
+              {"condition": {"operand": {"type": "data-value", "value": "20"}, "operator": ">="},
+               "backgroundColor": {"themeColorType": "visualizationColors", "position": 3}},
+              {"condition": {"operand": {"type": "data-value", "value": "15"}, "operator": ">="},
+               "backgroundColor": {"themeColorType": "visualizationColors", "position": 1}}
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "frame": {"showTitle": true, "title": "Cases by Category × Priority"}
+}
+```
+
+For a **continuous color gradient** instead of explicit thresholds, set `cell.fields[].cellType: "color-scale"` and drop the `style.rules`. The gradient auto-fits to min/max in the cell values.
+
+**Sort by cell values** (e.g., put the highest-volume column first) — useful for cohort tables:
+```json
+"columns": [{
+  "fieldName": "category",
+  "scale": {"type": "categorical", "sort": {"by": "cell", "field": {"index": 0}}}
+}]
+```
+`"by": "cell-reversed"` flips the order. `field.index` picks which value field to sort by when there are multiple.
+
+> **Cohort retention charts** are built as a `pivot`. Rows = cohort date, columns = period offset (`0`, `1 year`, `2 years`…), cell = retention ratio with `cellType: "color-scale"`. There is no separate `cohort` widget type.
+
+---
+
+## Histogram
+
+Frequency distribution. The bin width is set in the **widget's field expression**, not in the dataset SQL.
+
+- `version`: **3**
+- `widgetType`: "histogram"
+
+```json
+"queries": [{
+  "name": "main_query",
+  "query": {
+    "datasetName": "ds_cases",
+    "fields": [
+      {"name": "bin(time_to_resolution_hours, binWidth=2)",
+       "expression": "bin(`time_to_resolution_hours`, binWidth=2)"},
+      {"name": "count(*)", "expression": "COUNT(`*`)"}
+    ],
+    "disaggregated": false
+  }
+}],
+"spec": {
+  "version": 3,
+  "widgetType": "histogram",
+  "encodings": {
+    "x": {"fieldName": "bin(time_to_resolution_hours, binWidth=2)",
+          "scale": {"type": "quantitative"}},
+    "y": {"fieldName": "count(*)", "scale": {"type": "quantitative"}}
+  },
+  "frame": {"showTitle": true, "title": "Resolution Time Distribution"}
+}
+```
+
+`binWidth` is in the same units as the underlying column (hours, dollars, etc.). For a fixed bin count instead, use `bin(col, bins=N)`.
+
+---
+
+## Sankey
+
+Flow between two or more stages. Each stage is a categorical field; the value is a quantitative aggregate.
+
+- `version`: **1**
+- `widgetType`: "sankey"
+
+```json
+"spec": {
+  "version": 1,
+  "widgetType": "sankey",
+  "encodings": {
+    "value":  {"fieldName": "count(*)"},
+    "stages": [
+      {"fieldName": "channel"},
+      {"fieldName": "reopened_flag", "displayName": "Reopened"}
+    ]
+  },
+  "frame": {"showTitle": true, "title": "Channel → Reopen flow"}
+}
+```
+
+Add more `stages` entries for multi-step flows (e.g., funnel-with-attribution: `source → channel → outcome`).
+
+---
+
+## Symbol Map (point map)
+
+Lat/lon scatter plot on a map. Use this for **point data** (customer locations, sensor readings). Use `choropleth-map` for **regions** (countries, states) colored by aggregate.
+
+- `version`: **2**
+- `widgetType`: "symbol-map"
+- Dataset must include latitude and longitude columns (or a `GEOMETRY`/`GEOGRAPHY` column).
+
+```json
+"spec": {
+  "version": 2,
+  "widgetType": "symbol-map",
+  "encodings": {
+    "coordinates": {
+      "latitude":  {"fieldName": "customer_latitude"},
+      "longitude": {"fieldName": "customer_longitude"}
+    },
+    "color": {
+      "fieldName": "sum(satisfaction_score)",
+      "scale": {"type": "quantitative",
+                "colorRamp": {"mode": "scheme", "scheme": "magma"}},
+      "legend": {"hide": true}
+    },
+    "size": {"fieldName": "count(*)", "scale": {"type": "quantitative"}}
+  },
+  "mark": {"opacity": 0.7},
+  "frame": {"showTitle": true, "title": "Customer Locations"}
+}
+```
+
+Color ramp schemes available: `magma`, `viridis`, `plasma`, `inferno`, `YlGnBu`, `RdYlBu`, plus theme-aware presets. For categorical color (e.g., colored by region instead of by intensity), use `scale.type: "categorical"` and the same `mappings` syntax as bar charts.
+
+---
+
+## Heatmap
+
+Color-intensity grid: x-axis categorical, y-axis categorical, color = numeric aggregate. Useful for "X by Y" matrices.
+
+- `version`: **3**
+- `widgetType`: "heatmap"
+
+```json
+"spec": {
+  "version": 3,
+  "widgetType": "heatmap",
+  "encodings": {
+    "x":     {"fieldName": "priority",  "scale": {"type": "categorical"}},
+    "y":     {"fieldName": "ship_mode", "scale": {"type": "categorical"}},
+    "color": {"fieldName": "sum(order_count)",
+              "scale": {"type": "quantitative",
+                        "colorRamp": {"mode": "scheme", "scheme": "viridis"}}}
+  },
+  "frame": {"showTitle": true, "title": "Order count by priority × ship mode"}
+}
+```
+
+Heatmap limit: 64K rows / 10MB. For larger data, pre-aggregate to a smaller grid.
+
+---
+
+## Funnel
+
+Stage-by-stage conversion: how many users / records make it from step 1 to step N.
+
+- `version`: **1**
+- `widgetType`: "funnel"
+
+```json
+"spec": {
+  "version": 1,
+  "widgetType": "funnel",
+  "encodings": {
+    "x":     {"fieldName": "stage"},
+    "y":     {"fieldName": "count",      "scale": {"type": "quantitative"}},
+    "color": {"fieldName": "count"}
+  },
+  "frame": {"showTitle": true, "title": "Signup funnel"}
+}
+```
+
+Dataset SQL typically returns one row per stage, with an ordering column. Use `ORDER BY stage_order` in the SQL to guarantee top-to-bottom visualization.
+
+---
+
+## Box
+
+Distribution summary (median, quartiles, whiskers, outliers). Compare distributions across categories.
+
+- `version`: **1**
+- `widgetType`: "box"
+
+```json
+"spec": {
+  "version": 1,
+  "widgetType": "box",
+  "encodings": {
+    "x": {"fieldName": "return_flag",      "displayName": "Return flag"},
+    "y": {"fieldName": "l_extendedprice",  "displayName": "Extended price",
+          "scale": {"type": "quantitative"}}
+  },
+  "frame": {"showTitle": true, "title": "Price distribution by return flag"}
+}
+```
+
+---
+
+## Waterfall
+
+Cumulative effect of positive/negative deltas — useful for P&L bridges, MoM revenue walks, factor decomposition.
+
+- `version`: **1**
+- `widgetType`: "waterfall"
+
+```json
+"spec": {
+  "version": 1,
+  "widgetType": "waterfall",
+  "encodings": {
+    "x": {"fieldName": "monthly(date_col)",
+          "expression": "DATE_TRUNC(\"MONTH\", `date_col`)"},
+    "y": {"fieldName": "sum(amount)", "scale": {"type": "quantitative"}}
+  },
+  "frame": {"showTitle": true, "title": "Monthly P&L"}
+}
+```
+
+Dataset typically returns one row per period with signed values (positive contributions, negative deductions).
+
+---
+
+## Other (less common)
+
+| Widget Type | When to use |
 |-------------|-------------|
-| heatmap | Color intensity grid for numerical data |
-| histogram | Frequency distribution with configurable bins |
-| funnel | Stage-based metric analysis |
-| sankey | Flow visualization between value sets |
-| box | Distribution summary with quartiles |
-| marker-map | Latitude/longitude point markers |
-| pivot | Drag-and-drop aggregation table |
-| word-cloud | Word frequency visualization |
-| sunburst | Hierarchical data in concentric circles |
-| cohort | Group outcome analysis over time |
+| `word-cloud` | Word/category frequency from a text field. |
+| `sunburst`   | Hierarchical data in nested rings (org chart, taxonomy). |
+
+These follow the same `version`/`widgetType`/`encodings` pattern — see the [official docs](https://docs.databricks.com/aws/en/dashboards/manage/visualizations/types) for spec details.

--- a/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
+++ b/databricks-skills/databricks-aibi-dashboards/2-advanced-widget-specifications.md
@@ -10,6 +10,8 @@ Advanced visualization types for AI/BI dashboards. For core widgets (text, count
 - `widgetType`: "area"
 - Same structure as line chart - useful for showing cumulative values or emphasizing volume
 
+> Time-series area charts benefit from a `vertical-line` annotation marking a meaningful event (launch, incident, holiday) — turns a generic trend into a readable story. See [Annotations in 1-widget-specifications.md](1-widget-specifications.md#annotations-event-markers).
+
 ```json
 "spec": {
   "version": 3,
@@ -60,6 +62,8 @@ Combines bar and line visualizations on the same chart - useful for showing rela
 - `widgetType`: "combo"
 - `y.primary`: bar chart fields
 - `y.secondary`: line chart fields
+
+> Mark meaningful events with a `vertical-line` annotation when the x-axis is temporal. See [Annotations in 1-widget-specifications.md](1-widget-specifications.md#annotations-event-markers).
 
 ```json
 {

--- a/databricks-skills/databricks-aibi-dashboards/3-filters.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-filters.md
@@ -10,6 +10,7 @@
 - `filter-date-range-picker`: for DATE/TIMESTAMP fields (date range selection)
 - `filter-single-select`: categorical with single selection
 - `filter-multi-select`: categorical with multiple selections (preferred for drill-down)
+- `range-slider`: numeric range filter on a quantitative column (e.g., "resolution time hours", "order amount")
 
 > **Performance note**: Global filters automatically apply `WHERE` clauses to dataset queries at runtime. You don't need to pre-filter data in your SQL - the dashboard engine handles this efficiently.
 
@@ -232,6 +233,43 @@ When a filter should affect multiple datasets (e.g., "Region" filter for both sa
 ```
 
 Each `queryName` in `encodings.fields` binds the filter to that specific dataset. Datasets not bound will not be filtered.
+
+---
+
+## Range Slider (numeric range filter)
+
+For filtering on a numeric column where the user wants to drag a min/max slider — e.g., resolution-time hours, amount, age. Same structure as other filters; the bound field must be quantitative.
+
+```json
+{
+  "widget": {
+    "name": "time-to-resolution",
+    "queries": [{
+      "name": "ds_resolution",
+      "query": {
+        "datasetName": "ds_cases",
+        "fields": [
+          {"name": "time_to_resolution_hours", "expression": "`time_to_resolution_hours`"}
+        ],
+        "disaggregated": false
+      }
+    }],
+    "spec": {
+      "version": 2,
+      "widgetType": "range-slider",
+      "encodings": {
+        "fields": [
+          {"fieldName": "time_to_resolution_hours", "queryName": "ds_resolution"}
+        ]
+      },
+      "frame": {"showTitle": true, "title": "Resolution time (hours)"}
+    }
+  },
+  "position": {"x": 0, "y": 0, "width": 4, "height": 2}
+}
+```
+
+`range-slider` only works on numeric / temporal columns. On a categorical field it will fail at render. To filter a numeric field by an explicit min/max in SQL (rather than a UI-only WHERE), bind to a `:param.min`/`:param.max` parameter — same pattern as date-range, see "Date Range Filtering" above.
 
 ---
 

--- a/databricks-skills/databricks-aibi-dashboards/3-filters.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-filters.md
@@ -238,7 +238,7 @@ Each `queryName` in `encodings.fields` binds the filter to that specific dataset
 
 ## Range Slider (numeric range filter)
 
-For filtering on a numeric column where the user wants to drag a min/max slider — e.g., resolution-time hours, amount, age. Same structure as other filters; the bound field must be quantitative.
+For filtering on a numeric column where the user wants to drag a min/max slider — e.g., resolution-time hours, amount, age. The query exposes `MIN(col)` and `MAX(col)` so the dashboard knows the slider bounds; `encodings.fields[].fieldName` is the underlying column name.
 
 ```json
 {
@@ -249,7 +249,8 @@ For filtering on a numeric column where the user wants to drag a min/max slider 
       "query": {
         "datasetName": "ds_cases",
         "fields": [
-          {"name": "time_to_resolution_hours", "expression": "`time_to_resolution_hours`"}
+          {"name": "min(time_to_resolution_hours)", "expression": "MIN(`time_to_resolution_hours`)"},
+          {"name": "max(time_to_resolution_hours)", "expression": "MAX(`time_to_resolution_hours`)"}
         ],
         "disaggregated": false
       }

--- a/databricks-skills/databricks-aibi-dashboards/3-filters.md
+++ b/databricks-skills/databricks-aibi-dashboards/3-filters.md
@@ -236,6 +236,49 @@ Each `queryName` in `encodings.fields` binds the filter to that specific dataset
 
 ---
 
+## Multi-Select Parameters (`MULTI`)
+
+When the dataset **pre-aggregates** (`GROUP BY` in the SQL), uses a CTE, or wraps a table function (e.g. `AI_FORECAST`), a field-based filter can't auto-inject a `WHERE` — you must filter explicitly with a parameter. Same goes when you want the filter expressed in SQL for traceability.
+
+A `MULTI` parameter binds as a **SQL `ARRAY`**, not an `IN`-list. Two rules to filter correctly:
+
+```sql
+-- ❌ WRONG: a MULTI param is an ARRAY → DATATYPE_MISMATCH (STRING vs ARRAY<STRING>)
+WHERE category IN (:category_filter)
+
+-- ✅ RIGHT: array_contains, with size()=0 guard so an empty selection means "all"
+WHERE (size(:category_filter) = 0 OR array_contains(:category_filter, category))
+```
+
+The empty-selection default is an **empty array, not NULL** — without the `size()=0` guard, the dashboard loads showing zero rows.
+
+```json
+{
+  "name": "metric_by_category",
+  "queryLines": [
+    "SELECT category, SUM(revenue) AS total FROM orders ",
+    "WHERE (size(:category_filter) = 0 OR array_contains(:category_filter, category)) ",
+    "GROUP BY category"
+  ],
+  "parameters": [{
+    "keyword": "category_filter",
+    "dataType": "STRING",
+    "complexType": "MULTI",
+    "defaultSelection": {"values": {"dataType": "STRING", "values": []}}
+  }]
+}
+```
+
+The filter widget binds the parameter via `parameterName` (NOT `fieldName`), same shape as the date-range parameter example above:
+
+```json
+"encodings": {"fields": [{"parameterName": "category_filter", "queryName": "q_param"}]}
+```
+
+> **Parameters live on the dataset + the filter widget only.** Don't add `parameters` to a chart/counter widget's own query — the chart reads the dataset, which the filter has already parameterized. Adding parameters to the consuming widget makes it render blank with no error.
+
+---
+
 ## Range Slider (numeric range filter)
 
 For filtering on a numeric column where the user wants to drag a min/max slider — e.g., resolution-time hours, amount, age. The query exposes `MIN(col)` and `MAX(col)` so the dashboard knows the slider bounds; `encodings.fields[].fieldName` is the underlying column name.

--- a/databricks-skills/databricks-aibi-dashboards/4-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/4-examples.md
@@ -1,458 +1,448 @@
 # Complete Dashboard Example
 
-This is a **reference example** to understand the JSON structure and layout patterns. **Always adapt to what the user requests** - use their tables, metrics, and visualizations. This example demonstrates the correct syntax; your dashboard should reflect the user's actual requirements.
+A working dashboard JSON that exercises the new feature set:
 
-## Key Patterns (Read First)
+- **`dataset.columns[]` + `MEASURE()`** — reusable named measures across widgets.
+- **`forecast-line`** with `AI_FORECAST` SQL and a **vertical-line annotation** for a known event.
+- **`pivot`** with conditional cell coloring.
+- **`symbol-map`** (lat/lon) with a continuous color ramp.
+- **`range-slider`** filter on a numeric column.
+- **Counter sparkline** via the `period` encoding.
 
-### 1. Page Types (Required)
-- `PAGE_TYPE_CANVAS` - Main content page with widgets
-- `PAGE_TYPE_GLOBAL_FILTERS` - Dedicated filter page that affects all canvas pages
+**Adapt this to the user's actual data and story** — the structure and feature mix is what to copy, not the column names.
 
-### 2. Widget Versions (Critical!)
-| Widget Type | Version |
-|-------------|---------|
-| `counter`, `table` | **2** |
-| `bar`, `line`, `area`, `pie` | **3** |
-| `filter-*` | **2** |
+## Key Patterns (read first)
 
-### 3. KPI Counter with Currency Formatting
-```json
-"format": {
-  "type": "number-currency",
-  "currencyCode": "USD",
-  "abbreviation": "compact",
-  "decimalPlaces": {"type": "max", "places": 1}
-}
+### Page types
+- `PAGE_TYPE_CANVAS` — content page with widgets.
+- `PAGE_TYPE_GLOBAL_FILTERS` — dedicated filter page, applies to all canvas pages whose datasets contain the filter field.
+
+### Widget versions used in this example
+
+| Widget | Version |
+|---|---|
+| `counter`, `table`, `filter-*`, `range-slider`, `symbol-map` | **2** |
+| `bar`, `line`, `area`, `pie`, `pivot`, `histogram`, `heatmap` | **3** |
+| `combo`, `choropleth-map`, `forecast-line`, `sankey`, `funnel`, `box`, `waterfall` | **1** |
+
+See [SKILL.md](SKILL.md#widget-index-version--where-documented) for the full version table.
+
+### Layout (12-col grid)
+
 ```
-
-### 4. Filter Binding to Multiple Datasets
-Each filter query binds the filter to one dataset. Add multiple queries to filter multiple datasets:
-```json
-"queries": [
-  {"name": "ds1_region", "query": {"datasetName": "dataset1", ...}},
-  {"name": "ds2_region", "query": {"datasetName": "dataset2", ...}}
-]
+y=0:  Header (w=12, h=2)
+y=2:  KPI (w=3) | KPI w/ sparkline (w=3) | KPI (w=3) | KPI (w=3)  ← fills 12
+y=5:  Forecast (w=8, h=4)            | Pivot summary (w=4, h=4)
+y=9:  Symbol map (w=8, h=5)          | Histogram (w=4, h=5)
+y=14: Detail table (w=12, h=6)
 ```
-
-### 5. Layout Grid (12 columns)
-```
-y=0:  Header with title + description (w=12, h=2)
-y=2:  KPI(w=4,h=3) | KPI(w=4,h=3) | KPI(w=4,h=3)  ← fills 12
-y=5:  Section header (w=12, h=1)
-y=6:  Area chart (w=12, h=5)
-y=11: Section header (w=12, h=1)
-y=12: Pie(w=4,h=5) | Bar chart(w=8,h=5)           ← fills 12
-```
-
-Use `\n\n` in text widget lines array to create line breaks within a single widget.
 
 ---
 
-## Full Dashboard: Sales Analytics
-
-This example shows a complete dashboard with:
-- Title and subtitle text widgets
-- 3 KPI counters with currency/number formatting
-- Area chart for time series trends
-- Pie chart for category breakdown
-- Bar chart with color grouping by region
-- Data table for detailed records
-- Global filters (date range, region, category)
-
-> **Note**: Queries reference bare table names only (no catalog, no schema). Catalog and schema are set via `--dataset-catalog "my_catalog" --dataset-schema "gold"` when creating the dashboard. These flags only apply when the query omits catalog/schema — they will NOT override anything you hardcode in the `FROM` clause.
+## Full Dashboard: Support Operations
 
 ```json
 {
   "datasets": [
     {
-      "name": "ds_daily_sales",
-      "displayName": "Daily Sales",
+      "name": "ds_support",
+      "displayName": "Support cases",
       "queryLines": [
-        "SELECT sale_date, region, department, total_orders, total_units, total_revenue, total_cost, profit_margin ",
-        "FROM daily_sales ",
-        "ORDER BY sale_date"
+        "SELECT case_id, opened_at, closed_at, priority, channel, region_name,",
+        "       customer_id, reopened_flag, satisfaction_score,",
+        "       customer_latitude, customer_longitude,",
+        "       (unix_timestamp(closed_at) - unix_timestamp(opened_at)) / 3600.0 AS time_to_resolution_hours",
+        "FROM support_cases"
+      ],
+      "columns": [
+        {"displayName": "Total Cases",       "description": "Count of support cases",
+         "expression": "COUNT(`case_id`)"},
+        {"displayName": "Avg Resolution Hours",
+         "description": "Mean resolution time across closed cases",
+         "expression": "AVG(`time_to_resolution_hours`)"},
+        {"displayName": "Reopen Rate %",
+         "description": "Percent of cases reopened after closure",
+         "expression": "SUM(CASE WHEN `reopened_flag`=true THEN 1 ELSE 0 END) * 100.0 / COUNT(`case_id`)"},
+        {"displayName": "Avg Satisfaction",
+         "description": "Average customer satisfaction (1-10)",
+         "expression": "AVG(`satisfaction_score`)"},
+        {"displayName": "Priority Level",
+         "description": "Sortable priority label",
+         "expression": "CASE WHEN `priority`='Critical' THEN '1-Critical' WHEN `priority`='High' THEN '2-High' WHEN `priority`='Medium' THEN '3-Medium' ELSE '4-Low' END"}
       ]
     },
     {
-      "name": "ds_products",
-      "displayName": "Product Performance",
+      "name": "ds_forecast",
+      "displayName": "Cases forecast",
       "queryLines": [
-        "SELECT product_id, product_name, department, region, units_sold, revenue, cost, profit ",
-        "FROM product_performance"
+        "WITH original AS (",
+        "  SELECT DATE_TRUNC('WEEK', opened_at) AS opened_at, COUNT(*) AS count",
+        "  FROM support_cases",
+        "  -- Drop the partial-elapsed week so the line doesn't dip right before the forecast.",
+        "  -- Cutoff grain MUST match the DATE_TRUNC grain above.",
+        "  WHERE DATE_TRUNC('WEEK', opened_at) < DATE_TRUNC('WEEK', current_date())",
+        "  GROUP BY 1",
+        "),",
+        "dates AS (SELECT MAX(opened_at) AS max_d, MIN(opened_at) AS min_d FROM original),",
+        "forecast AS (",
+        "  SELECT opened_at, count_forecast, count_upper, count_lower, NULL AS count",
+        "  FROM AI_FORECAST(TABLE(original),",
+        "    horizon  => (SELECT max_d + MAKE_DT_INTERVAL(CAST(FLOOR(DATEDIFF(max_d, min_d) * 0.5) AS INT), 0, 0, 0) FROM dates),",
+        "    time_col => 'opened_at', value_col => 'count')",
+        ")",
+        "SELECT * FROM forecast UNION ALL SELECT opened_at, NULL, NULL, NULL, count FROM original"
       ]
     }
   ],
+
   "pages": [
     {
-      "name": "sales_overview",
-      "displayName": "Sales Overview",
+      "name": "overview",
+      "displayName": "Overview",
       "pageType": "PAGE_TYPE_CANVAS",
       "layoutVersion": "GRID_V1",
       "layout": [
+
         {
           "widget": {
             "name": "header",
-            "multilineTextboxSpec": {
-              "lines": ["# Sales Dashboard\n\nMonitor daily sales, revenue, and profit margins across regions and departments."]
-            }
+            "multilineTextboxSpec": {"lines": ["# Support Operations\n\nWeekly volume, resolution speed, and forecast."]}
           },
           "position": {"x": 0, "y": 0, "width": 12, "height": 2}
         },
+
         {
           "widget": {
-            "name": "kpi_revenue",
+            "name": "kpi-total-cases",
             "queries": [{
               "name": "main_query",
               "query": {
-                "datasetName": "ds_daily_sales",
-                "fields": [{"name": "sum(total_revenue)", "expression": "SUM(`total_revenue`)"}],
+                "datasetName": "ds_support",
+                "fields": [{"name": "measure(Total Cases)", "expression": "MEASURE(`Total Cases`)"}],
                 "disaggregated": false
               }
             }],
             "spec": {
-              "version": 2,
-              "widgetType": "counter",
+              "version": 2, "widgetType": "counter",
               "encodings": {
-                "value": {
-                  "fieldName": "sum(total_revenue)",
-                  "displayName": "Total Revenue",
-                  "format": {
-                    "type": "number-currency",
-                    "currencyCode": "USD",
-                    "abbreviation": "compact",
-                    "decimalPlaces": {"type": "max", "places": 1}
-                  }
-                }
+                "value": {"fieldName": "measure(Total Cases)", "displayName": "Total Cases",
+                          "format": {"type": "number", "abbreviation": "compact"}}
               },
-              "frame": {"title": "Total Revenue", "showTitle": true, "description": "For the selected period", "showDescription": true}
+              "frame": {"title": "Total Cases", "showTitle": true}
             }
           },
-          "position": {"x": 0, "y": 2, "width": 4, "height": 3}
+          "position": {"x": 0, "y": 2, "width": 3, "height": 3}
         },
+
         {
           "widget": {
-            "name": "kpi_orders",
+            "name": "kpi-volume-trend",
             "queries": [{
               "name": "main_query",
               "query": {
-                "datasetName": "ds_daily_sales",
-                "fields": [{"name": "sum(total_orders)", "expression": "SUM(`total_orders`)"}],
-                "disaggregated": false
-              }
-            }],
-            "spec": {
-              "version": 2,
-              "widgetType": "counter",
-              "encodings": {
-                "value": {
-                  "fieldName": "sum(total_orders)",
-                  "displayName": "Total Orders",
-                  "format": {
-                    "type": "number",
-                    "abbreviation": "compact",
-                    "decimalPlaces": {"type": "max", "places": 0}
-                  }
-                }
-              },
-              "frame": {"title": "Total Orders", "showTitle": true, "description": "For the selected period", "showDescription": true}
-            }
-          },
-          "position": {"x": 4, "y": 2, "width": 4, "height": 3}
-        },
-        {
-          "widget": {
-            "name": "kpi_profit",
-            "queries": [{
-              "name": "main_query",
-              "query": {
-                "datasetName": "ds_daily_sales",
-                "fields": [{"name": "avg(profit_margin)", "expression": "AVG(`profit_margin`)"}],
-                "disaggregated": false
-              }
-            }],
-            "spec": {
-              "version": 2,
-              "widgetType": "counter",
-              "encodings": {
-                "value": {
-                  "fieldName": "avg(profit_margin)",
-                  "displayName": "Avg Profit Margin",
-                  "format": {
-                    "type": "number-percent",
-                    "decimalPlaces": {"type": "max", "places": 1}
-                  }
-                }
-              },
-              "frame": {"title": "Profit Margin", "showTitle": true, "description": "Average for period", "showDescription": true}
-            }
-          },
-          "position": {"x": 8, "y": 2, "width": 4, "height": 3}
-        },
-        {
-          "widget": {
-            "name": "section_trends",
-            "multilineTextboxSpec": {
-              "lines": ["## Revenue Trend"]
-            }
-          },
-          "position": {"x": 0, "y": 5, "width": 12, "height": 1}
-        },
-        {
-          "widget": {
-            "name": "chart_revenue_trend",
-            "queries": [{
-              "name": "main_query",
-              "query": {
-                "datasetName": "ds_daily_sales",
+                "datasetName": "ds_support",
                 "fields": [
-                  {"name": "sale_date", "expression": "`sale_date`"},
-                  {"name": "sum(total_revenue)", "expression": "SUM(`total_revenue`)"}
+                  {"name": "weekly(opened_at)", "expression": "DATE_TRUNC(\"WEEK\", `opened_at`)"},
+                  {"name": "measure(Total Cases)", "expression": "MEASURE(`Total Cases`)"}
                 ],
                 "disaggregated": false
               }
             }],
             "spec": {
-              "version": 3,
-              "widgetType": "area",
+              "version": 2, "widgetType": "counter",
               "encodings": {
-                "x": {
-                  "fieldName": "sale_date",
-                  "scale": {"type": "temporal"},
-                  "axis": {"title": "Date"},
-                  "displayName": "Date"
-                },
-                "y": {
-                  "fieldName": "sum(total_revenue)",
-                  "scale": {"type": "quantitative"},
-                  "format": {
-                    "type": "number-currency",
-                    "currencyCode": "USD",
-                    "abbreviation": "compact"
-                  },
-                  "axis": {"title": "Revenue ($)"},
-                  "displayName": "Revenue ($)"
-                }
+                "value":  {"fieldName": "measure(Total Cases)", "displayName": "This Week"},
+                "period": {"fieldName": "weekly(opened_at)"}
               },
-              "frame": {
-                "title": "Daily Revenue",
-                "showTitle": true,
-                "description": "Track daily revenue trends"
-              }
+              "frame": {"title": "Volume (with trend)", "showTitle": true}
             }
           },
-          "position": {"x": 0, "y": 6, "width": 12, "height": 5}
+          "position": {"x": 3, "y": 2, "width": 3, "height": 3}
         },
+
         {
           "widget": {
-            "name": "section_breakdown",
-            "multilineTextboxSpec": {
-              "lines": ["## Breakdown"]
-            }
-          },
-          "position": {"x": 0, "y": 11, "width": 12, "height": 1}
-        },
-        {
-          "widget": {
-            "name": "chart_by_department",
+            "name": "kpi-resolution",
             "queries": [{
               "name": "main_query",
               "query": {
-                "datasetName": "ds_daily_sales",
-                "fields": [
-                  {"name": "department", "expression": "`department`"},
-                  {"name": "sum(total_revenue)", "expression": "SUM(`total_revenue`)"}
-                ],
+                "datasetName": "ds_support",
+                "fields": [{"name": "measure(Avg Resolution Hours)", "expression": "MEASURE(`Avg Resolution Hours`)"}],
                 "disaggregated": false
               }
             }],
             "spec": {
-              "version": 3,
-              "widgetType": "pie",
+              "version": 2, "widgetType": "counter",
               "encodings": {
-                "angle": {
-                  "fieldName": "sum(total_revenue)",
-                  "scale": {"type": "quantitative"},
-                  "displayName": "Revenue"
-                },
-                "color": {
-                  "fieldName": "department",
-                  "scale": {"type": "categorical"},
-                  "displayName": "Department"
-                },
-                "label": {"show": true}
+                "value": {"fieldName": "measure(Avg Resolution Hours)", "displayName": "Avg Hours",
+                          "format": {"type": "number", "decimalPlaces": {"type": "max", "places": 1}}}
               },
-              "frame": {"title": "Revenue by Department", "showTitle": true}
+              "frame": {"title": "Avg Resolution Time", "showTitle": true}
             }
           },
-          "position": {"x": 0, "y": 12, "width": 4, "height": 5}
+          "position": {"x": 6, "y": 2, "width": 3, "height": 3}
         },
+
         {
           "widget": {
-            "name": "chart_by_region",
+            "name": "kpi-reopen",
             "queries": [{
               "name": "main_query",
               "query": {
-                "datasetName": "ds_daily_sales",
-                "fields": [
-                  {"name": "sale_date", "expression": "`sale_date`"},
-                  {"name": "region", "expression": "`region`"},
-                  {"name": "sum(total_revenue)", "expression": "SUM(`total_revenue`)"}
-                ],
+                "datasetName": "ds_support",
+                "fields": [{"name": "measure(Reopen Rate %)", "expression": "MEASURE(`Reopen Rate %`)"}],
                 "disaggregated": false
               }
             }],
             "spec": {
-              "version": 3,
-              "widgetType": "bar",
+              "version": 2, "widgetType": "counter",
               "encodings": {
-                "x": {
-                  "fieldName": "sale_date",
-                  "scale": {"type": "temporal"},
-                  "axis": {"title": "Date"},
-                  "displayName": "Date"
-                },
-                "y": {
-                  "fieldName": "sum(total_revenue)",
-                  "scale": {"type": "quantitative"},
-                  "format": {
-                    "type": "number-currency",
-                    "currencyCode": "USD",
-                    "abbreviation": "compact"
-                  },
-                  "axis": {"title": "Revenue ($)"},
-                  "displayName": "Revenue ($)"
-                },
-                "color": {
-                  "fieldName": "region",
-                  "scale": {"type": "categorical"},
-                  "displayName": "Region"
-                }
+                "value": {"fieldName": "measure(Reopen Rate %)", "displayName": "Reopen Rate",
+                          "format": {"type": "number", "decimalPlaces": {"type": "max", "places": 1}}}
               },
-              "frame": {"title": "Revenue by Region", "showTitle": true}
+              "frame": {"title": "Reopen Rate (%)", "showTitle": true}
             }
           },
-          "position": {"x": 4, "y": 12, "width": 8, "height": 5}
+          "position": {"x": 9, "y": 2, "width": 3, "height": 3}
         },
+
         {
           "widget": {
-            "name": "section_products",
-            "multilineTextboxSpec": {
-              "lines": ["## Top Products"]
-            }
-          },
-          "position": {"x": 0, "y": 17, "width": 12, "height": 1}
-        },
-        {
-          "widget": {
-            "name": "table_products",
+            "name": "case-forecast",
             "queries": [{
               "name": "main_query",
               "query": {
-                "datasetName": "ds_products",
+                "datasetName": "ds_forecast",
                 "fields": [
-                  {"name": "product_name", "expression": "`product_name`"},
-                  {"name": "department", "expression": "`department`"},
-                  {"name": "units_sold", "expression": "`units_sold`"},
-                  {"name": "revenue", "expression": "`revenue`"},
-                  {"name": "profit", "expression": "`profit`"}
+                  {"name": "opened_at",       "expression": "`opened_at`"},
+                  {"name": "count",           "expression": "`count`"},
+                  {"name": "count_forecast",  "expression": "`count_forecast`"},
+                  {"name": "count_upper",     "expression": "`count_upper`"},
+                  {"name": "count_lower",     "expression": "`count_lower`"}
                 ],
                 "disaggregated": true
               }
             }],
             "spec": {
-              "version": 2,
-              "widgetType": "table",
+              "version": 1, "widgetType": "forecast-line",
               "encodings": {
-                "columns": [
-                  {"fieldName": "product_name", "displayName": "Product"},
-                  {"fieldName": "department", "displayName": "Department"},
-                  {"fieldName": "units_sold", "displayName": "Units Sold"},
-                  {"fieldName": "revenue", "displayName": "Revenue ($)"},
-                  {"fieldName": "profit", "displayName": "Profit ($)"}
-                ]
+                "x": {"fieldName": "opened_at", "scale": {"type": "temporal"}},
+                "y": {
+                  "scale":           {"type": "quantitative"},
+                  "original":        {"fieldName": "count",          "displayName": "Cases"},
+                  "prediction":      {"fieldName": "count_forecast", "displayName": "Forecast"},
+                  "predictionUpper": {"fieldName": "count_upper"},
+                  "predictionLower": {"fieldName": "count_lower"}
+                }
               },
-              "frame": {
-                "title": "Product Performance",
-                "showTitle": true,
-                "description": "Top products by revenue"
-              }
+              "annotations": [
+                {
+                  "type": "vertical-line",
+                  "encodings": {
+                    "x":     {"dataValue": "2024-11-28T12:00:00.000", "dataType": "DATETIME"},
+                    "label": {"value": "Thanksgiving"},
+                    "color": {"value": {"themeColorType": "visualizationColors", "position": 3}}
+                  }
+                }
+              ],
+              "frame": {"showTitle": true, "title": "Case Volume — actuals + forecast"}
             }
           },
-          "position": {"x": 0, "y": 18, "width": 12, "height": 6}
+          "position": {"x": 0, "y": 5, "width": 8, "height": 4}
+        },
+
+        {
+          "widget": {
+            "name": "priority-by-channel",
+            "queries": [{
+              "name": "main_query",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [
+                  {"name": "channel",        "expression": "`channel`"},
+                  {"name": "Priority Level", "expression": "`Priority Level`"},
+                  {"name": "count(case_id)", "expression": "COUNT(`case_id`)"}
+                ],
+                "disaggregated": false
+              }
+            }],
+            "spec": {
+              "version": 3,
+              "widgetType": "pivot",
+              "encodings": {
+                "rows":    [{"fieldName": "channel"}],
+                "columns": [{"fieldName": "Priority Level"}],
+                "cell": {
+                  "type": "multi-cell",
+                  "fields": [{
+                    "fieldName": "count(case_id)", "cellType": "text",
+                    "style": {
+                      "type": "basic",
+                      "rules": [
+                        {"condition": {"operand": {"type": "data-value", "value": "30"}, "operator": ">="},
+                         "backgroundColor": {"themeColorType": "visualizationColors", "position": 6}},
+                        {"condition": {"operand": {"type": "data-value", "value": "10"}, "operator": ">="},
+                         "backgroundColor": {"themeColorType": "visualizationColors", "position": 3}}
+                      ]
+                    }
+                  }]
+                }
+              },
+              "frame": {"showTitle": true, "title": "Cases by channel × priority"}
+            }
+          },
+          "position": {"x": 8, "y": 5, "width": 4, "height": 4}
+        },
+
+        {
+          "widget": {
+            "name": "customer-map",
+            "queries": [{
+              "name": "main_query",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [
+                  {"name": "customer_latitude",  "expression": "`customer_latitude`"},
+                  {"name": "customer_longitude", "expression": "`customer_longitude`"},
+                  {"name": "measure(Avg Satisfaction)", "expression": "MEASURE(`Avg Satisfaction`)"},
+                  {"name": "count(*)", "expression": "COUNT(`*`)"}
+                ],
+                "disaggregated": false
+              }
+            }],
+            "spec": {
+              "version": 2, "widgetType": "symbol-map",
+              "encodings": {
+                "coordinates": {
+                  "latitude":  {"fieldName": "customer_latitude"},
+                  "longitude": {"fieldName": "customer_longitude"}
+                },
+                "color": {
+                  "fieldName": "measure(Avg Satisfaction)",
+                  "scale":  {"type": "quantitative", "colorRamp": {"mode": "scheme", "scheme": "RdYlBu"}}
+                },
+                "size":  {"fieldName": "count(*)", "scale": {"type": "quantitative"}}
+              },
+              "mark": {"opacity": 0.7},
+              "frame": {"showTitle": true, "title": "Customer Satisfaction Map"}
+            }
+          },
+          "position": {"x": 0, "y": 9, "width": 8, "height": 5}
+        },
+
+        {
+          "widget": {
+            "name": "resolution-distribution",
+            "queries": [{
+              "name": "main_query",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [
+                  {"name": "bin(time_to_resolution_hours, binWidth=2)",
+                   "expression": "bin(`time_to_resolution_hours`, binWidth=2)"},
+                  {"name": "count(*)", "expression": "COUNT(`*`)"}
+                ],
+                "disaggregated": false
+              }
+            }],
+            "spec": {
+              "version": 3, "widgetType": "histogram",
+              "encodings": {
+                "x": {"fieldName": "bin(time_to_resolution_hours, binWidth=2)",
+                      "scale": {"type": "quantitative"}},
+                "y": {"fieldName": "count(*)", "scale": {"type": "quantitative"}}
+              },
+              "frame": {"showTitle": true, "title": "Resolution time (hours)"}
+            }
+          },
+          "position": {"x": 8, "y": 9, "width": 4, "height": 5}
+        },
+
+        {
+          "widget": {
+            "name": "case-detail",
+            "queries": [{
+              "name": "main_query",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [
+                  {"name": "case_id",                  "expression": "`case_id`"},
+                  {"name": "opened_at",                "expression": "`opened_at`"},
+                  {"name": "channel",                  "expression": "`channel`"},
+                  {"name": "Priority Level",           "expression": "`Priority Level`"},
+                  {"name": "time_to_resolution_hours", "expression": "`time_to_resolution_hours`"},
+                  {"name": "satisfaction_score",       "expression": "`satisfaction_score`"}
+                ],
+                "disaggregated": true
+              }
+            }],
+            "spec": {
+              "version": 2, "widgetType": "table",
+              "encodings": {
+                "columns": [
+                  {"fieldName": "case_id",                  "displayName": "Case"},
+                  {"fieldName": "opened_at",                "displayName": "Opened"},
+                  {"fieldName": "channel",                  "displayName": "Channel"},
+                  {"fieldName": "Priority Level",           "displayName": "Priority"},
+                  {"fieldName": "time_to_resolution_hours", "displayName": "Hours to resolve",
+                   "format": {"type": "number", "decimalPlaces": {"type": "max", "places": 1}},
+                   "style": {
+                     "type": "basic",
+                     "rules": [
+                       {"condition": {"operand": {"type": "data-value", "value": "24"}, "operator": ">"},
+                        "backgroundColor": {"themeColorType": "visualizationColors", "position": 6}}
+                     ]
+                   }},
+                  {"fieldName": "satisfaction_score",       "displayName": "CSAT"}
+                ]
+              },
+              "frame": {"showTitle": true, "title": "Case Detail"}
+            }
+          },
+          "position": {"x": 0, "y": 14, "width": 12, "height": 6}
         }
       ]
     },
+
     {
-      "name": "global_filters",
+      "name": "filters",
       "displayName": "Filters",
       "pageType": "PAGE_TYPE_GLOBAL_FILTERS",
       "layoutVersion": "GRID_V1",
       "layout": [
         {
           "widget": {
-            "name": "filter_date_range",
-            "queries": [
-              {
-                "name": "ds_sales_date",
-                "query": {
-                  "datasetName": "ds_daily_sales",
-                  "fields": [{"name": "sale_date", "expression": "`sale_date`"}],
-                  "disaggregated": false
-                }
+            "name": "filter-date",
+            "queries": [{
+              "name": "ds_date",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [{"name": "opened_at", "expression": "`opened_at`"}],
+                "disaggregated": false
               }
-            ],
+            }],
             "spec": {
-              "version": 2,
-              "widgetType": "filter-date-range-picker",
-              "encodings": {
-                "fields": [
-                  {"fieldName": "sale_date", "displayName": "Date", "queryName": "ds_sales_date"}
-                ]
-              },
-              "selection": {
-                "defaultSelection": {
-                  "range": {
-                    "dataType": "DATE",
-                    "min": {"value": "now/y"},
-                    "max": {"value": "now/y"}
-                  }
-                }
-              },
-              "frame": {"showTitle": true, "title": "Date Range"}
+              "version": 2, "widgetType": "filter-date-range-picker",
+              "encodings": {"fields": [{"fieldName": "opened_at", "queryName": "ds_date"}]},
+              "frame": {"showTitle": true, "title": "Date"}
             }
           },
           "position": {"x": 0, "y": 0, "width": 4, "height": 2}
         },
         {
           "widget": {
-            "name": "filter_region",
-            "queries": [
-              {
-                "name": "ds_sales_region",
-                "query": {
-                  "datasetName": "ds_daily_sales",
-                  "fields": [{"name": "region", "expression": "`region`"}],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "ds_products_region",
-                "query": {
-                  "datasetName": "ds_products",
-                  "fields": [{"name": "region", "expression": "`region`"}],
-                  "disaggregated": false
-                }
+            "name": "filter-region",
+            "queries": [{
+              "name": "ds_region",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [{"name": "region_name", "expression": "`region_name`"}],
+                "disaggregated": false
               }
-            ],
+            }],
             "spec": {
-              "version": 2,
-              "widgetType": "filter-multi-select",
-              "encodings": {
-                "fields": [
-                  {"fieldName": "region", "displayName": "Region", "queryName": "ds_sales_region"},
-                  {"fieldName": "region", "displayName": "Region", "queryName": "ds_products_region"}
-                ]
-              },
+              "version": 2, "widgetType": "filter-multi-select",
+              "encodings": {"fields": [{"fieldName": "region_name", "queryName": "ds_region", "displayName": "Region"}]},
               "frame": {"showTitle": true, "title": "Region"}
             }
           },
@@ -460,35 +450,19 @@ This example shows a complete dashboard with:
         },
         {
           "widget": {
-            "name": "filter_department",
-            "queries": [
-              {
-                "name": "ds_sales_dept",
-                "query": {
-                  "datasetName": "ds_daily_sales",
-                  "fields": [{"name": "department", "expression": "`department`"}],
-                  "disaggregated": false
-                }
-              },
-              {
-                "name": "ds_products_dept",
-                "query": {
-                  "datasetName": "ds_products",
-                  "fields": [{"name": "department", "expression": "`department`"}],
-                  "disaggregated": false
-                }
+            "name": "filter-resolution-time",
+            "queries": [{
+              "name": "ds_resolution",
+              "query": {
+                "datasetName": "ds_support",
+                "fields": [{"name": "time_to_resolution_hours", "expression": "`time_to_resolution_hours`"}],
+                "disaggregated": false
               }
-            ],
+            }],
             "spec": {
-              "version": 2,
-              "widgetType": "filter-multi-select",
-              "encodings": {
-                "fields": [
-                  {"fieldName": "department", "displayName": "Department", "queryName": "ds_sales_dept"},
-                  {"fieldName": "department", "displayName": "Department", "queryName": "ds_products_dept"}
-                ]
-              },
-              "frame": {"showTitle": true, "title": "Department"}
+              "version": 2, "widgetType": "range-slider",
+              "encodings": {"fields": [{"fieldName": "time_to_resolution_hours", "queryName": "ds_resolution"}]},
+              "frame": {"showTitle": true, "title": "Resolution time (hrs)"}
             }
           },
           "position": {"x": 8, "y": 0, "width": 4, "height": 2}
@@ -498,3 +472,19 @@ This example shows a complete dashboard with:
   ]
 }
 ```
+
+## What each widget demonstrates
+
+| Widget | Feature shown |
+|---|---|
+| 4 KPI counters | `MEASURE()` referencing dataset-level `columns[]` |
+| `kpi-volume-trend` counter | `period` encoding (sparkline behind the value) |
+| `case-forecast` | `forecast-line` with `AI_FORECAST` SQL + `vertical-line` annotation |
+| `priority-by-channel` | `pivot` with conditional cell-color rules |
+| `customer-map` | `symbol-map` with continuous `colorRamp` |
+| `resolution-distribution` | `histogram` with `bin(col, binWidth=N)` |
+| `case-detail` table | per-column `format` + conditional `style.rules` for high-hour cells |
+| `filter-resolution-time` | `range-slider` filter on a numeric column |
+| Global filters page | Filters bound to one source dataset cascade to every widget that uses it |
+
+Adapt the table names, columns, story, and palette to your domain — the structure stays the same.

--- a/databricks-skills/databricks-aibi-dashboards/4-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/4-examples.md
@@ -472,9 +472,30 @@ y=14: Detail table (w=12, h=6)
         }
       ]
     }
-  ]
+  ],
+
+  "uiSettings": {
+    "theme": {
+      "canvasBackgroundColor": {"light": "#FCFCFC", "dark": "#1F272D"},
+      "widgetBackgroundColor": {"light": "#FFFFFF", "dark": "#11171C"},
+      "fontColor":             {"light": "#11171C", "dark": "#E8ECF0"},
+      "selectionColor":        {"light": "#2272B4", "dark": "#8ACAFF"},
+      "visualizationColors": [
+        "#3B82F6",
+        "#10B981",
+        "#F59E0B",
+        "#8B5CF6",
+        "#14B8A6",
+        "#EF4444",
+        "#6B7280"
+      ],
+      "widgetHeaderAlignment": "LEFT"
+    }
+  }
 }
 ```
+
+The palette puts the Critical-red at `position: 6` (`#EF4444`) and the warning-amber at `position: 3` (`#F59E0B`) — that's what the pivot conditional rules and the forecast annotation reference. Position 1 (blue) is the default for chart series that don't pin a value.
 
 ## What each widget demonstrates
 

--- a/databricks-skills/databricks-aibi-dashboards/4-examples.md
+++ b/databricks-skills/databricks-aibi-dashboards/4-examples.md
@@ -339,7 +339,7 @@ y=14: Detail table (w=12, h=6)
                 "datasetName": "ds_support",
                 "fields": [
                   {"name": "bin(time_to_resolution_hours, binWidth=2)",
-                   "expression": "bin(`time_to_resolution_hours`, binWidth=2)"},
+                   "expression": "BIN_FLOOR(`time_to_resolution_hours`, 2)"},
                   {"name": "count(*)", "expression": "COUNT(`*`)"}
                 ],
                 "disaggregated": false
@@ -455,7 +455,10 @@ y=14: Detail table (w=12, h=6)
               "name": "ds_resolution",
               "query": {
                 "datasetName": "ds_support",
-                "fields": [{"name": "time_to_resolution_hours", "expression": "`time_to_resolution_hours`"}],
+                "fields": [
+                  {"name": "min(time_to_resolution_hours)", "expression": "MIN(`time_to_resolution_hours`)"},
+                  {"name": "max(time_to_resolution_hours)", "expression": "MAX(`time_to_resolution_hours`)"}
+                ],
                 "disaggregated": false
               }
             }],

--- a/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
+++ b/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
@@ -122,8 +122,8 @@ If you change the chart's aggregation grain (weekly → monthly), update **both*
 
 ## Range-slider filter shows error or no min/max
 
-- The bound `fieldName` must be a numeric or temporal column. Categorical fields fail at render — use `filter-single-select` / `filter-multi-select` instead.
-- Query inside the filter widget must include the field as a plain expression (`{"name": "x", "expression": "\`x\`"}`), not pre-aggregated.
+- The filter's `query.fields[]` must expose `MIN(col)` and `MAX(col)` — the dashboard reads these to set the slider bounds. See [3-filters.md](3-filters.md#range-slider-numeric-range-filter).
+- Slider only works on numeric / temporal columns. Categorical fields fail at render — use `filter-single-select` / `filter-multi-select` instead.
 
 ## Symbol-map shows no points
 

--- a/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
+++ b/databricks-skills/databricks-aibi-dashboards/5-troubleshooting.md
@@ -98,3 +98,41 @@ These errors occur when the JSON structure is wrong:
 - Use TOP-N + "Other" bucketing in dataset SQL
 - Aggregate to a higher level (region instead of store)
 - Use a table widget instead of a chart for high-cardinality data
+
+## `MEASURE()` errors
+
+- **"Cannot resolve `MEASURE(\`X\`)`"** — measure `X` is not defined on the dataset. Either add it to `dataset.columns[]` with `displayName: "X"`, or (if the source is a metric view) confirm the YAML defines a measure named `X`. Name matching is case-sensitive and backticks are required if the name has spaces.
+- **`MEASURE()` returns wrong number** — check that `query.disaggregated: false` is set on the widget. With `true`, the widget bypasses dataset measures and shows raw rows.
+
+## Forecast-line shows blank or partial line
+
+- Dataset must return both historical AND forecast columns, with historical rows having `NULL` in the forecast columns and forecast rows having `NULL` in the historical column. Use `UNION ALL` to glue them — see [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md#forecast-line-with-ai_forecast).
+- All four y-encoding fields (`original`, `prediction`, `predictionUpper`, `predictionLower`) must reference columns that exist in `query.fields`.
+- `AI_FORECAST` requires the time column to be sorted and have no gaps — pre-aggregate (e.g., `DATE_TRUNC('WEEK', ts)`) before passing to the table function.
+
+## Forecast-line dips right before the prediction starts
+
+The last historical bucket is the **current (partial) period** — e.g., aggregating weekly but today is Tuesday → "this week" bucket has only 2 days of data and looks like a cliff. Filter the partial bucket out in the dataset SQL with a cutoff using the **same `DATE_TRUNC` grain as the aggregation**:
+
+```sql
+WHERE DATE_TRUNC('WEEK', event_ts) < DATE_TRUNC('WEEK', current_date())
+```
+
+If you change the chart's aggregation grain (weekly → monthly), update **both** the `DATE_TRUNC` in `GROUP BY` and the one in the `WHERE`. Mismatched grains cause the same cliff.
+
+## Range-slider filter shows error or no min/max
+
+- The bound `fieldName` must be a numeric or temporal column. Categorical fields fail at render — use `filter-single-select` / `filter-multi-select` instead.
+- Query inside the filter widget must include the field as a plain expression (`{"name": "x", "expression": "\`x\`"}`), not pre-aggregated.
+
+## Symbol-map shows no points
+
+- Verify the dataset returns both `latitude` and `longitude` columns with valid floats (not strings, not nulls for all rows).
+- Lat values must be in [-90, 90], lon in [-180, 180]. Out-of-range rows are silently dropped.
+- For region-based maps (countries, states), use `choropleth-map`, not `symbol-map`.
+
+## Annotations not appearing on chart
+
+- `annotations` is a sibling of `encodings` inside `spec`, not nested inside it.
+- Each annotation needs `type: "vertical-line"`, `encodings.x.dataValue` matching the chart's x-axis type, and a matching `dataType` (`DATETIME` / `STRING` / `NUMBER`).
+- Annotations are only rendered on time-series chart types (`line`, `area`, `bar`, `combo`, `forecast-line`). Pie / pivot / map ignore them.

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -272,7 +272,7 @@ Apply unless user specifies otherwise:
 
 ## Reference Files
 
-> **Before generating any dashboard JSON, read [4-examples.md](4-examples.md) first.** It's a complete, validated, copy-pasteable dashboard exercising every construct (dataset measures + `MEASURE()`, sparkline counters, forecast-line with annotations, pivot with conditional cells, symbol-map, histogram, range-slider filter, theme). Starting from the working example and adapting is far more reliable than writing from scratch — most failure modes are subtle shape errors that are easy to copy correctly and hard to invent correctly.
+> **Before generating any dashboard JSON, read [4-examples.md](4-examples.md) first.** It's a complete reference dashboard exercising every construct (dataset measures + `MEASURE()`, sparkline counters, forecast-line with annotations, pivot with conditional cells, symbol-map, histogram, range-slider filter, theme). Use it to learn the JSON shape; then adapt to the user's data and demo story — keep the structure, swap the tables, metrics, palette, and narrative for the case you're building.
 
 | What are you building? | Reference |
 |------------------------|-----------|

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -214,20 +214,46 @@ Every dashboard's `serialized_dashboard` content must follow this exact structur
 - `pageType`: Required on every page (`PAGE_TYPE_CANVAS` or `PAGE_TYPE_GLOBAL_FILTERS`)
 - Query binding: `query.fields[].name` must exactly match `encodings.*.fieldName`
 
-### Linking a Genie Space (Optional)
+### Dashboard Theme (Optional)
 
-To add an "Ask Genie" button to the dashboard, or to link a genie space/room with an ID, add `uiSettings.genieSpace` to the JSON:
+Top-level `uiSettings.theme` controls colors, fonts, and widget chrome across every widget on the dashboard. Without it, the dashboard inherits the workspace default. With it, you get a consistent palette across all charts, plus the index that `{"themeColorType": "visualizationColors", "position": N}` in per-widget specs resolves against.
 
 ```json
 {
   "datasets": [...],
   "pages": [...],
   "uiSettings": {
-    "genieSpace": {
-      "isEnabled": true,
-      "overrideId": "your-genie-space-id-here",
-      "enablementMode": "ENABLED"
+    "theme": {
+      "canvasBackgroundColor": {"light": "#FCFCFC", "dark": "#1F272D"},
+      "widgetBackgroundColor": {"light": "#FFFFFF", "dark": "#11171C"},
+      "fontColor":             {"light": "#11171C", "dark": "#E8ECF0"},
+      "selectionColor":        {"light": "#2272B4", "dark": "#8ACAFF"},
+      "visualizationColors": [
+        "#FFA600", "#FF7054", "#DE5582", "#995495",
+        "#4E5185", "#1D425C", "#99DDB4"
+      ],
+      "widgetHeaderAlignment": "LEFT"
     }
+  }
+}
+```
+
+- `visualizationColors` is the **ordered palette** chart series and category mappings cycle through. `position: 1` is the first color (`#FFA600` above), `position: 6` is the 6th (`#1D425C`). Length is whatever you want — 5-8 colors is typical.
+- Background / font / selection colors take `light` + `dark` pairs; the dashboard automatically applies the right pair based on the viewer's mode.
+- `widgetHeaderAlignment`: `"LEFT"` (default), `"CENTER"`, or `"RIGHT"`.
+- Per-widget color references use `{"themeColorType": "visualizationColors", "position": N}` to pin a value to a specific slot in this palette (e.g., Critical → position 6 → always red, regardless of how the chart sorts). For an exact hex outside the palette, use `{"hex": "#FF0000"}` instead.
+
+### Linking a Genie Space (Optional)
+
+To add an "Ask Genie" button to the dashboard, or to link a genie space/room with an ID, add `uiSettings.genieSpace` to the JSON (alongside `theme` if you have one):
+
+```json
+"uiSettings": {
+  "theme": { /* ... */ },
+  "genieSpace": {
+    "isEnabled": true,
+    "overrideId": "your-genie-space-id-here",
+    "enablementMode": "ENABLED"
   }
 }
 ```

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -26,17 +26,31 @@ A dashboard should be showing something relevant for a human, typically some KPI
 
 ---
 
-## CRITICAL: Widget Version Requirements
+## Widget Index (Version + Where Documented)
 
 > **Wrong version = broken widget!** This is the #1 cause of dashboard errors.
 
-| Widget Type | Version | Notes |
-|-------------|---------|-------|
-| `counter` | **2** | KPI cards |
-| `table` | **2** | Data tables |
-| `bar`, `line`, `area`, `pie`, `scatter` | **3** | Charts |
-| `combo`, `choropleth-map` | **1** | Advanced charts |
-| `filter-*` | **2** | All filter types |
+| Widget Type | Version | Documented in |
+|-------------|---------|---------------|
+| `counter` (KPI + sparkline + comparison) | **2** | [1-widget-specifications.md](1-widget-specifications.md) |
+| `table` | **2** | [1-widget-specifications.md](1-widget-specifications.md) |
+| `bar`, `line`, `pie` | **3** | [1-widget-specifications.md](1-widget-specifications.md) |
+| text (markdown, no spec block) | N/A | [1-widget-specifications.md](1-widget-specifications.md) |
+| `area`, `scatter` | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `combo` (bar+line, dual-axis) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `forecast-line` (with `AI_FORECAST` SQL) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `pivot` (with conditional cell rules) | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `histogram` (with `bin(col, binWidth=N)`) | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `heatmap` | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `funnel` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `sankey` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `box` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `waterfall` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `choropleth-map` (regions colored by value) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `symbol-map` (lat/lon point map) | **2** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
+| `filter-single-select`, `filter-multi-select`, `filter-date-range-picker`, `range-slider` | **2** | [3-filters.md](3-filters.md) |
+
+> Cohort retention charts are built as a `pivot` with a color-scale cell style — there is no `cohort` widget type. See pivot in [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md).
 
 ---
 
@@ -244,7 +258,10 @@ Apply unless user specifies otherwise:
 ### 1) DATASET ARCHITECTURE
 
 - **One dataset per domain** (e.g., orders, customers, products). Datasets shared across widgets benefit from the same filters.
-- **Exactly ONE valid SQL query per dataset** (no multiple queries separated by `;`)
+- **Two ways to define a dataset**:
+  - **SQL query**: `{"name": "ds_x", "displayName": "...", "queryLines": ["SELECT ...", "FROM table"]}` — full control, can include `WITH` / `JOIN` / `AI_FORECAST` / etc.
+  - **UC asset shorthand**: `{"name": "ds_x", "displayName": "...", "asset_name": "catalog.schema.table_or_view"}` — no SQL needed. Works for regular tables, views, and metric views.
+- **Exactly ONE valid SQL query per dataset** when using `queryLines` (no multiple queries separated by `;`)
 - **Queries must use bare table names only** — no catalog, no schema prefix. Example: `FROM orders`, never `FROM gold.orders` or `FROM main.gold.orders`. The catalog and schema come from the `--dataset-catalog` and `--dataset-schema` flags at creation time. These flags only fill in missing parts — they do NOT override any catalog/schema written in the query.
 - SELECT must include all dimensions needed by widgets and all derived columns via `AS` aliases
 - Put ALL business logic (CASE/WHEN, COALESCE, ratios) into the dataset SELECT with explicit aliases
@@ -253,6 +270,39 @@ Apply unless user specifies otherwise:
   - Time series: `ORDER BY date` for chronological display
   - Rankings/Top-N: `ORDER BY metric DESC LIMIT 10` for "Top 10" charts
   - Categorical charts: `ORDER BY metric DESC` to show largest values first
+
+#### Dataset-level measures + `MEASURE()`
+
+Widget expressions are usually inline aggregations (`{"name": "sum(x)", "expression": "SUM(\`x\`)"}`). But you can also **declare reusable measures on the dataset itself** and reference them by name — every widget that consumes the dataset can use the same metric without redefining it.
+
+Two ways to define measures:
+
+1. **Dashboard-level `columns`** (works on any dataset — SQL query or `asset_name`):
+   ```json
+   {
+     "name": "ds_support",
+     "queryLines": ["SELECT * FROM support_cases"],
+     "columns": [
+       {"displayName": "Total Cases",     "description": "Count of cases",
+        "expression": "COUNT(`case_id`)"},
+       {"displayName": "Reopen Rate %",   "description": "% of reopened cases",
+        "expression": "SUM(CASE WHEN `reopened_flag` THEN 1 ELSE 0 END) * 100.0 / COUNT(`case_id`)"},
+       {"displayName": "Priority Level",  "description": "Sorted priority label",
+        "expression": "CASE WHEN `priority`='Critical' THEN '1-Critical' ELSE '4-Low' END"}
+     ]
+   }
+   ```
+
+2. **Metric-view source** — if the dataset's `asset_name` (or `FROM` clause) is a UC metric view, its YAML-defined measures are already queryable. **Do not redeclare them** in `columns`. See [databricks-metric-views](../databricks-metric-views/SKILL.md).
+
+Either way, widgets reference the measure by name:
+
+```json
+"fields": [{"name": "measure(Total Cases)", "expression": "MEASURE(`Total Cases`)"}],
+"encodings": {"value": {"fieldName": "measure(Total Cases)", "displayName": "Total Cases"}}
+```
+
+`MEASURE(\`...\`)` works in counter, table, bar, line, pie, pivot — any widget that takes a field expression. Mix it with inline aggregations freely.
 
 ### 2) WIDGET FIELD EXPRESSIONS
 

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -272,12 +272,14 @@ Apply unless user specifies otherwise:
 
 ## Reference Files
 
+> **Before generating any dashboard JSON, read [4-examples.md](4-examples.md) first.** It's a complete, validated, copy-pasteable dashboard exercising every construct (dataset measures + `MEASURE()`, sparkline counters, forecast-line with annotations, pivot with conditional cells, symbol-map, histogram, range-slider filter, theme). Starting from the working example and adapting is far more reliable than writing from scratch — most failure modes are subtle shape errors that are easy to copy correctly and hard to invent correctly.
+
 | What are you building? | Reference |
 |------------------------|-----------|
+| **Start here** — full working dashboard template | [4-examples.md](4-examples.md) |
 | Any widget (text, counter, table, chart) | [1-widget-specifications.md](1-widget-specifications.md) |
 | Advanced charts (area, scatter/Bubble, combo (Line+Bar), Choropleth map) | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
 | Dashboard with filters (global or page-level) | [3-filters.md](3-filters.md) |
-| Need a complete working template to adapt | [4-examples.md](4-examples.md) |
 | Debugging a broken dashboard | [5-troubleshooting.md](5-troubleshooting.md) |
 
 ---

--- a/databricks-skills/databricks-aibi-dashboards/SKILL.md
+++ b/databricks-skills/databricks-aibi-dashboards/SKILL.md
@@ -32,23 +32,26 @@ A dashboard should be showing something relevant for a human, typically some KPI
 
 | Widget Type | Version | Documented in |
 |-------------|---------|---------------|
-| `counter` (KPI + sparkline + comparison) | **2** | [1-widget-specifications.md](1-widget-specifications.md) |
-| `table` | **2** | [1-widget-specifications.md](1-widget-specifications.md) |
-| `bar`, `line`, `pie` | **3** | [1-widget-specifications.md](1-widget-specifications.md) |
-| text (markdown, no spec block) | N/A | [1-widget-specifications.md](1-widget-specifications.md) |
-| `area`, `scatter` | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `combo` (bar+line, dual-axis) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `forecast-line` (with `AI_FORECAST` SQL) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `pivot` (with conditional cell rules) | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `histogram` (with `bin(col, binWidth=N)`) | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `heatmap` | **3** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `funnel` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `sankey` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `box` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `waterfall` | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `choropleth-map` (regions colored by value) | **1** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `symbol-map` (lat/lon point map) | **2** | [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md) |
-| `filter-single-select`, `filter-multi-select`, `filter-date-range-picker`, `range-slider` | **2** | [3-filters.md](3-filters.md) |
+| `counter` (KPI + sparkline + comparison) | **2** | [1-widget-specifications.md#counter-kpi](1-widget-specifications.md#counter-kpi) (L71) |
+| `table` | **2** | [1-widget-specifications.md#table](1-widget-specifications.md#table) (L235) |
+| `bar`, `line` | **3** | [1-widget-specifications.md#line--bar-charts](1-widget-specifications.md#line--bar-charts) (L310) |
+| `pie` | **3** | [1-widget-specifications.md#pie-chart](1-widget-specifications.md#pie-chart) (L422) |
+| text (markdown, no spec block) | N/A | [1-widget-specifications.md#text-headersdescriptions](1-widget-specifications.md#text-headersdescriptions) (L33) |
+| `area` | **3** | [2-advanced-widget-specifications.md#area-chart](2-advanced-widget-specifications.md#area-chart) (L7) |
+| `scatter` | **3** | [2-advanced-widget-specifications.md#scatter-plot--bubble-chart](2-advanced-widget-specifications.md#scatter-plot--bubble-chart) (L34) |
+| `combo` (bar+line, dual-axis) | **1** | [2-advanced-widget-specifications.md#combo-chart-bar--line](2-advanced-widget-specifications.md#combo-chart-bar--line) (L57) |
+| `forecast-line` (with `AI_FORECAST` SQL) | **1** | [2-advanced-widget-specifications.md#forecast-line-with-ai_forecast](2-advanced-widget-specifications.md#forecast-line-with-ai_forecast) (L166) |
+| `pivot` (with conditional cell rules) | **3** | [2-advanced-widget-specifications.md#pivot](2-advanced-widget-specifications.md#pivot) (L241) |
+| `histogram` (with `bin(col, binWidth=N)`) | **3** | [2-advanced-widget-specifications.md#histogram](2-advanced-widget-specifications.md#histogram) (L302) |
+| `heatmap` | **3** | [2-advanced-widget-specifications.md#heatmap](2-advanced-widget-specifications.md#heatmap) (L398) |
+| `funnel` | **1** | [2-advanced-widget-specifications.md#funnel](2-advanced-widget-specifications.md#funnel) (L424) |
+| `sankey` | **1** | [2-advanced-widget-specifications.md#sankey](2-advanced-widget-specifications.md#sankey) (L338) |
+| `box` | **1** | [2-advanced-widget-specifications.md#box](2-advanced-widget-specifications.md#box) (L448) |
+| `waterfall` | **1** | [2-advanced-widget-specifications.md#waterfall](2-advanced-widget-specifications.md#waterfall) (L470) |
+| `choropleth-map` (regions colored by value) | **1** | [2-advanced-widget-specifications.md#choropleth-map](2-advanced-widget-specifications.md#choropleth-map) (L109) |
+| `symbol-map` (lat/lon point map) | **2** | [2-advanced-widget-specifications.md#symbol-map-point-map](2-advanced-widget-specifications.md#symbol-map-point-map) (L364) |
+| `filter-single-select`, `filter-multi-select`, `filter-date-range-picker` | **2** | [3-filters.md#filter-widget-structure](3-filters.md#filter-widget-structure) (L32) |
+| `range-slider` | **2** | [3-filters.md#range-slider-numeric-range-filter](3-filters.md#range-slider-numeric-range-filter) (L239) |
 
 > Cohort retention charts are built as a `pivot` with a color-scale cell style — there is no `cohort` widget type. See pivot in [2-advanced-widget-specifications.md](2-advanced-widget-specifications.md).
 


### PR DESCRIPTION
## Summary

Upgrades the `databricks-aibi-dashboards` skill against (1) an in-the-wild example dashboard (dbdemos Customer Support Analysis) and (2) the four canonical Databricks docs pages — visualization types, maps, tables, text widgets.

- **`SKILL.md`** now has a complete widget index (every widget type → version → reference file), plus a new "Dataset-level measures + `MEASURE()`" subsection that documents both `dataset.columns[]` and the metric-view source path in one canonical place.
- **`1-widget-specifications.md`** — counter sparkline (`period`), comparison/target, format templates; bar custom-order sort + color `mappings` + 100% stacking; new cross-cutting Annotations subsection (vertical-line markers); table per-column conditional styling + link templates + tooltips.
- **`2-advanced-widget-specifications.md`** — proper sections for the previously-stub widget types: `forecast-line` (with `AI_FORECAST` template), `pivot` (with conditional cell rules + cohort note), `histogram`, `sankey`, `symbol-map` (distinguished from `choropleth-map`), `heatmap`, `funnel`, `box`, `waterfall`.
- **`3-filters.md`** — `range-slider` filter (numeric ranges).
- **`4-examples.md`** — rewritten Support Operations dashboard that exercises every new feature in one cohesive ~480-line JSON.
- **`5-troubleshooting.md`** — five new entries covering MEASURE() errors, forecast-line gotchas, range-slider misuse, symbol-map no-points, annotations not rendering.

### Forecast partial-bucket fix

Specific call-out: forecast charts dip right before the prediction starts because the last historical bucket is the **current (partial) period**. The skill now documents the fix in three places (forecast section, example SQL, troubleshooting): cutoff with \`WHERE DATE_TRUNC('<grain>', col) < DATE_TRUNC('<grain>', current_date())\` — grain MUST match the chart aggregation grain.

## Test plan

- [x] JSON example in \`4-examples.md\` parses cleanly via \`json.loads\`
- [x] Widget index in SKILL.md cross-references every section heading in \`1-\` and \`2-\`
- [ ] Manual deploy of the example dashboard against a test workspace (skipped for review — agent runs will exercise this)
- [ ] Run dashboard skill ground-truth tests once outcome-scorer lands

Net: +898 / -329 across 6 files.

This pull request and its description were written by Isaac.