### PR TITLE
skill: add databricks-qubika-metric-views

### DIFF
--- a/databricks-skills/databricks-qubika-metric-views/SKILL.md
+++ b/databricks-skills/databricks-qubika-metric-views/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: qubika-metric-views
+description: "Define governed, reusable business KPIs (revenue, conversion, order metrics) as Unity Catalog Metric Views. Use when building a KPI layer shared across dashboards, Genie Spaces, and SQL queries, or when defining ratio/window metrics that need safe re-aggregation."
+version: 1.0.0
+domain: data-analytics
+owner: data-platform-team
+---
+
+# Qubika Metric Views
+
+Unity Catalog Metric Views are the **canonical KPI layer** at Qubika. They separate metric definitions (what Revenue means, how Conversion Rate is calculated) from the query consuming them, making it safe to re-aggregate ratios and share consistent numbers across AI/BI dashboards, Genie Spaces, and ad-hoc SQL — without copy-pasting business logic.
+
+---
+
+## When to Use This Skill
+
+Use this skill when:
+- Defining a business KPI that will be consumed by more than one dashboard or team
+- Building ratio or per-unit metrics (Revenue per Customer, Fulfillment Rate) that break when re-aggregated naively
+- Creating a Gold-layer semantic layer on top of existing Silver or Gold Delta tables
+- Enabling a Genie Space with governed, pre-defined measures
+- Setting up period-over-period, YTD, or moving-average measures (window measures)
+
+Do NOT use this skill when:
+- Writing a one-off analytical query — use a SQL notebook instead
+- The "metric" is a simple column alias that doesn't need governance or reuse
+- The source table is in the Bronze layer — metric views belong on Silver or Gold
+
+---
+
+## Plan & Confirm Gates
+
+Before creating any metric view, Claude must:
+
+1. Present a numbered plan of every object to be created (catalog, schema, view name, source table, dimensions, measures).
+2. Confirm the **catalog** with the engineer — never default to one.
+3. Wait for explicit approval before issuing any `CREATE` or MCP `create` call.
+
+```
+✅ CORRECT:
+   "Here is my plan:
+    1. Create metric view `qubika_dev.sales_gold.order_kpis`
+       - Source: `qubika_dev.sales_silver.orders`
+       - Dimensions: Order Month, Customer Segment, Region
+       - Measures: Order Count, Total Revenue, Revenue per Customer, Fulfillment Rate
+    2. Add UC descriptions to the view and all measures (CLAUDE.md §11)
+    Shall I proceed?"
+
+❌ WRONG:
+   Creating the view and running the first query without asking.
+```
+
+---
+
+## Quick Start
+
+### Step 1 — Inspect the source table
+
+```python
+get_table_stats_and_schema(
+    catalog="qubika_dev",
+    schema="sales_silver",
+    table_names=["orders"],
+    table_stat_level="SIMPLE"
+)
+```
+
+### Step 2 — Create the metric view
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.sales_gold.order_kpis
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.sales_silver.orders
+  comment: "Core order KPIs for the Sales domain — shared across dashboards and Genie"
+  filter: order_date >= '2023-01-01'
+
+  dimensions:
+    - name: Order Month
+      expr: DATE_TRUNC('MONTH', order_date)
+      comment: "Calendar month of the order, UTC"
+    - name: Customer Segment
+      expr: CASE
+        WHEN customer_tier = 'A' THEN 'Enterprise'
+        WHEN customer_tier = 'B' THEN 'Mid-Market'
+        ELSE 'SMB'
+        END
+      comment: "Derived from customer_tier: A=Enterprise, B=Mid-Market, else SMB"
+    - name: Region
+      expr: region
+      comment: "Geographic region — source column, self-reported by sales rep"
+
+  measures:
+    - name: Order Count
+      expr: COUNT(1)
+      comment: "Total number of orders"
+    - name: Total Revenue
+      expr: SUM(total_price)
+      comment: "Sum of total_price (USD). Excludes cancelled orders via global filter."
+    - name: Revenue per Customer
+      expr: SUM(total_price) / COUNT(DISTINCT customer_id)
+      comment: "Average revenue per unique customer — safe ratio, not a simple AVG"
+    - name: Fulfillment Rate
+      expr: COUNT(1) FILTER (WHERE status = 'FULFILLED') * 1.0 / COUNT(1)
+      comment: "Fraction of orders fulfilled. Value 0–1, multiply by 100 for percentage."
+$$
+```
+
+### Step 3 — Add UC descriptions (mandatory, CLAUDE.md §11)
+
+```sql
+COMMENT ON VIEW qubika_dev.sales_gold.order_kpis
+  IS 'Core order KPIs for the Sales domain. Metric view on top of sales_silver.orders. Use MEASURE() to query measures.';
+```
+
+> **Note:** The `comment` fields inside the YAML are stored as column-level descriptions in the Catalog Explorer. The `COMMENT ON VIEW` above adds the table-level description. Both are required.
+
+### Step 4 — Query
+
+All measures must use the `MEASURE()` function. `SELECT *` is not supported.
+
+```sql
+-- Monthly revenue by segment
+SELECT
+  `Order Month`,
+  `Customer Segment`,
+  MEASURE(`Total Revenue`)        AS total_revenue,
+  MEASURE(`Order Count`)          AS order_count,
+  MEASURE(`Revenue per Customer`) AS rev_per_customer
+FROM qubika_dev.sales_gold.order_kpis
+WHERE EXTRACT(YEAR FROM `Order Month`) = 2024
+GROUP BY ALL
+ORDER BY `Order Month`, total_revenue DESC
+
+-- Single KPI scalar (for a counter widget)
+SELECT MEASURE(`Total Revenue`) AS total_revenue
+FROM qubika_dev.sales_gold.order_kpis
+WHERE `Order Month` >= DATE_TRUNC('MONTH', CURRENT_DATE())
+GROUP BY ALL
+```
+
+### Step 5 — Via MCP tool
+
+```python
+manage_metric_views(
+    action="create",
+    full_name="qubika_dev.sales_gold.order_kpis",
+    source="qubika_dev.sales_silver.orders",
+    or_replace=True,
+    comment="Core order KPIs for the Sales domain — shared across dashboards and Genie",
+    filter_expr="order_date >= '2023-01-01'",
+    dimensions=[
+        {"name": "Order Month",       "expr": "DATE_TRUNC('MONTH', order_date)",          "comment": "Calendar month of the order, UTC"},
+        {"name": "Customer Segment",  "expr": "CASE WHEN customer_tier = 'A' THEN 'Enterprise' WHEN customer_tier = 'B' THEN 'Mid-Market' ELSE 'SMB' END", "comment": "Derived from customer_tier"},
+        {"name": "Region",            "expr": "region",                                    "comment": "Geographic region — source column"},
+    ],
+    measures=[
+        {"name": "Order Count",          "expr": "COUNT(1)",                                                             "comment": "Total number of orders"},
+        {"name": "Total Revenue",        "expr": "SUM(total_price)",                                                     "comment": "Sum of total_price (USD)"},
+        {"name": "Revenue per Customer", "expr": "SUM(total_price) / COUNT(DISTINCT customer_id)",                       "comment": "Average revenue per unique customer"},
+        {"name": "Fulfillment Rate",     "expr": "COUNT(1) FILTER (WHERE status = 'FULFILLED') * 1.0 / COUNT(1)",        "comment": "Fraction of orders fulfilled (0–1)"},
+    ],
+)
+```
+
+---
+
+## Naming Conventions
+
+| Object | Convention | Example |
+|--------|------------|---------|
+| Catalog | `qubika_dev` (dev) / `qubika_prod` (prod) | `qubika_dev` |
+| Schema | `{domain}_gold` — metric views live on Gold | `sales_gold` |
+| View name | `{domain}_{entity}_kpis` or `{domain}_{entity}_metrics` | `sales_order_kpis` |
+| Dimension names | Title case with spaces | `Order Month`, `Customer Segment` |
+| Measure names | Title case, noun phrase | `Total Revenue`, `Fulfillment Rate` |
+
+---
+
+## Common Patterns
+
+See [patterns.md](patterns.md) for full code examples. Summary:
+
+- **Simple flat table** — Pattern 1 (single source, direct column dims + standard aggregations)
+- **Business-friendly categories** — Pattern 2 (CASE-derived dimensions for bucketing)
+- **Ratios and per-unit KPIs** — Pattern 3 (profit margin, revenue per employee)
+- **Status-segmented measures** — Pattern 4 (FILTER clause — open vs. fulfilled, active vs. churned)
+- **Star schema** — Pattern 5 (fact + dim_customer + dim_product joins)
+- **Snowflake / geographic hierarchy** — Pattern 6 (nested joins — requires DBR 17.1+)
+- **Pre-computed aggregations** — Pattern 7 (materialization for high-query-volume KPIs)
+- **Moving averages, YTD, running totals** — Pattern 9 (window measures — experimental, `version: 0.1`)
+
+---
+
+## Anti-Patterns
+
+```sql
+-- ❌ WRONG — ratio computed in the query, breaks on re-aggregation
+SELECT
+  region,
+  SUM(revenue) / COUNT(customer_id) AS rev_per_customer  -- NOT safe across GROUP BY
+FROM qubika_dev.sales_gold.order_kpis
+GROUP BY region
+
+-- ✅ CORRECT — define the ratio as a measure, query it with MEASURE()
+SELECT
+  `Region`,
+  MEASURE(`Revenue per Customer`) AS rev_per_customer
+FROM qubika_dev.sales_gold.order_kpis
+GROUP BY ALL
+```
+
+```sql
+-- ❌ WRONG — SELECT * is not supported on metric views
+SELECT * FROM qubika_dev.sales_gold.order_kpis
+
+-- ✅ CORRECT — explicitly list dimensions and wrap measures in MEASURE()
+SELECT `Region`, MEASURE(`Total Revenue`) AS revenue
+FROM qubika_dev.sales_gold.order_kpis
+GROUP BY ALL
+```
+
+```sql
+-- ❌ WRONG — metric view on a Bronze table
+CREATE OR REPLACE VIEW qubika_dev.raw.order_kpis   -- raw = Bronze, not appropriate
+WITH METRICS ...
+
+-- ✅ CORRECT — metric views sit on Silver or Gold
+CREATE OR REPLACE VIEW qubika_dev.sales_gold.order_kpis
+WITH METRICS ...
+```
+
+| Anti-pattern | Problem | Correct alternative |
+|---|---|---|
+| Ratio computed in the SELECT query | Breaks when GROUP BY changes | Define as a measure with SUM/COUNT, use `MEASURE()` |
+| `SELECT *` on a metric view | Not supported — runtime error | Explicitly list dimensions + `MEASURE()` calls |
+| Building on Bronze tables | Data not validated; no medallion contract | Source from Silver or Gold only |
+| Skipping `comment` on measures | No documentation in Catalog Explorer or Genie | Every measure and dimension must have a `comment` |
+| Missing `COMMENT ON VIEW` | Table-level UC description is blank | Always run `COMMENT ON VIEW` after creation |
+| Hardcoding `qubika_prod` without approval | Writes to production | Always use `qubika_dev` and confirm prod promotion explicitly |
+| Using spaces in backtick-quoted identifiers inconsistently | Query errors | Backtick-quote all dimension/measure names that contain spaces |
+
+---
+
+## UC Descriptions Checklist (CLAUDE.md §11)
+
+After creating or altering a metric view, verify:
+
+- [ ] `comment` field populated on the view (top-level YAML)
+- [ ] `comment` field populated on **every** dimension
+- [ ] `comment` field populated on **every** measure
+- [ ] `COMMENT ON VIEW catalog.schema.view IS '...'` executed (table-level UC description)
+
+Column-level comments travel into Catalog Explorer, Genie, and AI/BI dashboard column pickers. Without them, analysts have no context on what a measure means.
+
+---
+
+## Runtime Requirements
+
+| Feature | Minimum DBR |
+|---------|-------------|
+| Metric views (YAML v1.1) | 17.2+ |
+| Metric views (YAML v0.1) | 16.4+ |
+| Snowflake / nested joins | 17.1+ |
+| Materialization | 17.2+ (serverless required) |
+| Window measures | 16.4+ (experimental, `version: 0.1`) |
+
+---
+
+## Reference Files
+
+- [patterns.md](patterns.md) — Nine common patterns with full code (single table, joins, ratios, filtered measures, window measures, materialization)
+- [yaml-reference.md](yaml-reference.md) — Complete YAML spec: dimensions, measures, joins, filters, materialization, window blocks
+- [Databricks Metric Views docs](https://docs.databricks.com/en/metric-views/)
+- [MEASURE() function reference](https://docs.databricks.com/en/sql/language-manual/functions/measure)
+
+---
+
+## FAQ
+
+| Question | Answer |
+|----------|--------|
+| Can I source a metric view from another metric view? | No — source must be a table or view, not another metric view. |
+| Can dimensions reference columns from joined tables? | Yes — use `join_name.column_name` in the `expr`. |
+| Why does `MEASURE()` exist instead of just SUM()? | It signals to the engine that safe re-aggregation rules apply (e.g. ratio measures). Without it, the query errors. |
+| Can I add a metric view to an AI/BI dashboard? | Yes — add it as a dataset in the dashboard. Queries must use `MEASURE()`. |
+| Can I add a metric view to a Genie Space? | Yes — Genie natively understands metric views and the MEASURE() contract. |
+| Should metric views be in `qubika_dev` or `qubika_prod`? | Always develop in `qubika_dev`. Promote to `qubika_prod` only after explicit confirmation (CLAUDE.md §12). |
+| What if my source table is updated frequently? | Use materialization (`every N hours`) or accept live re-computation — metric views run on the warehouse at query time. |
+
+---
+
+## Related Skills
+
+- `qubika-aibi-dashboards` — consume this KPI layer in Lakeview dashboards
+- `qubika-medallion-architecture` — metric views sit on the Gold layer of the medallion
+- `qubika-unity-catalog-governance` — catalog/schema creation, UC permissions, and descriptions
+- `qubika-data-quality` — validate the Silver tables that feed this metric view
+- `qubika-databricks-jobs` — schedule materialization pipeline refreshes
+
+---
+
+## Changelog
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0.0 | 2026-06-12 | Initial version — adapted from databricks-metric-views (ai-dev-kit) with Qubika naming conventions, plan gates, UC description requirements, and anti-patterns |

--- a/databricks-skills/databricks-qubika-metric-views/patterns.md
+++ b/databricks-skills/databricks-qubika-metric-views/patterns.md
@@ -1,0 +1,653 @@
+# Metric View Patterns & Examples
+
+Common patterns for creating and querying metric views.
+
+> **Qubika conventions:** Replace `{domain}` with your actual domain (e.g. `sales`, `marketing`, `ops`). All examples use `qubika_dev` — confirm the catalog with the engineer before creating any object. Always add `comment` fields on every dimension and measure (CLAUDE.md §11).
+
+## Pattern 1: Simple Metrics from a Single Table
+
+The most basic pattern with direct column dimensions and standard aggregations.
+
+### Create
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.product_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.sales
+  comment: "Product sales metrics"
+  dimensions:
+    - name: Product Name
+      expr: product_name
+    - name: Sale Date
+      expr: sale_date
+  measures:
+    - name: Units Sold
+      expr: COUNT(1)
+    - name: Total Revenue
+      expr: SUM(price * quantity)
+    - name: Average Price
+      expr: AVG(price)
+$$
+```
+
+### Query
+
+```sql
+-- Revenue by product
+SELECT
+  `Product Name`,
+  MEASURE(`Total Revenue`) AS revenue,
+  MEASURE(`Units Sold`) AS units
+FROM qubika_dev.{domain}_gold.product_metrics
+GROUP BY ALL
+ORDER BY revenue DESC
+LIMIT 10
+
+-- Monthly trend
+SELECT
+  DATE_TRUNC('MONTH', `Sale Date`) AS month,
+  MEASURE(`Total Revenue`) AS revenue
+FROM qubika_dev.{domain}_gold.product_metrics
+GROUP BY ALL
+ORDER BY month
+```
+
+## Pattern 2: Derived Dimensions with CASE
+
+Transform raw values into business-friendly categories.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.order_kpis
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.orders
+  dimensions:
+    - name: Order Month
+      expr: DATE_TRUNC('MONTH', order_date)
+    - name: Priority Level
+      expr: CASE
+        WHEN priority <= 2 THEN 'High'
+        WHEN priority <= 4 THEN 'Medium'
+        ELSE 'Low'
+        END
+      comment: "Bucketed priority: High (1-2), Medium (3-4), Low (5)"
+    - name: Size Category
+      expr: CASE
+        WHEN total_amount > 10000 THEN 'Large'
+        WHEN total_amount > 1000 THEN 'Medium'
+        ELSE 'Small'
+        END
+  measures:
+    - name: Order Count
+      expr: COUNT(1)
+    - name: Total Amount
+      expr: SUM(total_amount)
+$$
+```
+
+## Pattern 3: Ratio Measures
+
+Ratios and per-unit metrics that safely handle re-aggregation.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.efficiency_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.transactions
+  comment: "Efficiency and per-unit metrics"
+  dimensions:
+    - name: Department
+      expr: department_name
+    - name: Quarter
+      expr: DATE_TRUNC('QUARTER', transaction_date)
+  measures:
+    - name: Total Revenue
+      expr: SUM(revenue)
+    - name: Total Cost
+      expr: SUM(cost)
+    - name: Profit Margin
+      expr: (SUM(revenue) - SUM(cost)) / SUM(revenue)
+      comment: "Profit as percentage of revenue"
+    - name: Revenue per Employee
+      expr: SUM(revenue) / COUNT(DISTINCT employee_id)
+    - name: Average Transaction Size
+      expr: SUM(revenue) / COUNT(1)
+$$
+```
+
+## Pattern 4: Filtered Measures (FILTER clause)
+
+Create measures that only count a subset of rows.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.order_status_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.orders
+  dimensions:
+    - name: Order Month
+      expr: DATE_TRUNC('MONTH', order_date)
+    - name: Region
+      expr: region
+  measures:
+    - name: Total Orders
+      expr: COUNT(1)
+    - name: Open Orders
+      expr: COUNT(1) FILTER (WHERE status = 'OPEN')
+    - name: Fulfilled Orders
+      expr: COUNT(1) FILTER (WHERE status = 'FULFILLED')
+    - name: Open Revenue
+      expr: SUM(amount) FILTER (WHERE status = 'OPEN')
+      comment: "Revenue at risk from unfulfilled orders"
+    - name: Fulfillment Rate
+      expr: COUNT(1) FILTER (WHERE status = 'FULFILLED') * 1.0 / COUNT(1)
+      comment: "Percentage of orders fulfilled"
+$$
+```
+
+### Query filtered measures
+
+```sql
+SELECT
+  `Order Month`,
+  MEASURE(`Total Orders`) AS total,
+  MEASURE(`Open Orders`) AS open_orders,
+  MEASURE(`Fulfillment Rate`) AS fulfillment_rate
+FROM qubika_dev.{domain}_gold.order_status_metrics
+WHERE `Region` = 'EMEA'
+GROUP BY ALL
+ORDER BY ALL
+```
+
+## Pattern 5: Star Schema with Joins
+
+Join a fact table to dimension tables.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.sales_analytics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.fact_sales
+  comment: "Sales analytics with customer and product dimensions"
+
+  joins:
+    - name: customer
+      source: qubika_dev.{domain}_silver.dim_customer
+      on: source.customer_id = customer.customer_id
+    - name: product
+      source: qubika_dev.{domain}_silver.dim_product
+      on: source.product_id = product.product_id
+    - name: store
+      source: qubika_dev.{domain}_silver.dim_store
+      on: source.store_id = store.store_id
+
+  dimensions:
+    - name: Customer Segment
+      expr: customer.segment
+    - name: Product Category
+      expr: product.category
+    - name: Store City
+      expr: store.city
+    - name: Sale Month
+      expr: DATE_TRUNC('MONTH', source.sale_date)
+
+  measures:
+    - name: Total Revenue
+      expr: SUM(source.amount)
+    - name: Unique Customers
+      expr: COUNT(DISTINCT source.customer_id)
+    - name: Average Basket Size
+      expr: SUM(source.amount) / COUNT(DISTINCT source.transaction_id)
+$$
+```
+
+## Pattern 6: Snowflake Schema (Nested Joins)
+
+Multi-level dimension hierarchies. Requires DBR 17.1+.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.geo_sales
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.orders
+
+  joins:
+    - name: customer
+      source: qubika_dev.{domain}_silver.customer
+      on: source.customer_key = customer.customer_key
+      joins:
+        - name: nation
+          source: qubika_dev.{domain}_silver.nation
+          on: customer.nation_key = nation.nation_key
+          joins:
+            - name: region
+              source: qubika_dev.{domain}_silver.region
+              on: nation.region_key = region.region_key
+
+  dimensions:
+    - name: Customer Name
+      expr: customer.name
+    - name: Nation
+      expr: nation.name
+    - name: Region
+      expr: region.name
+    - name: Order Year
+      expr: EXTRACT(YEAR FROM source.order_date)
+
+  measures:
+    - name: Total Revenue
+      expr: SUM(source.total_price)
+    - name: Order Count
+      expr: COUNT(1)
+$$
+```
+
+### Query across hierarchy levels
+
+```sql
+-- Revenue by region (rolls up across nations and customers)
+SELECT
+  `Region`,
+  MEASURE(`Total Revenue`) AS revenue
+FROM qubika_dev.{domain}_gold.geo_sales
+GROUP BY ALL
+
+-- Revenue by nation within a specific region
+SELECT
+  `Nation`,
+  MEASURE(`Total Revenue`) AS revenue,
+  MEASURE(`Order Count`) AS orders
+FROM qubika_dev.{domain}_gold.geo_sales
+WHERE `Region` = 'EUROPE'
+GROUP BY ALL
+ORDER BY revenue DESC
+```
+
+## Pattern 7: Materialized Metric View
+
+Pre-compute common aggregations for faster queries.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.ecommerce_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: qubika_dev.{domain}_silver.transactions
+
+  dimensions:
+    - name: Category
+      expr: product_category
+    - name: Day
+      expr: DATE_TRUNC('DAY', transaction_date)
+    - name: Channel
+      expr: sales_channel
+
+  measures:
+    - name: Revenue
+      expr: SUM(amount)
+    - name: Transactions
+      expr: COUNT(1)
+    - name: Unique Buyers
+      expr: COUNT(DISTINCT customer_id)
+
+  materialization:
+    schedule: every 1 hour
+    mode: relaxed
+    materialized_views:
+      - name: daily_category
+        type: aggregated
+        dimensions:
+          - Category
+          - Day
+        measures:
+          - Revenue
+          - Transactions
+      - name: full_model
+        type: unaggregated
+$$
+```
+
+## Pattern 8: Using samples.tpch for Quick Demos
+
+The TPC-H sample dataset is available on all Databricks workspaces.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.tpch_orders_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  source: samples.tpch.orders
+  comment: "TPC-H Orders KPIs - demo metric view"
+  filter: o_orderdate > '1990-01-01'
+
+  dimensions:
+    - name: Order Month
+      expr: DATE_TRUNC('MONTH', o_orderdate)
+      comment: "Month of order"
+    - name: Order Status
+      expr: CASE
+        WHEN o_orderstatus = 'O' THEN 'Open'
+        WHEN o_orderstatus = 'P' THEN 'Processing'
+        WHEN o_orderstatus = 'F' THEN 'Fulfilled'
+        END
+      comment: "Status: Open, Processing, or Fulfilled"
+    - name: Order Priority
+      expr: SPLIT(o_orderpriority, '-')[1]
+      comment: "Numeric priority 1-5; 1 is highest"
+
+  measures:
+    - name: Order Count
+      expr: COUNT(1)
+    - name: Total Revenue
+      expr: SUM(o_totalprice)
+      comment: "Sum of total price"
+    - name: Revenue per Customer
+      expr: SUM(o_totalprice) / COUNT(DISTINCT o_custkey)
+      comment: "Average revenue per distinct customer"
+    - name: Open Order Revenue
+      expr: SUM(o_totalprice) FILTER (WHERE o_orderstatus = 'O')
+      comment: "Potential revenue from open orders"
+$$
+```
+
+### Demo queries
+
+```sql
+-- Monthly revenue trend
+SELECT
+  `Order Month`,
+  MEASURE(`Total Revenue`)::BIGINT AS revenue,
+  MEASURE(`Order Count`) AS orders
+FROM qubika_dev.{domain}_gold.tpch_orders_metrics
+WHERE extract(year FROM `Order Month`) = 1995
+GROUP BY ALL
+ORDER BY ALL
+
+-- Revenue by status
+SELECT
+  `Order Status`,
+  MEASURE(`Total Revenue`)::BIGINT AS revenue,
+  MEASURE(`Revenue per Customer`)::BIGINT AS rev_per_customer
+FROM qubika_dev.{domain}_gold.tpch_orders_metrics
+GROUP BY ALL
+
+-- Open orders risk assessment
+SELECT
+  `Order Month`,
+  MEASURE(`Open Order Revenue`)::BIGINT AS at_risk_revenue,
+  MEASURE(`Total Revenue`)::BIGINT AS total_revenue
+FROM qubika_dev.{domain}_gold.tpch_orders_metrics
+WHERE extract(year FROM `Order Month`) >= 1995
+GROUP BY ALL
+ORDER BY ALL
+```
+
+## Pattern 9: Window Measures (Experimental)
+
+Window measures enable moving averages, running totals, period-over-period changes, and semiadditive measures. Add a `window` block to any measure definition. See [Window Measures Documentation](https://docs.databricks.com/aws/en/metric-views/data-modeling/window-measures).
+
+### Window Range Values
+
+| Range | Description |
+|-------|-------------|
+| `current` | Only rows where the window ordering value equals the current row |
+| `cumulative` | All rows up to and including the current row |
+| `trailing <N> <unit>` | N units before the current row (**excludes** current) |
+| `leading <N> <unit>` | N units after the current row |
+| `all` | All rows regardless of ordering |
+
+### Trailing Window: 7-Day Distinct Customers
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.customer_activity
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 0.1
+  source: qubika_dev.{domain}_silver.orders
+  filter: order_date > DATE'2024-01-01'
+
+  dimensions:
+    - name: date
+      expr: order_date
+
+  measures:
+    - name: t7d_customers
+      expr: COUNT(DISTINCT customer_id)
+      window:
+        - order: date
+          range: trailing 7 day
+          semiadditive: last
+$$
+```
+
+**Key:** `trailing 7 day` includes the 7 days **before** each date, **excluding** the current date. `semiadditive: last` returns the last value when the `date` dimension is not in the GROUP BY.
+
+### Running Total (Cumulative)
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.cumulative_sales
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 0.1
+  source: qubika_dev.{domain}_silver.orders
+  filter: order_date > DATE'2024-01-01'
+
+  dimensions:
+    - name: date
+      expr: order_date
+
+  measures:
+    - name: running_total_sales
+      expr: SUM(total_price)
+      window:
+        - order: date
+          range: cumulative
+          semiadditive: last
+$$
+```
+
+### Period-Over-Period: Day-Over-Day Growth
+
+Compose window measures using `MEASURE()` references in derived measures.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.daily_growth
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 0.1
+  source: qubika_dev.{domain}_silver.orders
+  filter: order_date > DATE'2024-01-01'
+
+  dimensions:
+    - name: date
+      expr: order_date
+
+  measures:
+    - name: previous_day_sales
+      expr: SUM(total_price)
+      window:
+        - order: date
+          range: trailing 1 day
+          semiadditive: last
+
+    - name: current_day_sales
+      expr: SUM(total_price)
+      window:
+        - order: date
+          range: current
+          semiadditive: last
+
+    - name: day_over_day_growth
+      expr: (MEASURE(current_day_sales) - MEASURE(previous_day_sales)) / MEASURE(previous_day_sales) * 100
+$$
+```
+
+**Key:** The derived `day_over_day_growth` measure uses `MEASURE()` to reference other window measures. It does NOT need its own `window` block.
+
+### Year-to-Date (Composing Multiple Windows)
+
+A single measure can have multiple window specs to create period-to-date calculations.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.ytd_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 0.1
+  source: qubika_dev.{domain}_silver.orders
+  filter: order_date > DATE'2023-01-01'
+
+  dimensions:
+    - name: date
+      expr: order_date
+    - name: year
+      expr: DATE_TRUNC('year', order_date)
+
+  measures:
+    - name: ytd_sales
+      expr: SUM(total_price)
+      window:
+        - order: date
+          range: cumulative
+          semiadditive: last
+        - order: year
+          range: current
+          semiadditive: last
+$$
+```
+
+**Key:** The first window does a cumulative sum over `date`. The second window restricts scope to the `current` year. Together they produce year-to-date.
+
+### Semiadditive Measure: Bank Balance
+
+For measures like balances that should not be summed across time.
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.account_balances
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 0.1
+  source: qubika_dev.{domain}_silver.daily_balances
+
+  dimensions:
+    - name: date
+      expr: date
+    - name: customer
+      expr: customer_id
+
+  measures:
+    - name: balance
+      expr: SUM(balance)
+      window:
+        - order: date
+          range: current
+          semiadditive: last
+$$
+```
+
+**Key:** `semiadditive: last` prevents summing across dates (returns the last date's value instead), but the measure **still aggregates across other dimensions** like `customer`. When grouped by date, you get total balance across all customers for that day. When not grouped by date, you get the balance from the most recent date.
+
+### Query window measures
+
+Window measures are queried with the same `MEASURE()` syntax:
+
+```sql
+SELECT
+  date,
+  MEASURE(t7d_customers) AS trailing_7d_customers,
+  MEASURE(running_total_sales) AS running_total
+FROM qubika_dev.{domain}_gold.customer_activity
+WHERE date >= DATE'2024-06-01'
+GROUP BY ALL
+ORDER BY ALL
+```
+
+## MCP Tool Examples
+
+### Create with joins
+
+```python
+manage_metric_views(
+    action="create",
+    full_name="qubika_dev.{domain}_gold.sales_metrics",
+    source="qubika_dev.{domain}_silver.fact_sales",
+    or_replace=True,
+    joins=[
+        {
+            "name": "customer",
+            "source": "qubika_dev.{domain}_silver.dim_customer",
+            "on": "source.customer_id = customer.id"
+        },
+        {
+            "name": "product",
+            "source": "qubika_dev.{domain}_silver.dim_product",
+            "on": "source.product_id = product.id"
+        }
+    ],
+    dimensions=[
+        {"name": "Customer Segment", "expr": "customer.segment"},
+        {"name": "Product Category", "expr": "product.category"},
+        {"name": "Sale Month", "expr": "DATE_TRUNC('MONTH', source.sale_date)"},
+    ],
+    measures=[
+        {"name": "Total Revenue", "expr": "SUM(source.amount)"},
+        {"name": "Order Count", "expr": "COUNT(1)"},
+        {"name": "Unique Customers", "expr": "COUNT(DISTINCT source.customer_id)"},
+    ],
+)
+```
+
+### Alter to add a new measure
+
+```python
+manage_metric_views(
+    action="alter",
+    full_name="qubika_dev.{domain}_gold.sales_metrics",
+    source="qubika_dev.{domain}_silver.fact_sales",
+    joins=[
+        {"name": "customer", "source": "qubika_dev.{domain}_silver.dim_customer", "on": "source.customer_id = customer.id"},
+    ],
+    dimensions=[
+        {"name": "Customer Segment", "expr": "customer.segment"},
+        {"name": "Sale Month", "expr": "DATE_TRUNC('MONTH', source.sale_date)"},
+    ],
+    measures=[
+        {"name": "Total Revenue", "expr": "SUM(source.amount)"},
+        {"name": "Order Count", "expr": "COUNT(1)"},
+        {"name": "Average Order Value", "expr": "AVG(source.amount)"},  # New measure
+    ],
+)
+```
+
+### Query with filters
+
+```python
+manage_metric_views(
+    action="query",
+    full_name="qubika_dev.{domain}_gold.sales_metrics",
+    query_measures=["Total Revenue", "Order Count"],
+    query_dimensions=["Customer Segment", "Sale Month"],
+    where="`Customer Segment` = 'Enterprise'",
+    order_by="ALL",
+    limit=50,
+)
+```

--- a/databricks-skills/databricks-qubika-metric-views/yaml-reference.md
+++ b/databricks-skills/databricks-qubika-metric-views/yaml-reference.md
@@ -1,0 +1,340 @@
+# Metric View YAML Reference
+
+Complete reference for the YAML specification used in Unity Catalog metric views.
+
+> **Qubika conventions:** Replace `{domain}` with your actual domain (e.g. `sales`, `marketing`, `ops`). Use `qubika_dev` for development and `qubika_prod` for production — always confirm the catalog with the engineer before creating any object.
+
+## Top-Level Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `version` | No | string | YAML spec version. `"1.1"` for DBR 17.2+, `"0.1"` for DBR 16.4-17.1. Defaults to `1.1`. |
+| `source` | Yes | string | Source table, view, or SQL query in three-level namespace format. |
+| `comment` | No | string | Description of the metric view (v1.1+). |
+| `filter` | No | string | SQL boolean expression applied as a global WHERE clause. |
+| `dimensions` | Yes | list | Array of dimension definitions (at least one). |
+| `measures` | Yes | list | Array of measure definitions (at least one). |
+| `joins` | No | list | Star/snowflake schema join definitions. |
+| `materialization` | No | object | Pre-computation configuration (experimental). |
+
+## Dimensions
+
+Dimensions define the categorical attributes used to group and filter data.
+
+```yaml
+dimensions:
+  - name: Region               # Display name, backtick-quoted in queries
+    expr: region_name           # Direct column reference
+    comment: "Sales region"     # Optional description (v1.1+)
+
+  - name: Order Month
+    expr: DATE_TRUNC('MONTH', order_date)  # SQL transformation
+
+  - name: Order Year
+    expr: EXTRACT(YEAR FROM `Order Month`)  # Can reference other dimensions
+
+  - name: Customer Type
+    expr: CASE
+      WHEN customer_tier = 'A' THEN 'Enterprise'
+      WHEN customer_tier = 'B' THEN 'Mid-Market'
+      ELSE 'SMB'
+      END                      # Multi-line CASE expressions supported
+
+  - name: Nation
+    expr: customer.c_name      # Reference joined table columns
+```
+
+### Dimension Rules
+
+- `name` is required and becomes the column name in queries (backtick-quoted if it has spaces)
+- `expr` is required and must be a valid SQL expression
+- Can reference source columns, SQL functions, CASE expressions, and other dimensions
+- Can reference columns from joined tables using `join_name.column_name`
+- Cannot use aggregate functions (those belong in measures)
+
+## Measures
+
+Measures define aggregated values computed at query time.
+
+```yaml
+measures:
+  - name: Total Revenue
+    expr: SUM(total_price)
+    comment: "Sum of all order prices"
+
+  - name: Order Count
+    expr: COUNT(1)
+
+  - name: Average Order Value
+    expr: AVG(total_price)
+
+  - name: Unique Customers
+    expr: COUNT(DISTINCT customer_id)
+
+  - name: Revenue per Customer           # Ratio measure
+    expr: SUM(total_price) / COUNT(DISTINCT customer_id)
+
+  - name: Open Order Revenue             # Filtered measure
+    expr: SUM(total_price) FILTER (WHERE status = 'O')
+    comment: "Revenue from open orders only"
+
+  - name: Open Revenue per Customer      # Filtered ratio
+    expr: SUM(total_price) FILTER (WHERE status = 'O') / COUNT(DISTINCT customer_id) FILTER (WHERE status = 'O')
+```
+
+### Window Measures (Experimental)
+
+Add a `window` block to a measure for windowed, cumulative, or semiadditive aggregations. See [Window Measures Documentation](https://docs.databricks.com/aws/en/metric-views/data-modeling/window-measures).
+
+```yaml
+measures:
+  - name: Running Total
+    expr: SUM(total_price)
+    window:
+      - order: date              # Dimension that orders the window
+        range: cumulative        # Window extent (see range values below)
+        semiadditive: last       # How to summarize when order dim is not in GROUP BY
+
+  - name: 7-Day Customers
+    expr: COUNT(DISTINCT customer_id)
+    window:
+      - order: date
+        range: trailing 7 day    # 7 days before current, EXCLUDING current day
+        semiadditive: last
+```
+
+**Window range values:**
+
+| Range | Description |
+|-------|-------------|
+| `current` | Only rows matching the current ordering value |
+| `cumulative` | All rows up to and including the current row |
+| `trailing <N> <unit>` | N units before current row (excludes current) |
+| `leading <N> <unit>` | N units after current row |
+| `all` | All rows |
+
+**Window spec fields:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `order` | Yes | Dimension name that determines window ordering |
+| `range` | Yes | Window extent (see values above) |
+| `semiadditive` | Yes | `first` or `last` - value to use when order dimension is absent from GROUP BY |
+
+**Multiple windows** can be composed on a single measure (e.g., for year-to-date):
+
+```yaml
+  - name: ytd_sales
+    expr: SUM(total_price)
+    window:
+      - order: date
+        range: cumulative
+        semiadditive: last
+      - order: year
+        range: current
+        semiadditive: last
+```
+
+**Derived measures** can reference window measures using `MEASURE()`:
+
+```yaml
+  - name: day_over_day_growth
+    expr: (MEASURE(current_day_sales) - MEASURE(previous_day_sales)) / MEASURE(previous_day_sales) * 100
+```
+
+### Measure Rules
+
+- `name` is required and queried via `MEASURE(\`name\`)`
+- `expr` must contain an aggregate function (SUM, COUNT, AVG, MIN, MAX, etc.)
+- Supports `FILTER (WHERE ...)` for conditional aggregation
+- Supports ratios of aggregates
+- Derived measures can reference other measures via `MEASURE()` (used with window measures)
+- Window measures use `version: 0.1` (experimental feature)
+- `SELECT *` on metric views is NOT supported; must use `MEASURE()` explicitly
+
+## Joins
+
+### Star Schema (Single Level)
+
+```yaml
+source: qubika_dev.{domain}_gold.fact_orders
+joins:
+  - name: customer
+    source: qubika_dev.{domain}_gold.dim_customer
+    on: source.customer_id = customer.id
+
+  - name: product
+    source: qubika_dev.{domain}_gold.dim_product
+    on: source.product_id = product.id
+```
+
+### Star Schema with USING
+
+```yaml
+joins:
+  - name: customer
+    source: qubika_dev.{domain}_gold.dim_customer
+    using:
+      - customer_id
+      - region_id
+```
+
+### Snowflake Schema (Nested Joins, DBR 17.1+)
+
+```yaml
+source: qubika_dev.{domain}_gold.orders
+joins:
+  - name: customer
+    source: qubika_dev.{domain}_gold.customer
+    on: source.customer_id = customer.id
+    joins:
+      - name: nation
+        source: qubika_dev.{domain}_gold.nation
+        on: customer.nation_id = nation.id
+        joins:
+          - name: region
+            source: qubika_dev.{domain}_gold.region
+            on: nation.region_id = region.id
+```
+
+### Join Rules
+
+- `name` is required and used to reference joined columns: `name.column`
+- `source` is the fully qualified table/view name
+- Use either `on` (expression) or `using` (column list), not both
+- In `on`, reference the fact table as `source` and join tables by their `name`
+- Nested `joins` create snowflake schema (requires DBR 17.1+)
+- Joined tables cannot include MAP type columns
+
+## Filter
+
+A global filter applied to all queries as a WHERE clause.
+
+```yaml
+filter: order_date > '2020-01-01'
+
+# Multiple conditions
+filter: order_date > '2020-01-01' AND status != 'CANCELLED'
+
+# Using joined columns
+filter: customer.active = true
+```
+
+## Materialization (Experimental)
+
+Pre-compute aggregations for faster query performance. Uses Lakeflow Spark Declarative Pipelines under the hood.
+
+```yaml
+materialization:
+  schedule: every 6 hours           # Same syntax as MV schedule clause
+  mode: relaxed                     # Only "relaxed" supported currently
+
+  materialized_views:
+    - name: baseline
+      type: unaggregated            # Full unaggregated data model
+
+    - name: revenue_breakdown
+      type: aggregated              # Pre-computed aggregation
+      dimensions:
+        - category
+        - region
+      measures:
+        - total_revenue
+        - order_count
+
+    - name: daily_summary
+      type: aggregated
+      dimensions:
+        - order_date
+      measures:
+        - total_revenue
+```
+
+### Materialization Types
+
+| Type | Description | When to Use |
+|------|-------------|-------------|
+| `unaggregated` | Materializes full data model (source + joins + filter) | Expensive source views or many joins |
+| `aggregated` | Pre-computes specific dimension/measure combos | Frequently queried combinations |
+
+### Materialization Requirements
+
+- Serverless compute must be enabled
+- Databricks Runtime 17.2+
+- `TRIGGER ON UPDATE` clause is not supported
+- Schedule uses same syntax as materialized view schedules
+
+### Refresh Materialization
+
+```python
+# Find and refresh the pipeline
+from databricks.sdk import WorkspaceClient
+w = WorkspaceClient()
+pipeline_id = "your-pipeline-id"
+w.pipelines.start_update(pipeline_id)
+```
+
+## Complete Example
+
+```sql
+CREATE OR REPLACE VIEW qubika_dev.{domain}_gold.sales_metrics
+WITH METRICS
+LANGUAGE YAML
+AS $$
+  version: 1.1
+  comment: "Comprehensive sales metrics with customer and product dimensions"
+  source: qubika_dev.{domain}_gold.fact_sales
+  filter: sale_date >= '2023-01-01'
+
+  joins:
+    - name: customer
+      source: qubika_dev.{domain}_gold.dim_customer
+      on: source.customer_id = customer.id
+      joins:
+        - name: region
+          source: qubika_dev.{domain}_gold.dim_region
+          on: customer.region_id = region.id
+    - name: product
+      source: qubika_dev.{domain}_gold.dim_product
+      on: source.product_id = product.id
+
+  dimensions:
+    - name: Sale Month
+      expr: DATE_TRUNC('MONTH', sale_date)
+      comment: "Month of sale"
+    - name: Customer Name
+      expr: customer.name
+    - name: Region
+      expr: region.name
+      comment: "Geographic region"
+    - name: Product Category
+      expr: product.category
+
+  measures:
+    - name: Total Revenue
+      expr: SUM(amount)
+      comment: "Sum of sale amounts"
+    - name: Transaction Count
+      expr: COUNT(1)
+    - name: Unique Customers
+      expr: COUNT(DISTINCT customer_id)
+    - name: Average Transaction
+      expr: AVG(amount)
+    - name: Revenue per Customer
+      expr: SUM(amount) / COUNT(DISTINCT customer_id)
+      comment: "Average revenue per unique customer"
+
+  materialization:
+    schedule: every 1 hour
+    mode: relaxed
+    materialized_views:
+      - name: hourly_region
+        type: aggregated
+        dimensions:
+          - Sale Month
+          - Region
+        measures:
+          - Total Revenue
+          - Transaction Count
+$$
+```


### PR DESCRIPTION
Adds the qubika-metric-views skill — a Qubika-tailored wrapper over the existing databricks-metric-views skill with Qubika naming conventions (qubika_dev/staging/prod catalogs, {domain}_gold schema placement), mandatory plan-confirm gates before any CREATE, UC description checklist (comment on every dimension + measure + COMMENT ON VIEW), and anti-pattern guardrails. Includes SKILL.md, patterns.md (9 patterns), and yaml-reference.md.