### PR TITLE
Announce upcoming move of skills to official Databricks skills set

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 </p>
 
 ---
+> 📣 **Heads up: a major evolution is coming**
+>
+> This will be the **last release where AI Dev Kit skills are installed from the skill files in this repository.** AI Dev Kit skills are becoming part of the official, engineering-supported Databricks skills set, and the skill files in this repo will soon be deprecated.
+>
+> In the next release you'll install these skills directly from the official Databricks set — either straight from the CLI, or through the AI Dev Kit installer, which will continue to guide you through the process.
+>
+> **What stays:** The MCP server and Builder App remain fully supported. The Builder App will keep being developed and improved, and the MCP server will be maintained and updated on a best-effort basis as GitHub issues are filed.
+>
+> **What's next:** AI Dev Kit will soon add several tutorials to help you get started using coding agents to build on Databricks, including getting started with Genie Code or Omnigent.
+---
 > 🔒 Proactive Dependency Security  
 > As part of our commitment to supply chain integrity, we continually monitor our dependency tree against known vulnerabilities and industry advisories. In response to a recently disclosed supply chain incident affecting litellm versions 1.82.7–1.82.8, we have audited our packages and removed the litellm dependency for most usage. It is solely used in the test directory for skills evaluation and optimization, and has been pinned to a safe version.  
 > For full third-party attribution, see NOTICE.txt.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 ---
 > 📣 **Heads up: a major evolution is coming**
 >
-> This will be the **last release where AI Dev Kit skills are installed from the skill files in this repository.** AI Dev Kit skills are becoming part of the official, engineering-supported Databricks skills set, and the skill files in this repo will soon be deprecated.
+> This will be the **last release where AI Dev Kit skills are installed from the skill files in this repository.** AI Dev Kit skills are becoming part of the official, engineering-supported Databricks skills set, and the skill files in this repo will soon be deprecated. In the next release you'll install these skills directly from the official Databricks set — either straight from the CLI, or through the AI Dev Kit installer, which will continue to guide you through the process.
 >
-> In the next release you'll install these skills directly from the official Databricks set — either straight from the CLI, or through the AI Dev Kit installer, which will continue to guide you through the process.
 >
-> **What stays:** The MCP server and Builder App remain fully supported. The Builder App will keep being developed and improved, and the MCP server will be maintained and updated on a best-effort basis as GitHub issues are filed.
+> **What stays:** The MCP server and Builder App will remain in this repository. The Builder App will keep being developed and improved, and the MCP server will be maintained and updated on a best-effort basis as GitHub issues are filed.
 >
-> **What's next:** AI Dev Kit will soon add several tutorials to help you get started using coding agents to build on Databricks, including getting started with Genie Code or Omnigent.
+>
+> **What's next:** AI Dev Kit will continue to guide you through setting up your AI coding environment and be a place to find experimental tools developed by Field Engineering. Beyond the skills installs, we plan to add several tutorials to help you get started using coding agents for building on Databricks, including getting started with Genie Code or Omnigent.
 ---
 > 🔒 Proactive Dependency Security  
 > As part of our commitment to supply chain integrity, we continually monitor our dependency tree against known vulnerabilities and industry advisories. In response to a recently disclosed supply chain incident affecting litellm versions 1.82.7–1.82.8, we have audited our packages and removed the litellm dependency for most usage. It is solely used in the test directory for skills evaluation and optimization, and has been pinned to a safe version.  

--- a/README.md
+++ b/README.md
@@ -7,13 +7,32 @@
 ---
 > 📣 **Heads up: a major evolution is coming**
 >
-> This will be the **last release where AI Dev Kit skills are installed from the skill files in this repository.** AI Dev Kit skills are becoming part of the official, engineering-supported Databricks skills set, and the skill files in this repo will soon be deprecated. In the next release you'll install these skills directly from the official Databricks set — either straight from the CLI, or through the AI Dev Kit installer, which will continue to guide you through the process.
+> This will be the **last release where AI Dev Kit skills are installed from the skill files in this
+> repository.** AI Dev Kit skills are becoming part of the official, engineering-supported Databricks
+> skills set, and the skill files in this repo will soon be deprecated. In the next release you'll
+> install these skills directly from the official Databricks set — either straight from the CLI, or
+> through the AI Dev Kit installer, which will continue to guide you through the process.
 >
 >
-> **What stays:** The MCP server and Builder App will remain in this repository. The Builder App will keep being developed and improved, and the MCP server will be maintained and updated on a best-effort basis as GitHub issues are filed.
+> **What stays:** The MCP server and Builder App will remain in this repository. The Builder App will
+> keep being developed and improved, and the MCP server will be maintained and updated on a
+> best-effort basis as GitHub issues are filed.
 >
 >
-> **What's next:** AI Dev Kit will continue to guide you through setting up your AI coding environment and be a place to find experimental tools developed by Field Engineering. Beyond the skills installs, we plan to add several tutorials to help you get started using coding agents for building on Databricks, including getting started with Genie Code or Omnigent.
+> **What's next:** AI Dev Kit will continue to guide you through setting up your AI coding
+> environment and be a place to find experimental tools developed by Field Engineering. Beyond the
+> skills installs, we plan to add several tutorials to help you get started using coding agents for
+> building on Databricks, including getting started with Genie Code or Omnigent.
+>
+> **A few skills will be renamed or merged** in the official install. Most names are unchanged; the
+> exceptions are:
+>
+> | Today (AI Dev Kit) | Official Databricks skills |
+> |---|---|
+> | `databricks-bundles` | `databricks-dabs` |
+> | `databricks-spark-declarative-pipelines` | `databricks-pipelines` |
+> | `databricks-lakebase-autoscale`, `databricks-lakebase-provisioned` | `databricks-lakebase` (merged) |
+> | `databricks-config` | folded into `databricks-core` |
 ---
 > 🔒 Proactive Dependency Security  
 > As part of our commitment to supply chain integrity, we continually monitor our dependency tree against known vulnerabilities and industry advisories. In response to a recently disclosed supply chain incident affecting litellm versions 1.82.7–1.82.8, we have audited our packages and removed the litellm dependency for most usage. It is solely used in the test directory for skills evaluation and optimization, and has been pinned to a safe version.  

--- a/install.ps1
+++ b/install.ps1
@@ -208,6 +208,22 @@ function Write-Err  {
 }
 function Write-Step { param([string]$Text) if (-not $script:Silent) { Write-Host ""; Write-Host "$Text" -ForegroundColor White } }
 
+# Deprecation notice - shown on every install/upgrade while skills still ship
+# from this repo. The next major release installs skills via the Databricks CLI
+# from the official databricks/databricks-agent-skills set.
+function Show-DeprecationNotice {
+    if ($script:Silent) { return }
+    $bar = "  ------------------------------------------------------------"
+    Write-Host ""
+    Write-Host $bar -ForegroundColor Yellow
+    Write-Host "  !  Heads up: skills are moving" -ForegroundColor Yellow
+    Write-Host "  In the next release, the skills for AI Dev Kit will be" -ForegroundColor DarkGray
+    Write-Host "  promoted to a shared, engineering-supported repository." -ForegroundColor DarkGray
+    Write-Host "  In future releases, this installer will set up skills" -ForegroundColor DarkGray
+    Write-Host "  using the Databricks CLI." -ForegroundColor DarkGray
+    Write-Host $bar -ForegroundColor Yellow
+}
+
 # ─── Parse arguments ─────────────────────────────────────────
 $i = 0
 while ($i -lt $args.Count) {
@@ -2055,6 +2071,10 @@ function Invoke-Main {
         Write-Host "Databricks AI Dev Kit Installer" -ForegroundColor White
         Write-Host "--------------------------------"
     }
+
+    # Deprecation notice: this is the last line of releases that installs skills
+    # from this repo's skill files. Shown on every install and upgrade.
+    Show-DeprecationNotice
 
     # ── Step 1: Release channel selection (may re-exec from experimental branch) ──
     Invoke-PromptChannel

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,21 @@ warn() { [ "$SILENT" = true ] || echo -e "  ${Y}!${N} $*"; }
 die()  { echo -e "  ${R}✗${N} $*" >&2; exit 1; }  # Always show errors
 step() { [ "$SILENT" = true ] || echo -e "\n${B}$*${N}"; }
 
+# Deprecation notice — shown on every install/upgrade while skills still ship
+# from this repo. The next major release installs skills via the Databricks CLI
+# from the official databricks/databricks-agent-skills set.
+deprecation_notice() {
+    [ "$SILENT" = true ] && return
+    echo ""
+    echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+    echo -e "  ${Y}${B}⚠  Heads up: skills are moving${N}"
+    echo -e "  ${D}In the next release, the skills for AI Dev Kit will be${N}"
+    echo -e "  ${D}promoted to a shared, engineering-supported repository.${N}"
+    echo -e "  ${D}In future releases, this installer will set up skills${N}"
+    echo -e "  ${D}using the Databricks CLI.${N}"
+    echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
+}
+
 # Parse arguments
 while [ $# -gt 0 ]; do
     case $1 in
@@ -1916,7 +1931,11 @@ main() {
         echo -e "${B}Databricks AI Dev Kit Installer${N}"
         echo "────────────────────────────────"
     fi
-    
+
+    # Deprecation notice: this is the last line of releases that installs skills
+    # from this repo's skill files. Shown on every install and upgrade.
+    deprecation_notice
+
     # ── Step 1: Release channel selection (may re-exec from experimental branch) ──
     prompt_channel
 


### PR DESCRIPTION
## What

Adds an advance-notice announcement that the **next** major release will change how AI Dev Kit skills are installed. This is a heads-up only — no behavior changes to the current install flow.

### README
- New notice block near the top announcing that this is the last release where skills install from the repo's skill files; skills are moving to the official, engineering-supported Databricks skills set (`databricks/databricks-agent-skills`).
- Clarifies what stays (MCP server + Builder App) and what's next (tutorials for Genie Code / Omnigent).
- Includes the skill rename/merge mapping (e.g. `databricks-bundles` → `databricks-dabs`, `databricks-spark-declarative-pipelines` → `databricks-pipelines`, the two Lakebase skills → `databricks-lakebase`, `databricks-config` folded into `databricks-core`).

### Installers (`install.sh` + `install.ps1`)
- Added a deprecation notice shown on **every install and upgrade**, before the version check can exit early. Respects silent mode. Rename mapping intentionally lives only in the README, not the installer notice.

## Testing
- `bash -n install.sh` passes; rendered the notice to confirm it fits the box border.
- `install.ps1` mirrors the same wording (couldn't run `pwsh` locally — no PowerShell on the dev machine).

This pull request and its description were written by Isaac.