### PR TITLE
feat(install): add --uninstall (skills + MCP server + config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,34 @@ irm https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/insta
 **Next steps:** Respond to interactive prompts and follow the on-screen instructions.
 - Note: Cursor and Copilot require updating settings manually after install.
 
+### Uninstall
+
+Run the same script with `--uninstall`. It removes the installed skill folders (including ones from older versions), the MCP server runtime (`~/.ai-dev-kit`), and the `databricks` MCP entry from each editor's config — leaving your other MCP servers, skills, and settings untouched. Editor config files are backed up to `<file>.bak` first.
+
+```bash
+# Preview what would be removed (changes nothing)
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --uninstall --dry-run
+
+# Uninstall the project-scope install in the current directory
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --uninstall
+
+# Uninstall a global install (add -y to skip the confirmation prompt)
+bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --uninstall --global -y
+```
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+```powershell
+.\install.ps1 -Uninstall -DryRun     # preview
+.\install.ps1 -Uninstall             # project scope
+.\install.ps1 -Uninstall -Global -Yes  # global, no prompt
+```
+
+</details>
+
+Scope mirrors install: a project uninstall touches only the current directory's config; `--global` touches only the per-user (`$HOME`) config. Run it once per scope you installed into.
+
 
 ### Visual Builder App
 

--- a/install.ps1
+++ b/install.ps1
@@ -334,19 +334,81 @@ function Get-PluginKeys {
 function Get-PluginKeysGlobal { Get-PluginKeys -Files @((Join-Path $env:USERPROFILE ".claude\settings.json")) }
 function Get-PluginKeysProject { param([string]$Dir) Get-PluginKeys -Files @((Join-Path $Dir ".claude\settings.json"), (Join-Path $Dir ".claude\settings.local.json")) }
 
-# Warn that the plugin also exists in the scope we're NOT uninstalling, and print
-# the command to remove each detected key there too. Leads with a blank line to
-# separate it from whatever preceded it (the plan, or the "Nothing to uninstall" tip).
-function Show-PluginOtherScopeWarning {
-    param([string[]]$OtherKeys)
-    Write-Host ""
-    if ($script:Scope -eq "project") {
-        Write-Warn "The Claude Code plugin is also installed globally - this project uninstall leaves it. To remove that too:"
-        foreach ($k in $OtherKeys) { Write-Host "    claude plugin uninstall $k --scope user" -ForegroundColor White }
-    } else {
-        Write-Warn "The Claude Code plugin is also installed at project scope - this global uninstall leaves it. To remove that too:"
-        foreach ($k in $OtherKeys) { Write-Host "    claude plugin uninstall $k --scope project" -ForegroundColor White }
+# Count skill folders + 'databricks' MCP entries under the given roots/targets, plus
+# hook/state/plugin, returning one "  - ..." summary line each. Shared by the project-
+# and global-scope summaries below. Read-only.
+function Get-LeftoversSummary {
+    param([string]$Hook, [string]$StateDir, [string]$StateLabel, [string[]]$PluginKeys, [string[]]$SkillRoots, [hashtable[]]$McpTargets)
+    $lines = @()
+    $n = 0
+    foreach ($root in $SkillRoots) {
+        if (Test-Path $root) { foreach ($name in $script:UninstallSkillNames) { if (Test-Path (Join-Path $root $name)) { $n++ } } }
     }
+    if ($n -gt 0) { $lines += "  - $n skill folder(s)" }
+    $n = 0
+    foreach ($t in $McpTargets) {
+        if (-not (Test-Path $t.Path)) { continue }
+        if ($t.Kind -eq "json" -and (Test-McpJsonHasDatabricks -Path $t.Path -Top $t.Top)) { $n++ }
+        elseif ($t.Kind -eq "toml" -and (Select-String -Path $t.Path -Pattern 'mcp_servers\.databricks' -Quiet)) { $n++ }
+    }
+    if ($n -gt 0) { $lines += "  - $n MCP config file(s) with the 'databricks' server" }
+    if ($Hook -and (Test-Path $Hook) -and (Select-String -Path $Hook -Pattern 'check_update' -Quiet)) { $lines += "  - Claude update hook" }
+    if ($StateDir -and (Test-Path $StateDir)) { $lines += "  - $StateLabel" }
+    if ($PluginKeys.Count -gt 0) { $lines += "  - Claude Code plugin: $($PluginKeys -join ' ')" }
+    return @($lines)
+}
+
+# Project-scope artifacts under $Dir (what a project uninstall from that dir removes).
+function Get-ProjectLeftoversSummary {
+    param([string]$Dir)
+    $skillRoots = @("\.claude\skills","\.cursor\skills","\.github\skills","\.agents\skills","\.gemini\skills","\.windsurf\skills","\.opencode\skills","\.kiro\skills") | ForEach-Object { Join-Path $Dir $_.TrimStart('\') }
+    $mcpTargets = @(
+        @{ Path=(Join-Path $Dir ".mcp.json"); Kind="json"; Top="mcpServers" }, @{ Path=(Join-Path $Dir ".cursor\mcp.json"); Kind="json"; Top="mcpServers" }, @{ Path=(Join-Path $Dir ".vscode\mcp.json"); Kind="json"; Top="servers" },
+        @{ Path=(Join-Path $Dir ".codex\config.toml"); Kind="toml" }, @{ Path=(Join-Path $Dir ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+        @{ Path=(Join-Path $Dir "opencode.json"); Kind="json"; Top="mcp" }, @{ Path=(Join-Path $Dir ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+    )
+    Get-LeftoversSummary -Hook (Join-Path $Dir ".claude\settings.json") -StateDir (Join-Path $Dir ".ai-dev-kit") -StateLabel "state files (.ai-dev-kit/)" `
+        -PluginKeys (Get-PluginKeysProject -Dir $Dir) -SkillRoots $skillRoots -McpTargets $mcpTargets
+}
+
+# Global/user-scope artifacts (what a --global uninstall removes).
+function Get-GlobalLeftoversSummary {
+    $h = $env:USERPROFILE
+    $installDir = if ($script:UserMcpPath) { $script:UserMcpPath } elseif ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $h ".ai-dev-kit" }
+    $skillRoots = @(".claude\skills",".cursor\skills",".github\skills",".agents\skills",".gemini\skills",".gemini\antigravity\skills",".codeium\windsurf\skills",".config\opencode\skills",".kiro\skills") | ForEach-Object { Join-Path $h $_ }
+    $mcpTargets = @(
+        @{ Path=(Join-Path $h ".claude.json"); Kind="json"; Top="mcpServers" }, @{ Path=(Join-Path $h ".codex\config.toml"); Kind="toml" }, @{ Path=(Join-Path $h ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+        @{ Path=(Join-Path $h ".gemini\antigravity\mcp_config.json"); Kind="json"; Top="mcpServers" }, @{ Path=(Join-Path $h ".codeium\windsurf\mcp_config.json"); Kind="json"; Top="mcpServers" },
+        @{ Path=(Join-Path $h ".config\opencode\opencode.json"); Kind="json"; Top="mcp" }, @{ Path=(Join-Path $h ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+    )
+    Get-LeftoversSummary -Hook (Join-Path $h ".claude\settings.json") -StateDir $installDir -StateLabel "MCP server runtime / state ($installDir)" `
+        -PluginKeys (Get-PluginKeysGlobal) -SkillRoots $skillRoots -McpTargets $mcpTargets
+}
+
+# Very noticeable end-of-run box warning that files remain in the OTHER scope.
+function Show-LeftoversBox {
+    param([string]$Headline, [string]$Detail, [string[]]$Summary, [string]$Action)
+    $bar = "  ------------------------------------------------------------"
+    Write-Host ""
+    Write-Host $bar -ForegroundColor Yellow
+    Write-Host "  $Headline" -ForegroundColor Yellow
+    Write-Host $bar -ForegroundColor Yellow
+    Write-Host "  $Detail" -ForegroundColor DarkGray
+    foreach ($l in $Summary) { Write-Host $l }
+    Write-Host "  $Action" -ForegroundColor Yellow
+    Write-Host $bar -ForegroundColor Yellow
+}
+function Show-ProjectLeftoversWarning {
+    param([string]$Dir, [string[]]$Summary)
+    Show-LeftoversBox -Headline "!  PROJECT-LEVEL AI DEV KIT FILES STILL REMAIN" `
+        -Detail "This global uninstall did not touch project-scoped files in: $Dir" `
+        -Summary $Summary -Action "Re-run the uninstaller from that folder WITHOUT --global to remove them."
+}
+function Show-GlobalLeftoversWarning {
+    param([string[]]$Summary)
+    Show-LeftoversBox -Headline "!  GLOBAL AI DEV KIT FILES STILL REMAIN" `
+        -Detail "This project uninstall did not touch global (user-level) files:" `
+        -Summary $Summary -Action "Re-run the uninstaller with --global to remove them."
 }
 
 # Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
@@ -377,6 +439,17 @@ function Remove-ClaudePlugin {
     if ($script:Scope -eq "project") { $alt = " (or --scope local)" }
     $manual = (($Keys | ForEach-Object { "claude plugin uninstall $_ --scope $cmdScope" }) -join "; ")
     Write-Err "Could not remove the Claude Code plugin. ${partial}Finish it manually: $manual$alt"
+}
+
+# Read-only: true only if the EXACT top-level server key ($Top) contains a
+# 'databricks' entry - the same thing removal targets. Does NOT match nested
+# occurrences (e.g. ~/.claude.json's projects.<path>.mcpServers.databricks, a
+# project-scoped server we never touch) that a plain match would flag.
+function Test-McpJsonHasDatabricks {
+    param([string]$Path, [string]$Top)
+    if (-not (Test-Path $Path)) { return $false }
+    try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
+    return ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks')
 }
 
 function Remove-McpJsonKey {
@@ -495,7 +568,7 @@ function Invoke-Uninstall {
     }
     foreach ($t in $mcpTargets) {
         if (-not (Test-Path $t.Path)) { continue }
-        if ($t.Kind -eq "json" -and (Select-String -Path $t.Path -Pattern '"databricks"' -Quiet)) { $planMcp += $t }
+        if ($t.Kind -eq "json" -and (Test-McpJsonHasDatabricks -Path $t.Path -Top $t.Top)) { $planMcp += $t }
         elseif ($t.Kind -eq "toml" -and (Select-String -Path $t.Path -Pattern 'mcp_servers\.databricks' -Quiet)) { $planMcp += $t }
     }
     foreach ($h in $hookTargets) {
@@ -510,24 +583,29 @@ function Invoke-Uninstall {
     $projMarker = Join-Path $baseDir ".ai-dev-kit"
     if ($script:Scope -eq "project" -and (Test-Path $projMarker)) { $planState += $projMarker }
 
-    # Claude Code plugin — detect at BOTH scopes (read-only), collecting the enabled
-    # "name@marketplace" key(s) so any marketplace is matched. We only remove the
-    # current uninstall scope; presence in the other scope is a warning.
+    # Claude Code plugin at the CURRENT scope — collect the enabled "name@marketplace"
+    # key(s) so any marketplace is matched; these are what we remove.
+    if ($script:Scope -eq "global") { $pluginKeys = Get-PluginKeysGlobal } else { $pluginKeys = Get-PluginKeysProject -Dir $baseDir }
+    $planPlugin = ($pluginKeys.Count -gt 0)
+
+    # Warn about artifacts left behind in the OTHER scope. A global uninstall looks
+    # for project-scope files in the current folder; a project uninstall looks for
+    # global/user-level files. Skip the $cwd scan when it is $HOME (there project and
+    # global paths coincide and are already handled by the global side).
+    $projectLeftovers = @(); $globalLeftovers = @()
+    $cwd = (Get-Location).Path
     if ($script:Scope -eq "global") {
-        $pluginKeys      = Get-PluginKeysGlobal
-        $pluginOtherKeys = Get-PluginKeysProject -Dir (Get-Location).Path
+        if ($cwd -ne $env:USERPROFILE) { $projectLeftovers = Get-ProjectLeftoversSummary -Dir $cwd }
     } else {
-        $pluginKeys      = Get-PluginKeysProject -Dir $baseDir
-        $pluginOtherKeys = Get-PluginKeysGlobal
+        if ($baseDir -ne $env:USERPROFILE) { $globalLeftovers = Get-GlobalLeftoversSummary }
     }
-    $planPlugin  = ($pluginKeys.Count -gt 0)
-    $pluginOther = ($pluginOtherKeys.Count -gt 0)
 
     $total = $planSkills.Count + $planMcp.Count + $planHooks.Count + $planRuntime.Count + $planState.Count + $pluginKeys.Count
     if ($total -eq 0) {
         Write-Ok "Nothing to uninstall for $($script:Scope) scope at $baseDir - no AI Dev Kit artifacts found."
-        if ($script:Scope -eq "project") { Write-Msg "Tip: pass --global to remove a global install." }
-        if ($pluginOther) { Show-PluginOtherScopeWarning -OtherKeys $pluginOtherKeys }
+        if ($script:Scope -eq "project" -and -not $globalLeftovers.Count) { Write-Msg "Tip: pass --global to remove a global install." }
+        if ($projectLeftovers.Count) { Show-ProjectLeftoversWarning -Dir $cwd -Summary $projectLeftovers }
+        if ($globalLeftovers.Count)  { Show-GlobalLeftoversWarning -Summary $globalLeftovers }
         return
     }
 
@@ -542,11 +620,15 @@ function Invoke-Uninstall {
         foreach ($k in $pluginKeys) { Write-Host "    $k (removed via the claude CLI, $($script:Scope) scope)" -ForegroundColor DarkGray }
         Write-Host "  !  Heads up: the AI Dev Kit Claude Code plugin will also be removed." -ForegroundColor Yellow
     }
-    if ($pluginOther) { Show-PluginOtherScopeWarning -OtherKeys $pluginOtherKeys }
     Write-Host ""
     Write-Msg "Config files are backed up to <file>.bak before editing."
 
-    if ($script:DryRun) { Write-Ok "Dry run - nothing was changed. Re-run without --dry-run to apply."; return }
+    if ($script:DryRun) {
+        if ($projectLeftovers.Count) { Show-ProjectLeftoversWarning -Dir $cwd -Summary $projectLeftovers }
+        if ($globalLeftovers.Count)  { Show-GlobalLeftoversWarning -Summary $globalLeftovers }
+        Write-Ok "Dry run - nothing was changed. Re-run without --dry-run to apply."
+        return
+    }
 
     if (-not $script:AssumeYes) {
         $reply = Read-Host "  Remove these $total item(s)? [y/N]"
@@ -566,7 +648,9 @@ function Invoke-Uninstall {
 
     Write-Host ""
     Write-Ok "AI Dev Kit uninstalled ($($script:Scope) scope)."
-    Write-Msg "Other scopes (e.g. --global) and per-editor .bak backups were left untouched."
+    Write-Msg "Other scopes and per-editor .bak backups were left untouched."
+    if ($projectLeftovers.Count) { Show-ProjectLeftoversWarning -Dir $cwd -Summary $projectLeftovers }
+    if ($globalLeftovers.Count)  { Show-GlobalLeftoversWarning -Summary $globalLeftovers }
 }
 
 if ($script:Uninstall) { Invoke-Uninstall; return }

--- a/install.ps1
+++ b/install.ps1
@@ -305,68 +305,78 @@ $script:UninstallSkillNames = @(
     "retrieving-mlflow-traces","searching-mlflow-docs"
 )
 
-# The Claude Code plugin (installed via the marketplace, separate from the skills
+# The Claude Code plugin (installed via a marketplace, separate from the skills
 # this script drops directly). Its on-disk state lives across several shared files
 # (installed_plugins.json, enabledPlugins in settings.json, known_marketplaces.json,
 # the cache dir) shared with the user's OTHER plugins — so we never hand-edit them.
 # Detection is read-only; removal is delegated to the official `claude` CLI.
-$script:PluginKey = "databricks-ai-dev-kit@databricks-ai-dev-kit"
-$script:PluginMarketplace = "databricks-ai-dev-kit"
+#
+# The plugin can be installed from ANY marketplace, so we match by plugin name and
+# discover the actual "name@marketplace" key(s) rather than assuming a marketplace.
+$script:PluginName = "databricks-ai-dev-kit"
 
 # Read-only detection of the plugin per scope. The scope is recorded by which
-# settings.json enables it: user scope in ~/.claude/settings.json, project scope
-# in the project's .claude/settings.json(.local). (installed_plugins.json is
-# user-level and lists ALL scopes together, so it can't distinguish them.)
-function Test-PluginInstalledGlobal {
-    $f = Join-Path $env:USERPROFILE ".claude\settings.json"
-    return ((Test-Path $f) -and (Select-String -Path $f -Pattern ([regex]::Escape($script:PluginKey)) -Quiet))
-}
-function Test-PluginInstalledProject {
-    param([string]$Dir)
-    foreach ($s in @((Join-Path $Dir ".claude\settings.json"), (Join-Path $Dir ".claude\settings.local.json"))) {
-        if ((Test-Path $s) -and (Select-String -Path $s -Pattern ([regex]::Escape($script:PluginKey)) -Quiet)) { return $true }
+# settings.json enables it: user scope in ~/.claude/settings.json, project scope in
+# the project's .claude/settings.json(.local). (installed_plugins.json is user-level
+# and lists ALL scopes together, so it can't distinguish them.) Returns the enabled
+# "name@marketplace" key(s) — any marketplace is matched.
+function Get-PluginKeys {
+    param([string[]]$Files)
+    $pattern = '"' + [regex]::Escape($script:PluginName) + '@[A-Za-z0-9._-]+"'
+    $keys = @()
+    foreach ($f in $Files) {
+        if (Test-Path $f) {
+            foreach ($m in [regex]::Matches((Get-Content $f -Raw), $pattern)) { $keys += $m.Value.Trim('"') }
+        }
     }
-    return $false
+    return @($keys | Sort-Object -Unique)
 }
+function Get-PluginKeysGlobal { Get-PluginKeys -Files @((Join-Path $env:USERPROFILE ".claude\settings.json")) }
+function Get-PluginKeysProject { param([string]$Dir) Get-PluginKeys -Files @((Join-Path $Dir ".claude\settings.json"), (Join-Path $Dir ".claude\settings.local.json")) }
 
 # Warn that the plugin also exists in the scope we're NOT uninstalling, and print
-# the command to remove it there too. Leads with a blank line to separate it from
-# whatever preceded it (the plan, or the "Nothing to uninstall" tip).
+# the command to remove each detected key there too. Leads with a blank line to
+# separate it from whatever preceded it (the plan, or the "Nothing to uninstall" tip).
 function Show-PluginOtherScopeWarning {
+    param([string[]]$OtherKeys)
     Write-Host ""
     if ($script:Scope -eq "project") {
         Write-Warn "The Claude Code plugin is also installed globally - this project uninstall leaves it. To remove that too:"
-        Write-Host "    claude plugin uninstall $($script:PluginKey) --scope user" -ForegroundColor White
+        foreach ($k in $OtherKeys) { Write-Host "    claude plugin uninstall $k --scope user" -ForegroundColor White }
     } else {
         Write-Warn "The Claude Code plugin is also installed at project scope - this global uninstall leaves it. To remove that too:"
-        Write-Host "    claude plugin uninstall $($script:PluginKey) --scope project" -ForegroundColor White
+        foreach ($k in $OtherKeys) { Write-Host "    claude plugin uninstall $k --scope project" -ForegroundColor White }
     }
 }
 
 # Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
-# across the shared plugin state - we never hand-edit it). A project install can be
-# either 'project' (.claude/settings.json) or 'local' (.claude/settings.local.json),
+# across the shared plugin state - we never hand-edit it). Removes every detected
+# "name@marketplace" key (the plugin may come from any marketplace). A project
+# install can be 'project' (.claude/settings.json) or 'local' (settings.local.json),
 # so a project uninstall tries both CLI scopes. If nothing could be removed this is a
 # hard error that reports whether the rest of the uninstall completed and prints the
 # exact command to run manually. $OthersRemoved = other artifacts removed this run.
 function Remove-ClaudePlugin {
-    param([int]$OthersRemoved)
+    param([int]$OthersRemoved, [string[]]$Keys)
     if ($script:Scope -eq "project") { $scopes = @("project","local"); $cmdScope = "project" }
     else { $scopes = @("user"); $cmdScope = "user" }
     if (Get-Command claude -ErrorAction SilentlyContinue) {
         $removed = $false
-        foreach ($sc in $scopes) {
-            # Subcommand name has varied across versions (uninstall vs remove) — try both.
-            & claude plugin uninstall $script:PluginKey -y --scope $sc *>$null
-            if ($LASTEXITCODE -ne 0) { & claude plugin remove $script:PluginKey -y --scope $sc *>$null }
-            if ($LASTEXITCODE -eq 0) { Write-Msg "removed Claude Code plugin $($script:PluginKey) ($sc scope)"; $removed = $true }
+        foreach ($k in $Keys) {
+            foreach ($sc in $scopes) {
+                # Subcommand name has varied across versions (uninstall vs remove) — try both.
+                & claude plugin uninstall $k -y --scope $sc *>$null
+                if ($LASTEXITCODE -ne 0) { & claude plugin remove $k -y --scope $sc *>$null }
+                if ($LASTEXITCODE -eq 0) { Write-Msg "removed Claude Code plugin $k ($sc scope)"; $removed = $true }
+            }
         }
         if ($removed) { return }
     }
     $partial = ""; $alt = ""
     if ($OthersRemoved -gt 0) { $partial = "Skills, MCP server, and config WERE removed (partial uninstall). " }
     if ($script:Scope -eq "project") { $alt = " (or --scope local)" }
-    Write-Err "Could not remove the Claude Code plugin. ${partial}Finish it manually: claude plugin uninstall $($script:PluginKey) --scope $cmdScope$alt"
+    $manual = (($Keys | ForEach-Object { "claude plugin uninstall $_ --scope $cmdScope" }) -join "; ")
+    Write-Err "Could not remove the Claude Code plugin. ${partial}Finish it manually: $manual$alt"
 }
 
 function Remove-McpJsonKey {
@@ -498,22 +508,24 @@ function Invoke-Uninstall {
     $projMarker = Join-Path $baseDir ".ai-dev-kit"
     if ($script:Scope -eq "project" -and (Test-Path $projMarker)) { $planState += $projMarker }
 
-    # Claude Code plugin — detect at BOTH scopes (read-only). We only remove the
+    # Claude Code plugin — detect at BOTH scopes (read-only), collecting the enabled
+    # "name@marketplace" key(s) so any marketplace is matched. We only remove the
     # current uninstall scope; presence in the other scope is a warning.
     if ($script:Scope -eq "global") {
-        $planPlugin  = Test-PluginInstalledGlobal
-        $pluginOther = Test-PluginInstalledProject -Dir (Get-Location).Path
+        $pluginKeys      = Get-PluginKeysGlobal
+        $pluginOtherKeys = Get-PluginKeysProject -Dir (Get-Location).Path
     } else {
-        $planPlugin  = Test-PluginInstalledProject -Dir $baseDir
-        $pluginOther = Test-PluginInstalledGlobal
+        $pluginKeys      = Get-PluginKeysProject -Dir $baseDir
+        $pluginOtherKeys = Get-PluginKeysGlobal
     }
+    $planPlugin  = ($pluginKeys.Count -gt 0)
+    $pluginOther = ($pluginOtherKeys.Count -gt 0)
 
-    $total = $planSkills.Count + $planMcp.Count + $planHooks.Count + $planRuntime.Count + $planState.Count
-    if ($planPlugin) { $total += 1 }
+    $total = $planSkills.Count + $planMcp.Count + $planHooks.Count + $planRuntime.Count + $planState.Count + $pluginKeys.Count
     if ($total -eq 0) {
         Write-Ok "Nothing to uninstall for $($script:Scope) scope at $baseDir - no AI Dev Kit artifacts found."
         if ($script:Scope -eq "project") { Write-Msg "Tip: pass --global to remove a global install." }
-        if ($pluginOther) { Show-PluginOtherScopeWarning }
+        if ($pluginOther) { Show-PluginOtherScopeWarning -OtherKeys $pluginOtherKeys }
         return
     }
 
@@ -525,10 +537,10 @@ function Invoke-Uninstall {
     if ($planState.Count)  { Write-Host "  State files:" -ForegroundColor White; $planState | ForEach-Object { Write-Host "    $_" } }
     if ($planPlugin) {
         Write-Host "  Claude Code plugin:" -ForegroundColor White
-        Write-Host "    $($script:PluginKey) (removed via the claude CLI, $($script:Scope) scope)" -ForegroundColor DarkGray
+        foreach ($k in $pluginKeys) { Write-Host "    $k (removed via the claude CLI, $($script:Scope) scope)" -ForegroundColor DarkGray }
         Write-Host "  !  Heads up: the AI Dev Kit Claude Code plugin will also be removed." -ForegroundColor Yellow
     }
-    if ($pluginOther) { Show-PluginOtherScopeWarning }
+    if ($pluginOther) { Show-PluginOtherScopeWarning -OtherKeys $pluginOtherKeys }
     Write-Host ""
     Write-Msg "Config files are backed up to <file>.bak before editing."
 
@@ -548,7 +560,7 @@ function Invoke-Uninstall {
     foreach ($p in $planHooks)   { if (Remove-ClaudeHook -Path $p) { Write-Msg "cleaned hook in $p" } }
     foreach ($p in $planRuntime) { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
     foreach ($p in $planState)   { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
-    if ($planPlugin) { Remove-ClaudePlugin -OthersRemoved ($total - 1) }
+    if ($planPlugin) { Remove-ClaudePlugin -OthersRemoved ($total - $pluginKeys.Count) -Keys $pluginKeys }
 
     Write-Host ""
     Write-Ok "AI Dev Kit uninstalled ($($script:Scope) scope)."

--- a/install.ps1
+++ b/install.ps1
@@ -577,8 +577,13 @@ function Invoke-Uninstall {
     if ($script:Scope -eq "global" -or $script:UserMcpPath) {
         if (Test-Path $installDir) { $planRuntime += $installDir }
     }
-    foreach ($s in @((Join-Path $stateDir ".installed-skills"), (Join-Path $stateDir ".skills-profile"), (Join-Path $stateDir "version"))) {
-        if (Test-Path $s) { $planState += $s }
+    # On a global uninstall $stateDir IS the runtime dir; when that dir is already in
+    # $planRuntime the state files inside it are removed along with it - planning them
+    # separately would make Remove-Item fail on the already-deleted paths.
+    if ($planRuntime -notcontains $stateDir) {
+        foreach ($s in @((Join-Path $stateDir ".installed-skills"), (Join-Path $stateDir ".skills-profile"), (Join-Path $stateDir "version"))) {
+            if (Test-Path $s) { $planState += $s }
+        }
     }
     $projMarker = Join-Path $baseDir ".ai-dev-kit"
     if ($script:Scope -eq "project" -and (Test-Path $projMarker)) { $planState += $projMarker }

--- a/install.ps1
+++ b/install.ps1
@@ -461,6 +461,7 @@ function Invoke-Uninstall {
             @{ Path=(Join-Path $home_ ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
             @{ Path=(Join-Path $home_ ".gemini\antigravity\mcp_config.json"); Kind="json"; Top="mcpServers" },
             @{ Path=(Join-Path $home_ ".codeium\windsurf\mcp_config.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $home_ ".config\opencode\opencode.json"); Kind="json"; Top="mcp" },
             @{ Path=(Join-Path $home_ ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
         )
         $hookTargets = @( (Join-Path $home_ ".claude\settings.json") )
@@ -477,6 +478,7 @@ function Invoke-Uninstall {
             @{ Path=(Join-Path $baseDir ".vscode\mcp.json"); Kind="json"; Top="servers" },
             @{ Path=(Join-Path $baseDir ".codex\config.toml"); Kind="toml" },
             @{ Path=(Join-Path $baseDir ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $baseDir "opencode.json"); Kind="json"; Top="mcp" },
             @{ Path=(Join-Path $baseDir ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
         )
         $hookTargets = @( (Join-Path $baseDir ".claude\settings.json") )

--- a/install.ps1
+++ b/install.ps1
@@ -310,13 +310,18 @@ function Remove-McpJsonKey {
     if (-not (Test-Path $Path)) { return $false }
     if (-not (Select-String -Path $Path -Pattern '"databricks"' -Quiet)) { return $false }
     if ($script:DryRun) { return $true }
-    Copy-Item $Path "$Path.bak" -Force
     try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
-    if ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks') {
-        $cfg.$Top.PSObject.Properties.Remove('databricks')
-        if (-not $cfg.$Top.PSObject.Properties.Name) { $cfg.PSObject.Properties.Remove($Top) }
+    # Only rewrite (and back up) when the exact top-level 'databricks' key is
+    # present. Otherwise a stray '"databricks"' elsewhere (a foreign server's
+    # path, a project named 'databricks') would trigger a lossy no-op rewrite —
+    # and ConvertTo-Json's -Depth would truncate deep configs like ~/.claude.json.
+    if (-not ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks')) {
+        return $false
     }
-    $cfg | ConvertTo-Json -Depth 20 | Set-Content $Path -Encoding UTF8
+    Copy-Item $Path "$Path.bak" -Force
+    $cfg.$Top.PSObject.Properties.Remove('databricks')
+    if (-not $cfg.$Top.PSObject.Properties.Name) { $cfg.PSObject.Properties.Remove($Top) }
+    $cfg | ConvertTo-Json -Depth 100 | Set-Content $Path -Encoding UTF8
     return $true
 }
 
@@ -344,19 +349,18 @@ function Remove-ClaudeHook {
     if (-not (Test-Path $Path)) { return $false }
     if (-not (Select-String -Path $Path -Pattern 'check_update' -Quiet)) { return $false }
     if ($script:DryRun) { return $true }
-    Copy-Item $Path "$Path.bak" -Force
     try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
     $ss = $cfg.hooks.SessionStart
-    if ($ss) {
-        foreach ($group in $ss) {
-            $group.hooks = @($group.hooks | Where-Object { $_.command -notmatch 'check_update' })
-        }
-        $cfg.hooks.SessionStart = @($ss | Where-Object { $_.hooks -and $_.hooks.Count -gt 0 })
-        if (-not $cfg.hooks.SessionStart -or $cfg.hooks.SessionStart.Count -eq 0) {
-            $cfg.hooks.PSObject.Properties.Remove('SessionStart')
-        }
+    if (-not $ss) { return $false }   # nothing to change — don't rewrite/back up
+    foreach ($group in $ss) {
+        $group.hooks = @($group.hooks | Where-Object { $_.command -notmatch 'check_update' })
     }
-    $cfg | ConvertTo-Json -Depth 20 | Set-Content $Path -Encoding UTF8
+    $cfg.hooks.SessionStart = @($ss | Where-Object { $_.hooks -and $_.hooks.Count -gt 0 })
+    if (-not $cfg.hooks.SessionStart -or $cfg.hooks.SessionStart.Count -eq 0) {
+        $cfg.hooks.PSObject.Properties.Remove('SessionStart')
+    }
+    Copy-Item $Path "$Path.bak" -Force
+    $cfg | ConvertTo-Json -Depth 100 | Set-Content $Path -Encoding UTF8
     return $true
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -76,6 +76,9 @@ $script:ProfileProvided = $false
 $script:SkillsProfile = ""
 $script:UserSkills   = ""
 $script:ListSkills   = $false
+$script:Uninstall    = $false
+$script:DryRun       = $false
+$script:AssumeYes    = $false
 $script:Channel      = if ($env:DEVKIT_CHANNEL) { $env:DEVKIT_CHANNEL } else { "stable" }  # stable or experimental
 
 # Databricks skills (bundled in repo)
@@ -233,6 +236,9 @@ while ($i -lt $args.Count) {
         { $_ -in "--list-skills", "-ListSkills" } { $script:ListSkills = $true; $i++ }
         { $_ -in "--experimental", "-Experimental" } { $script:Channel = "experimental"; $i++ }
         { $_ -in "-f", "--force", "-Force" }   { $script:Force = $true; $i++ }
+        { $_ -in "--uninstall", "-Uninstall" } { $script:Uninstall = $true; $i++ }
+        { $_ -in "--dry-run", "-DryRun" }      { $script:DryRun = $true; $i++ }
+        { $_ -in "-y", "--yes", "-Yes" }       { $script:AssumeYes = $true; $i++ }
         { $_ -in "-h", "--help", "-Help" } {
             Write-Host "Databricks AI Dev Kit Installer (Windows)"
             Write-Host ""
@@ -252,6 +258,9 @@ while ($i -lt $args.Count) {
             Write-Host "  --list-skills         List available skills and profiles, then exit"
             Write-Host "  --experimental        Install from experimental branch (early access features)"
             Write-Host "  -f, --force           Force reinstall"
+            Write-Host "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, and MCP config"
+            Write-Host "  --dry-run             With --uninstall: print what would be removed, change nothing"
+            Write-Host "  -y, --yes             With --uninstall: skip the confirmation prompt"
             Write-Host "  -h, --help            Show this help"
             Write-Host ""
             Write-Host "Environment Variables:"
@@ -274,6 +283,190 @@ while ($i -lt $args.Count) {
         default { Write-Err "Unknown option: $($args[$i]) (use -h for help)"; $i++ }
     }
 }
+
+# ─── --uninstall ───────────────────────────────────────────────
+# Every skill directory name ever shipped (current + historical renames/removals),
+# so old installs — e.g. the removed databricks-lakebase-provisioned or renamed
+# databricks-app-python — are swept, not just the current release's skills.
+$script:UninstallSkillNames = @(
+    "databricks-agent-bricks","databricks-ai-functions","databricks-aibi-dashboards",
+    "databricks-bundles","databricks-asset-bundles","databricks-apps-python","databricks-app-python",
+    "databricks-app-apx","databricks-config","databricks-dbsql","databricks-docs",
+    "databricks-execution-compute","databricks-genie","databricks-iceberg","databricks-jobs",
+    "databricks-lakebase-autoscale","databricks-lakebase-provisioned","databricks-metric-views",
+    "databricks-ml-training-serving","databricks-model-serving","databricks-mlflow-evaluation",
+    "databricks-parsing","databricks-python-sdk","databricks-spark-declarative-pipelines",
+    "databricks-spark-structured-streaming","databricks-synthetic-data-gen","databricks-synthetic-data-generation",
+    "databricks-unity-catalog","databricks-unstructured-pdf-generation","databricks-vector-search",
+    "databricks-zerobus-ingest","spark-python-data-source",
+    "databricks","databricks-apps","databricks-lakebase",
+    "agent-evaluation","analyze-mlflow-chat-session","analyze-mlflow-trace",
+    "instrumenting-with-mlflow-tracing","mlflow-onboarding","querying-mlflow-metrics",
+    "retrieving-mlflow-traces","searching-mlflow-docs"
+)
+
+function Remove-McpJsonKey {
+    param([string]$Path, [string]$Top)
+    if (-not (Test-Path $Path)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern '"databricks"' -Quiet)) { return $false }
+    if ($script:DryRun) { return $true }
+    Copy-Item $Path "$Path.bak" -Force
+    try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
+    if ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks') {
+        $cfg.$Top.PSObject.Properties.Remove('databricks')
+        if (-not $cfg.$Top.PSObject.Properties.Name) { $cfg.PSObject.Properties.Remove($Top) }
+    }
+    $cfg | ConvertTo-Json -Depth 20 | Set-Content $Path -Encoding UTF8
+    return $true
+}
+
+function Remove-McpTomlBlock {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern 'mcp_servers\.databricks' -Quiet)) { return $false }
+    if ($script:DryRun) { return $true }
+    Copy-Item $Path "$Path.bak" -Force
+    $out = New-Object System.Collections.Generic.List[string]
+    $skip = $false
+    foreach ($line in Get-Content "$Path.bak") {
+        if ($line -match '^\[mcp_servers\.databricks\]') { $skip = $true; continue }
+        if ($line -match '^\[' -and $skip) { $skip = $false }
+        if (-not $skip) { $out.Add($line) }
+    }
+    $out | Set-Content $Path -Encoding UTF8
+    return $true
+}
+
+function Remove-ClaudeHook {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern 'check_update' -Quiet)) { return $false }
+    if ($script:DryRun) { return $true }
+    Copy-Item $Path "$Path.bak" -Force
+    try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
+    $ss = $cfg.hooks.SessionStart
+    if ($ss) {
+        foreach ($group in $ss) {
+            $group.hooks = @($group.hooks | Where-Object { $_.command -notmatch 'check_update' })
+        }
+        $cfg.hooks.SessionStart = @($ss | Where-Object { $_.hooks -and $_.hooks.Count -gt 0 })
+        if (-not $cfg.hooks.SessionStart -or $cfg.hooks.SessionStart.Count -eq 0) {
+            $cfg.hooks.PSObject.Properties.Remove('SessionStart')
+        }
+    }
+    $cfg | ConvertTo-Json -Depth 20 | Set-Content $Path -Encoding UTF8
+    return $true
+}
+
+function Invoke-Uninstall {
+    $home_ = $env:USERPROFILE
+    if ($script:Scope -eq "global") { $baseDir = $home_ } else { $baseDir = (Get-Location).Path }
+    $installDir = if ($script:UserMcpPath) { $script:UserMcpPath }
+                  elseif ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME }
+                  else { Join-Path $home_ ".ai-dev-kit" }
+    if ($script:Scope -eq "global") { $stateDir = $installDir } else { $stateDir = Join-Path $baseDir ".ai-dev-kit" }
+
+    # Scope strictly gates locations (mirror of install.sh).
+    if ($script:Scope -eq "global") {
+        $skillRoots = @(
+            (Join-Path $home_ ".claude\skills"), (Join-Path $home_ ".cursor\skills"),
+            (Join-Path $home_ ".github\skills"), (Join-Path $home_ ".agents\skills"),
+            (Join-Path $home_ ".gemini\skills"), (Join-Path $home_ ".gemini\antigravity\skills"),
+            (Join-Path $home_ ".codeium\windsurf\skills"), (Join-Path $home_ ".config\opencode\skills"),
+            (Join-Path $home_ ".kiro\skills")
+        )
+        $mcpTargets = @(
+            @{ Path=(Join-Path $home_ ".claude\mcp.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $home_ ".codex\config.toml"); Kind="toml" },
+            @{ Path=(Join-Path $home_ ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $home_ ".gemini\antigravity\mcp_config.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $home_ ".codeium\windsurf\mcp_config.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $home_ ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+        )
+        $hookTargets = @( (Join-Path $home_ ".claude\settings.json") )
+    } else {
+        $skillRoots = @(
+            (Join-Path $baseDir ".claude\skills"), (Join-Path $baseDir ".cursor\skills"),
+            (Join-Path $baseDir ".github\skills"), (Join-Path $baseDir ".agents\skills"),
+            (Join-Path $baseDir ".gemini\skills"), (Join-Path $baseDir ".windsurf\skills"),
+            (Join-Path $baseDir ".opencode\skills"), (Join-Path $baseDir ".kiro\skills")
+        )
+        $mcpTargets = @(
+            @{ Path=(Join-Path $baseDir ".mcp.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $baseDir ".cursor\mcp.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $baseDir ".vscode\mcp.json"); Kind="json"; Top="servers" },
+            @{ Path=(Join-Path $baseDir ".codex\config.toml"); Kind="toml" },
+            @{ Path=(Join-Path $baseDir ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $baseDir ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+        )
+        $hookTargets = @( (Join-Path $baseDir ".claude\settings.json") )
+    }
+
+    # Build plan
+    $planSkills = @(); $planMcp = @(); $planHooks = @(); $planRuntime = @(); $planState = @()
+    foreach ($root in $skillRoots) {
+        if (-not (Test-Path $root)) { continue }
+        foreach ($name in $script:UninstallSkillNames) {
+            $p = Join-Path $root $name
+            if (Test-Path $p) { $planSkills += $p }
+        }
+    }
+    foreach ($t in $mcpTargets) {
+        if (-not (Test-Path $t.Path)) { continue }
+        if ($t.Kind -eq "json" -and (Select-String -Path $t.Path -Pattern '"databricks"' -Quiet)) { $planMcp += $t }
+        elseif ($t.Kind -eq "toml" -and (Select-String -Path $t.Path -Pattern 'mcp_servers\.databricks' -Quiet)) { $planMcp += $t }
+    }
+    foreach ($h in $hookTargets) {
+        if ((Test-Path $h) -and (Select-String -Path $h -Pattern 'check_update' -Quiet)) { $planHooks += $h }
+    }
+    if ($script:Scope -eq "global" -or $script:UserMcpPath) {
+        if (Test-Path $installDir) { $planRuntime += $installDir }
+    }
+    foreach ($s in @((Join-Path $stateDir ".installed-skills"), (Join-Path $stateDir ".skills-profile"), (Join-Path $stateDir "version"))) {
+        if (Test-Path $s) { $planState += $s }
+    }
+    $projMarker = Join-Path $baseDir ".ai-dev-kit"
+    if ($script:Scope -eq "project" -and (Test-Path $projMarker)) { $planState += $projMarker }
+
+    $total = $planSkills.Count + $planMcp.Count + $planHooks.Count + $planRuntime.Count + $planState.Count
+    if ($total -eq 0) {
+        Write-Ok "Nothing to uninstall for $($script:Scope) scope at $baseDir - no AI Dev Kit artifacts found."
+        if ($script:Scope -eq "project") { Write-Msg "Tip: pass --global to remove a global install." }
+        return
+    }
+
+    Write-Step "Uninstall plan ($($script:Scope) scope)"
+    if ($planSkills.Count) { Write-Host "  Skill folders ($($planSkills.Count)):" -ForegroundColor White; $planSkills | ForEach-Object { Write-Host "    $_" } }
+    if ($planMcp.Count)    { Write-Host "  MCP config - remove 'databricks' entry ($($planMcp.Count)):" -ForegroundColor White; $planMcp | ForEach-Object { Write-Host "    $($_.Path)" } }
+    if ($planHooks.Count)  { Write-Host "  Claude update hook ($($planHooks.Count)):" -ForegroundColor White; $planHooks | ForEach-Object { Write-Host "    $_" } }
+    if ($planRuntime.Count){ Write-Host "  MCP server runtime:" -ForegroundColor White; $planRuntime | ForEach-Object { Write-Host "    $_" } }
+    if ($planState.Count)  { Write-Host "  State files:" -ForegroundColor White; $planState | ForEach-Object { Write-Host "    $_" } }
+    Write-Host ""
+    Write-Msg "Config files are backed up to <file>.bak before editing."
+
+    if ($script:DryRun) { Write-Ok "Dry run - nothing was changed. Re-run without --dry-run to apply."; return }
+
+    if (-not $script:AssumeYes) {
+        $reply = Read-Host "  Remove these $total item(s)? [y/N]"
+        if ($reply -notmatch '^(y|yes)$') { Write-Warn "Aborted - nothing removed."; return }
+    }
+
+    Write-Step "Removing"
+    foreach ($p in $planSkills)  { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
+    foreach ($t in $planMcp) {
+        if ($t.Kind -eq "json") { if (Remove-McpJsonKey -Path $t.Path -Top $t.Top) { Write-Msg "cleaned $($t.Path)" } }
+        else { if (Remove-McpTomlBlock -Path $t.Path) { Write-Msg "cleaned $($t.Path)" } }
+    }
+    foreach ($p in $planHooks)   { if (Remove-ClaudeHook -Path $p) { Write-Msg "cleaned hook in $p" } }
+    foreach ($p in $planRuntime) { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
+    foreach ($p in $planState)   { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
+
+    Write-Host ""
+    Write-Ok "AI Dev Kit uninstalled ($($script:Scope) scope)."
+    Write-Msg "Other scopes (e.g. --global) and per-editor .bak backups were left untouched."
+}
+
+if ($script:Uninstall) { Invoke-Uninstall; return }
 
 # ─── Interactive helpers ──────────────────────────────────────
 

--- a/install.ps1
+++ b/install.ps1
@@ -329,8 +329,10 @@ function Remove-McpTomlBlock {
     $out = New-Object System.Collections.Generic.List[string]
     $skip = $false
     foreach ($line in Get-Content "$Path.bak") {
-        if ($line -match '^\[mcp_servers\.databricks\]') { $skip = $true; continue }
-        if ($line -match '^\[' -and $skip) { $skip = $false }
+        # Consume the databricks table AND its dotted subtables (e.g. .env);
+        # any other section header ends the skip.
+        if ($line -match '^\[mcp_servers\.databricks(\.|\])') { $skip = $true; continue }
+        if ($line -match '^\[') { $skip = $false }
         if (-not $skip) { $out.Add($line) }
     }
     $out | Set-Content $Path -Encoding UTF8

--- a/install.ps1
+++ b/install.ps1
@@ -258,7 +258,7 @@ while ($i -lt $args.Count) {
             Write-Host "  --list-skills         List available skills and profiles, then exit"
             Write-Host "  --experimental        Install from experimental branch (early access features)"
             Write-Host "  -f, --force           Force reinstall"
-            Write-Host "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, and MCP config"
+            Write-Host "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, MCP config, and Claude Code plugin"
             Write-Host "  --dry-run             With --uninstall: print what would be removed, change nothing"
             Write-Host "  -y, --yes             With --uninstall: skip the confirmation prompt"
             Write-Host "  -h, --help            Show this help"
@@ -304,6 +304,70 @@ $script:UninstallSkillNames = @(
     "instrumenting-with-mlflow-tracing","mlflow-onboarding","querying-mlflow-metrics",
     "retrieving-mlflow-traces","searching-mlflow-docs"
 )
+
+# The Claude Code plugin (installed via the marketplace, separate from the skills
+# this script drops directly). Its on-disk state lives across several shared files
+# (installed_plugins.json, enabledPlugins in settings.json, known_marketplaces.json,
+# the cache dir) shared with the user's OTHER plugins — so we never hand-edit them.
+# Detection is read-only; removal is delegated to the official `claude` CLI.
+$script:PluginKey = "databricks-ai-dev-kit@databricks-ai-dev-kit"
+$script:PluginMarketplace = "databricks-ai-dev-kit"
+
+# Read-only detection of the plugin per scope. The scope is recorded by which
+# settings.json enables it: user scope in ~/.claude/settings.json, project scope
+# in the project's .claude/settings.json(.local). (installed_plugins.json is
+# user-level and lists ALL scopes together, so it can't distinguish them.)
+function Test-PluginInstalledGlobal {
+    $f = Join-Path $env:USERPROFILE ".claude\settings.json"
+    return ((Test-Path $f) -and (Select-String -Path $f -Pattern ([regex]::Escape($script:PluginKey)) -Quiet))
+}
+function Test-PluginInstalledProject {
+    param([string]$Dir)
+    foreach ($s in @((Join-Path $Dir ".claude\settings.json"), (Join-Path $Dir ".claude\settings.local.json"))) {
+        if ((Test-Path $s) -and (Select-String -Path $s -Pattern ([regex]::Escape($script:PluginKey)) -Quiet)) { return $true }
+    }
+    return $false
+}
+
+# Warn that the plugin also exists in the scope we're NOT uninstalling, and print
+# the command to remove it there too. Leads with a blank line to separate it from
+# whatever preceded it (the plan, or the "Nothing to uninstall" tip).
+function Show-PluginOtherScopeWarning {
+    Write-Host ""
+    if ($script:Scope -eq "project") {
+        Write-Warn "The Claude Code plugin is also installed globally - this project uninstall leaves it. To remove that too:"
+        Write-Host "    claude plugin uninstall $($script:PluginKey) --scope user" -ForegroundColor White
+    } else {
+        Write-Warn "The Claude Code plugin is also installed at project scope - this global uninstall leaves it. To remove that too:"
+        Write-Host "    claude plugin uninstall $($script:PluginKey) --scope project" -ForegroundColor White
+    }
+}
+
+# Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
+# across the shared plugin state - we never hand-edit it). A project install can be
+# either 'project' (.claude/settings.json) or 'local' (.claude/settings.local.json),
+# so a project uninstall tries both CLI scopes. If nothing could be removed this is a
+# hard error that reports whether the rest of the uninstall completed and prints the
+# exact command to run manually. $OthersRemoved = other artifacts removed this run.
+function Remove-ClaudePlugin {
+    param([int]$OthersRemoved)
+    if ($script:Scope -eq "project") { $scopes = @("project","local"); $cmdScope = "project" }
+    else { $scopes = @("user"); $cmdScope = "user" }
+    if (Get-Command claude -ErrorAction SilentlyContinue) {
+        $removed = $false
+        foreach ($sc in $scopes) {
+            # Subcommand name has varied across versions (uninstall vs remove) — try both.
+            & claude plugin uninstall $script:PluginKey -y --scope $sc *>$null
+            if ($LASTEXITCODE -ne 0) { & claude plugin remove $script:PluginKey -y --scope $sc *>$null }
+            if ($LASTEXITCODE -eq 0) { Write-Msg "removed Claude Code plugin $($script:PluginKey) ($sc scope)"; $removed = $true }
+        }
+        if ($removed) { return }
+    }
+    $partial = ""; $alt = ""
+    if ($OthersRemoved -gt 0) { $partial = "Skills, MCP server, and config WERE removed (partial uninstall). " }
+    if ($script:Scope -eq "project") { $alt = " (or --scope local)" }
+    Write-Err "Could not remove the Claude Code plugin. ${partial}Finish it manually: claude plugin uninstall $($script:PluginKey) --scope $cmdScope$alt"
+}
 
 function Remove-McpJsonKey {
     param([string]$Path, [string]$Top)
@@ -434,10 +498,22 @@ function Invoke-Uninstall {
     $projMarker = Join-Path $baseDir ".ai-dev-kit"
     if ($script:Scope -eq "project" -and (Test-Path $projMarker)) { $planState += $projMarker }
 
+    # Claude Code plugin — detect at BOTH scopes (read-only). We only remove the
+    # current uninstall scope; presence in the other scope is a warning.
+    if ($script:Scope -eq "global") {
+        $planPlugin  = Test-PluginInstalledGlobal
+        $pluginOther = Test-PluginInstalledProject -Dir (Get-Location).Path
+    } else {
+        $planPlugin  = Test-PluginInstalledProject -Dir $baseDir
+        $pluginOther = Test-PluginInstalledGlobal
+    }
+
     $total = $planSkills.Count + $planMcp.Count + $planHooks.Count + $planRuntime.Count + $planState.Count
+    if ($planPlugin) { $total += 1 }
     if ($total -eq 0) {
         Write-Ok "Nothing to uninstall for $($script:Scope) scope at $baseDir - no AI Dev Kit artifacts found."
         if ($script:Scope -eq "project") { Write-Msg "Tip: pass --global to remove a global install." }
+        if ($pluginOther) { Show-PluginOtherScopeWarning }
         return
     }
 
@@ -447,6 +523,12 @@ function Invoke-Uninstall {
     if ($planHooks.Count)  { Write-Host "  Claude update hook ($($planHooks.Count)):" -ForegroundColor White; $planHooks | ForEach-Object { Write-Host "    $_" } }
     if ($planRuntime.Count){ Write-Host "  MCP server runtime:" -ForegroundColor White; $planRuntime | ForEach-Object { Write-Host "    $_" } }
     if ($planState.Count)  { Write-Host "  State files:" -ForegroundColor White; $planState | ForEach-Object { Write-Host "    $_" } }
+    if ($planPlugin) {
+        Write-Host "  Claude Code plugin:" -ForegroundColor White
+        Write-Host "    $($script:PluginKey) (removed via the claude CLI, $($script:Scope) scope)" -ForegroundColor DarkGray
+        Write-Host "  !  Heads up: the AI Dev Kit Claude Code plugin will also be removed." -ForegroundColor Yellow
+    }
+    if ($pluginOther) { Show-PluginOtherScopeWarning }
     Write-Host ""
     Write-Msg "Config files are backed up to <file>.bak before editing."
 
@@ -466,6 +548,7 @@ function Invoke-Uninstall {
     foreach ($p in $planHooks)   { if (Remove-ClaudeHook -Path $p) { Write-Msg "cleaned hook in $p" } }
     foreach ($p in $planRuntime) { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
     foreach ($p in $planState)   { Remove-Item -Recurse -Force $p; Write-Msg "removed $p" }
+    if ($planPlugin) { Remove-ClaudePlugin -OthersRemoved ($total - 1) }
 
     Write-Host ""
     Write-Ok "AI Dev Kit uninstalled ($($script:Scope) scope)."

--- a/install.sh
+++ b/install.sh
@@ -289,14 +289,16 @@ instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics
 retrieving-mlflow-traces searching-mlflow-docs
 "
 
-# The Claude Code plugin (installed via the marketplace, separate from the skills
+# The Claude Code plugin (installed via a marketplace, separate from the skills
 # this script drops directly). Its on-disk state lives across several shared
 # files (~/.claude/plugins/installed_plugins.json, enabledPlugins in
 # settings.json, known_marketplaces.json, the cache dir) that are shared with
 # the user's OTHER plugins — so we never hand-edit them. Detection is read-only;
 # removal is delegated to the official `claude` CLI (or shown as a command).
-PLUGIN_KEY="databricks-ai-dev-kit@databricks-ai-dev-kit"
-PLUGIN_MARKETPLACE="databricks-ai-dev-kit"
+#
+# The plugin can be installed from ANY marketplace, so we match by plugin name and
+# discover the actual "name@marketplace" key(s) rather than assuming a marketplace.
+PLUGIN_NAME="databricks-ai-dev-kit"
 
 # Remove the 'databricks' MCP server entry from a JSON config, preserving all
 # other servers and settings. $2 is the top-level key ('mcpServers' or 'servers').
@@ -382,62 +384,64 @@ PYEOF
     return 0
 }
 
-# Read-only detection of the Claude Code plugin per scope. The scope is recorded
-# by which settings.json enables it: user scope in ~/.claude/settings.json, project
-# scope in the project's .claude/settings.json(.local). (installed_plugins.json is
-# user-level and lists ALL scopes together, so it can't distinguish them.)
-plugin_installed_global() {
-    grep -qF "$PLUGIN_KEY" "$HOME/.claude/settings.json" 2>/dev/null
+# Read-only detection of the plugin per scope. The scope is recorded by which
+# settings.json enables it: user scope in ~/.claude/settings.json, project scope in
+# the project's .claude/settings.json(.local). (installed_plugins.json is user-level
+# and lists ALL scopes together, so it can't distinguish them.) Prints the enabled
+# "name@marketplace" key(s) — one per line — so any marketplace is matched.
+plugin_keys_in() {
+    grep -hoE "\"${PLUGIN_NAME}@[A-Za-z0-9._-]+\"" "$@" 2>/dev/null | tr -d '"' | sort -u
 }
-plugin_installed_project() {
-    local dir=$1 s
-    for s in "$dir/.claude/settings.json" "$dir/.claude/settings.local.json"; do
-        grep -qF "$PLUGIN_KEY" "$s" 2>/dev/null && return 0
-    done
-    return 1
-}
+plugin_keys_global()  { plugin_keys_in "$HOME/.claude/settings.json"; }
+plugin_keys_project() { plugin_keys_in "$1/.claude/settings.json" "$1/.claude/settings.local.json"; }
 
 # Warn that the plugin also exists in the scope we're NOT uninstalling, and print
-# the command to remove it there too. Leads with a blank line to separate it from
-# whatever preceded it (the plan, or the "Nothing to uninstall" tip).
+# the command to remove each detected key there too. $1 = newline-separated keys.
+# Leads with a blank line to separate it from whatever preceded it.
 warn_plugin_other_scope() {
+    local other_keys=$1 k
     echo ""
     if [ "$SCOPE" = "project" ]; then
         warn "The Claude Code plugin is also installed ${B}globally${N} — this project uninstall leaves it. To remove that too:"
-        msg  "${B}  claude plugin uninstall ${PLUGIN_KEY} --scope user${N} ${D}(or re-run with --global)${N}"
+        while IFS= read -r k; do [ -n "$k" ] && msg "${B}  claude plugin uninstall ${k} --scope user${N} ${D}(or re-run with --global)${N}"; done <<< "$other_keys"
     else
         warn "The Claude Code plugin is also installed at ${B}project${N} scope — this global uninstall leaves it. To remove that too:"
-        msg  "${B}  claude plugin uninstall ${PLUGIN_KEY} --scope project${N} ${D}(or re-run --uninstall from the project without --global)${N}"
+        while IFS= read -r k; do [ -n "$k" ] && msg "${B}  claude plugin uninstall ${k} --scope project${N} ${D}(or re-run --uninstall from the project without --global)${N}"; done <<< "$other_keys"
     fi
 }
 
 # Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
-# across the shared plugin state — we never hand-edit it). A project install can be
-# either 'project' (.claude/settings.json) or 'local' (.claude/settings.local.json),
+# across the shared plugin state — we never hand-edit it). Removes every detected
+# "name@marketplace" key (the plugin may come from any marketplace). A project
+# install can be 'project' (.claude/settings.json) or 'local' (settings.local.json),
 # so a project uninstall tries both CLI scopes. If nothing could be removed (CLI
 # missing or every attempt failed) this is a hard error that reports whether the
 # rest of the uninstall completed and prints the exact command to run manually.
-# $1 = count of other AI Dev Kit artifacts already removed this run.
+# $1 = count of other AI Dev Kit artifacts already removed this run; $2 = keys.
 remove_claude_plugin() {
-    local others_removed=$1
+    local others_removed=$1 keys=$2
     local scopes cmd_scope
     if [ "$SCOPE" = "project" ]; then scopes="project local"; cmd_scope="project"; else scopes="user"; cmd_scope="user"; fi
     if command -v claude >/dev/null 2>&1; then
-        local sc removed=false
-        for sc in $scopes; do
-            # Subcommand name has varied across versions (uninstall vs remove) — try both.
-            if claude plugin uninstall "$PLUGIN_KEY" -y --scope "$sc" >/dev/null 2>&1 \
-               || claude plugin remove "$PLUGIN_KEY" -y --scope "$sc" >/dev/null 2>&1; then
-                msg "removed Claude Code plugin ${PLUGIN_KEY} (${sc} scope)"
-                removed=true
-            fi
-        done
+        local k sc removed=false
+        while IFS= read -r k; do
+            [ -z "$k" ] && continue
+            for sc in $scopes; do
+                # Subcommand name has varied across versions (uninstall vs remove) — try both.
+                if claude plugin uninstall "$k" -y --scope "$sc" >/dev/null 2>&1 \
+                   || claude plugin remove "$k" -y --scope "$sc" >/dev/null 2>&1; then
+                    msg "removed Claude Code plugin ${k} (${sc} scope)"
+                    removed=true
+                fi
+            done
+        done <<< "$keys"
         [ "$removed" = true ] && return 0
     fi
-    local partial="" alt=""
+    local partial="" alt="" manual="" k
     [ "$others_removed" -gt 0 ] && partial="Skills, MCP server, and config WERE removed (partial uninstall). "
     [ "$SCOPE" = "project" ] && alt=" (or --scope local)"
-    die "Could not remove the Claude Code plugin. ${partial}Finish it manually: ${B}claude plugin uninstall ${PLUGIN_KEY} --scope ${cmd_scope}${N}${alt}"
+    while IFS= read -r k; do [ -n "$k" ] && manual="${manual:+$manual; }claude plugin uninstall ${k} --scope ${cmd_scope}"; done <<< "$keys"
+    die "Could not remove the Claude Code plugin. ${partial}Finish it manually: ${B}${manual}${N}${alt}"
 }
 
 run_uninstall() {
@@ -526,25 +530,28 @@ run_uninstall() {
     # Project-scope leftover marker dir
     [ "$SCOPE" = "project" ] && [ -d "$base_dir/.ai-dev-kit" ] && plan_state+=("$base_dir/.ai-dev-kit/")
 
-    # Claude Code plugin — detect at BOTH scopes (read-only). We only remove the
+    # Claude Code plugin — detect at BOTH scopes (read-only), collecting the enabled
+    # "name@marketplace" key(s) so any marketplace is matched. We only remove the
     # current uninstall scope; presence in the other scope is a warning. Project
     # detection uses the invocation dir ($PWD) — for a global uninstall base_dir is
     # $HOME, which is not the project we'd be warning about.
-    local plan_plugin=false plugin_other=false
+    local plugin_keys="" plugin_other_keys=""
     if [ "$SCOPE" = "global" ]; then
-        plugin_installed_global && plan_plugin=true
-        plugin_installed_project "$PWD" && plugin_other=true
+        plugin_keys=$(plugin_keys_global)
+        plugin_other_keys=$(plugin_keys_project "$PWD")
     else
-        plugin_installed_project "$base_dir" && plan_plugin=true
-        plugin_installed_global && plugin_other=true
+        plugin_keys=$(plugin_keys_project "$base_dir")
+        plugin_other_keys=$(plugin_keys_global)
     fi
+    local plan_plugin=false plugin_other=false plugin_count=0 k
+    [ -n "$plugin_keys" ]       && { plan_plugin=true;  plugin_count=$(printf '%s\n' "$plugin_keys" | grep -c .); }
+    [ -n "$plugin_other_keys" ] && plugin_other=true
 
-    local total=$(( ${#plan_skills[@]} + ${#plan_mcp[@]} + ${#plan_hooks[@]} + ${#plan_runtime[@]} + ${#plan_state[@]} ))
-    [ "$plan_plugin" = true ] && total=$(( total + 1 ))
+    local total=$(( ${#plan_skills[@]} + ${#plan_mcp[@]} + ${#plan_hooks[@]} + ${#plan_runtime[@]} + ${#plan_state[@]} + plugin_count ))
     if [ "$total" -eq 0 ]; then
         ok "Nothing to uninstall for ${B}$SCOPE${N} scope at ${D}${base_dir}${N} — no AI Dev Kit artifacts found."
         [ "$SCOPE" = "project" ] && msg "${D}Tip: pass --global to remove a global install.${N}"
-        [ "$plugin_other" = true ] && warn_plugin_other_scope
+        [ "$plugin_other" = true ] && warn_plugin_other_scope "$plugin_other_keys"
         exit 0
     fi
 
@@ -556,10 +563,10 @@ run_uninstall() {
     [ ${#plan_state[@]}   -gt 0 ] && { echo -e "  ${B}State files:${N}"; for p in "${plan_state[@]}"; do echo "    ${p/#$HOME/~}"; done; }
     [ "$plan_plugin" = true ] && {
         echo -e "  ${B}Claude Code plugin:${N}"
-        echo -e "    ${PLUGIN_KEY} ${D}(removed via the claude CLI, ${SCOPE} scope)${N}"
+        while IFS= read -r k; do [ -n "$k" ] && echo -e "    ${k} ${D}(removed via the claude CLI, ${SCOPE} scope)${N}"; done <<< "$plugin_keys"
         echo -e "  ${Y}${B}⚠  Heads up: the AI Dev Kit Claude Code plugin will also be removed.${N}"
     }
-    [ "$plugin_other" = true ] && warn_plugin_other_scope
+    [ "$plugin_other" = true ] && warn_plugin_other_scope "$plugin_other_keys"
     echo ""
     msg "${D}Config files are backed up to <file>.bak before editing.${N}"
 
@@ -593,7 +600,7 @@ run_uninstall() {
     for p in "${plan_hooks[@]}"; do uninstall_remove_claude_hook "$p" && msg "cleaned hook in ${p/#$HOME/~}"; done
     for p in "${plan_runtime[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
     for p in "${plan_state[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
-    [ "$plan_plugin" = true ] && remove_claude_plugin "$(( total - 1 ))"
+    [ "$plan_plugin" = true ] && remove_claude_plugin "$(( total - plugin_count ))" "$plugin_keys"
 
     echo ""
     ok "AI Dev Kit uninstalled (${SCOPE} scope)."

--- a/install.sh
+++ b/install.sh
@@ -479,6 +479,7 @@ run_uninstall() {
             "$HOME/.gemini/settings.json|json:mcpServers"
             "$HOME/.gemini/antigravity/mcp_config.json|json:mcpServers"
             "$HOME/.codeium/windsurf/mcp_config.json|json:mcpServers"
+            "$HOME/.config/opencode/opencode.json|json:mcp"
             "$HOME/.kiro/settings/mcp.json|json:mcpServers"
         )
         hook_targets=("$HOME/.claude/settings.json")
@@ -493,6 +494,7 @@ run_uninstall() {
             "$base_dir/.cursor/mcp.json|json:mcpServers" "$base_dir/.vscode/mcp.json|json:servers"
             "$base_dir/.codex/config.toml|toml"
             "$base_dir/.gemini/settings.json|json:mcpServers"
+            "$base_dir/opencode.json|json:mcp"
             "$base_dir/.kiro/settings/mcp.json|json:mcpServers"
         )
         hook_targets=("$base_dir/.claude/settings.json")

--- a/install.sh
+++ b/install.sh
@@ -294,39 +294,50 @@ retrieving-mlflow-traces searching-mlflow-docs
 uninstall_remove_json_key() {
     local path=$1 top=$2
     [ -f "$path" ] || return 1
-    grep -q '"databricks"' "$path" 2>/dev/null || return 1
+    grep -qF '"databricks"' "$path" 2>/dev/null || return 1
     if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
     local py=""
     command -v python3 >/dev/null 2>&1 && py=python3
     [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
     if [ -z "$py" ]; then warn "No Python to edit $path — remove the 'databricks' entry manually."; return 1; fi
+    # Python decides whether the exact top-level 'databricks' key is present; it
+    # writes (and the shell backs up) only when a key is actually removed, so a
+    # stray '"databricks"' elsewhere in the file doesn't trigger a no-op rewrite.
     cp "$path" "${path}.bak"
-    "$py" - "$path" "$top" <<'PYEOF'
+    if "$py" - "$path" "$top" <<'PYEOF'
 import json, sys
 path, top = sys.argv[1], sys.argv[2]
 try:
     with open(path) as f: cfg = json.load(f)
-except Exception: sys.exit(0)
-if isinstance(cfg.get(top), dict):
-    cfg[top].pop('databricks', None)
-    if not cfg[top]: cfg.pop(top, None)
+except Exception: sys.exit(2)
+if not (isinstance(cfg.get(top), dict) and 'databricks' in cfg[top]):
+    sys.exit(1)  # nothing to remove
+cfg[top].pop('databricks', None)
+if not cfg[top]: cfg.pop(top, None)
 with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+sys.exit(0)
 PYEOF
-    return 0
+    then
+        return 0
+    else
+        rm -f "${path}.bak"   # nothing changed — don't leave a spurious backup
+        return 1
+    fi
 }
 
 # Remove the [mcp_servers.databricks] block from a Codex TOML config.
 uninstall_remove_toml_block() {
     local path=$1
     [ -f "$path" ] || return 1
-    grep -q 'mcp_servers.databricks' "$path" 2>/dev/null || return 1
+    grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null || return 1
     if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
     cp "$path" "${path}.bak"
-    # Delete the [mcp_servers.databricks] header through the line before the next
+    # Delete the [mcp_servers.databricks] table AND its dotted subtables
+    # (e.g. [mcp_servers.databricks.env]) through to the next unrelated
     # [section] header (or EOF). awk keeps everything outside that block.
     awk '
-        /^\[mcp_servers\.databricks\]/ { skip=1; next }
-        /^\[/ && skip { skip=0 }
+        /^\[mcp_servers\.databricks(\.|\])/ { skip=1; next }
+        /^\[/ { skip=0 }
         !skip { print }
     ' "${path}.bak" > "$path"
     return 0
@@ -364,6 +375,14 @@ PYEOF
 
 run_uninstall() {
     local base_dir install_dir state_dir
+    # Mirror install: if scope wasn't set explicitly, ask (interactive, non --yes)
+    # so a user who did a global install isn't silently told "nothing to uninstall
+    # for project scope". Non-interactive/--yes keeps the documented 'project' default.
+    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ] && [ -t 0 ]; then
+        printf "  Uninstall scope — [p]roject (this directory) or [g]lobal (\$HOME)? [P/g] "
+        local sreply; read -r sreply </dev/tty || sreply=""
+        case "$sreply" in [gG]|[gG][lL][oO][bB][aA][lL]) SCOPE="global" ;; *) SCOPE="project" ;; esac
+    fi
     [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
     install_dir="${USER_MCP_PATH:-${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}}"
     [ "$SCOPE" = "global" ] && state_dir="$install_dir" || state_dir="$base_dir/.ai-dev-kit"
@@ -420,8 +439,8 @@ run_uninstall() {
     for entry in "${mcp_targets[@]}"; do
         path="${entry%%|*}"; kind="${entry#*|}"
         case "$kind" in
-            json:*) [ -f "$path" ] && grep -q '"databricks"' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
-            toml)   [ -f "$path" ] && grep -q 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+            json:*) [ -f "$path" ] && grep -qF '"databricks"' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+            toml)   [ -f "$path" ] && grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
         esac
     done
     for path in "${hook_targets[@]}"; do

--- a/install.sh
+++ b/install.sh
@@ -378,9 +378,9 @@ run_uninstall() {
     # Mirror install: if scope wasn't set explicitly, ask (interactive, non --yes)
     # so a user who did a global install isn't silently told "nothing to uninstall
     # for project scope". Non-interactive/--yes keeps the documented 'project' default.
-    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ] && [ -t 0 ]; then
+    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ] && { exec 3</dev/tty; } 2>/dev/null; then
         printf "  Uninstall scope — [p]roject (this directory) or [g]lobal (\$HOME)? [P/g] "
-        local sreply; read -r sreply </dev/tty || sreply=""
+        local sreply; read -r sreply <&3 || sreply=""; exec 3<&-
         case "$sreply" in [gG]|[gG][lL][oO][bB][aA][lL]) SCOPE="global" ;; *) SCOPE="project" ;; esac
     fi
     [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
@@ -480,8 +480,14 @@ run_uninstall() {
     fi
 
     if [ "$ASSUME_YES" != true ]; then
-        printf "  ${Y}Remove these %d item(s)?${N} [y/N] " "$total"
-        local reply; read -r reply </dev/tty || reply=""
+        local reply=""
+        if { exec 3</dev/tty; } 2>/dev/null; then
+            printf "  ${Y}Remove these %d item(s)?${N} [y/N] " "$total"
+            read -r reply <&3 || reply=""
+            exec 3<&-
+        else
+            die "No terminal to confirm on. Re-run with -y/--yes to proceed non-interactively (or --dry-run to preview)."
+        fi
         case "$reply" in [yY]|[yY][eE][sS]) ;; *) die "Aborted — nothing removed." ;; esac
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -626,9 +626,14 @@ run_uninstall() {
     if [ "$SCOPE" = "global" ] || [ -n "$USER_MCP_PATH" ]; then
         [ -d "$install_dir" ] && plan_runtime+=("$install_dir")
     fi
-    for path in "$state_dir/.installed-skills" "$state_dir/.skills-profile" "$state_dir/version"; do
-        [ -f "$path" ] && plan_state+=("$path")
-    done
+    # On a global uninstall state_dir IS the runtime dir; when that dir is already in
+    # plan_runtime the state files inside it are removed along with it — planning them
+    # separately would double-delete (and double-list them in the plan).
+    if [[ " ${plan_runtime[*]} " != *" $state_dir "* ]]; then
+        for path in "$state_dir/.installed-skills" "$state_dir/.skills-profile" "$state_dir/version"; do
+            [ -f "$path" ] && plan_state+=("$path")
+        done
+    fi
     # Project-scope leftover marker dir
     [ "$SCOPE" = "project" ] && [ -d "$base_dir/.ai-dev-kit" ] && plan_state+=("$base_dir/.ai-dev-kit/")
 

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,9 @@ SCOPE="${DEVKIT_SCOPE:-project}"
 SCOPE_EXPLICIT=false  # Track if --global was explicitly passed
 FORCE="${DEVKIT_FORCE:-false}"
 IS_UPDATE=false
+UNINSTALL=false
+DRY_RUN=false
+ASSUME_YES=false
 SILENT="${DEVKIT_SILENT:-false}"
 TOOLS="${DEVKIT_TOOLS:-}"
 USER_TOOLS=""
@@ -145,7 +148,10 @@ while [ $# -gt 0 ]; do
         --tools)          USER_TOOLS="$2"; shift 2 ;;
         --experimental)   CHANNEL="experimental"; shift ;;
         -f|--force)       FORCE=true; shift ;;
-        -h|--help)        
+        --uninstall)      UNINSTALL=true; shift ;;
+        --dry-run)        DRY_RUN=true; shift ;;
+        -y|--yes)         ASSUME_YES=true; shift ;;
+        -h|--help)
             echo "Databricks AI Dev Kit Installer"
             echo ""
             echo "Usage: bash <(curl -sL .../install.sh) [OPTIONS]"
@@ -164,6 +170,9 @@ while [ $# -gt 0 ]; do
             echo "  --list-skills         List available skills and profiles, then exit"
             echo "  --experimental        Install from experimental branch (early access features)"
             echo "  -f, --force           Force reinstall"
+            echo "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, and MCP config"
+            echo "  --dry-run             With --uninstall: print what would be removed, change nothing"
+            echo "  -y, --yes             With --uninstall: skip the confirmation prompt"
             echo "  -h, --help            Show this help"
             echo ""
             echo "Environment Variables (alternative to flags):"
@@ -256,6 +265,229 @@ if [ "${LIST_SKILLS:-false}" = true ]; then
     echo -e "${D}       bash install.sh --skills databricks-jobs,databricks-dbsql${N}"
     echo ""
     exit 0
+fi
+
+# ─── --uninstall handler ───────────────────────────────────────
+# All skill directory names the installer has EVER shipped (current + historical
+# renames/removals). Uninstall sweeps this union so old installs — e.g. the
+# removed databricks-lakebase-provisioned or the renamed databricks-app-python —
+# are cleaned up, not just whatever the current release ships.
+UNINSTALL_SKILL_NAMES="
+databricks-agent-bricks databricks-ai-functions databricks-aibi-dashboards
+databricks-bundles databricks-asset-bundles databricks-apps-python databricks-app-python
+databricks-app-apx databricks-config databricks-dbsql databricks-docs
+databricks-execution-compute databricks-genie databricks-iceberg databricks-jobs
+databricks-lakebase-autoscale databricks-lakebase-provisioned databricks-metric-views
+databricks-ml-training-serving databricks-model-serving databricks-mlflow-evaluation
+databricks-parsing databricks-python-sdk databricks-spark-declarative-pipelines
+databricks-spark-structured-streaming databricks-synthetic-data-gen databricks-synthetic-data-generation
+databricks-unity-catalog databricks-unstructured-pdf-generation databricks-vector-search
+databricks-zerobus-ingest spark-python-data-source
+databricks databricks-apps databricks-lakebase
+agent-evaluation analyze-mlflow-chat-session analyze-mlflow-trace
+instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics
+retrieving-mlflow-traces searching-mlflow-docs
+"
+
+# Remove the 'databricks' MCP server entry from a JSON config, preserving all
+# other servers and settings. $2 is the top-level key ('mcpServers' or 'servers').
+uninstall_remove_json_key() {
+    local path=$1 top=$2
+    [ -f "$path" ] || return 1
+    grep -q '"databricks"' "$path" 2>/dev/null || return 1
+    if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
+    local py=""
+    command -v python3 >/dev/null 2>&1 && py=python3
+    [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
+    if [ -z "$py" ]; then warn "No Python to edit $path — remove the 'databricks' entry manually."; return 1; fi
+    cp "$path" "${path}.bak"
+    "$py" - "$path" "$top" <<'PYEOF'
+import json, sys
+path, top = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f: cfg = json.load(f)
+except Exception: sys.exit(0)
+if isinstance(cfg.get(top), dict):
+    cfg[top].pop('databricks', None)
+    if not cfg[top]: cfg.pop(top, None)
+with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+PYEOF
+    return 0
+}
+
+# Remove the [mcp_servers.databricks] block from a Codex TOML config.
+uninstall_remove_toml_block() {
+    local path=$1
+    [ -f "$path" ] || return 1
+    grep -q 'mcp_servers.databricks' "$path" 2>/dev/null || return 1
+    if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
+    cp "$path" "${path}.bak"
+    # Delete the [mcp_servers.databricks] header through the line before the next
+    # [section] header (or EOF). awk keeps everything outside that block.
+    awk '
+        /^\[mcp_servers\.databricks\]/ { skip=1; next }
+        /^\[/ && skip { skip=0 }
+        !skip { print }
+    ' "${path}.bak" > "$path"
+    return 0
+}
+
+# Remove the AI Dev Kit SessionStart hook (identified by check_update.sh) from a
+# Claude settings.json, leaving other hooks intact.
+uninstall_remove_claude_hook() {
+    local path=$1
+    [ -f "$path" ] || return 1
+    grep -q 'check_update.sh' "$path" 2>/dev/null || return 1
+    if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
+    local py=""
+    command -v python3 >/dev/null 2>&1 && py=python3
+    [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
+    [ -z "$py" ] && { warn "No Python to edit $path — remove the check_update.sh hook manually."; return 1; }
+    cp "$path" "${path}.bak"
+    "$py" - "$path" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path) as f: cfg = json.load(f)
+except Exception: sys.exit(0)
+sh = cfg.get('hooks', {}).get('SessionStart')
+if isinstance(sh, list):
+    for group in sh:
+        group['hooks'] = [h for h in group.get('hooks', []) if 'check_update.sh' not in h.get('command', '')]
+    sh[:] = [g for g in sh if g.get('hooks')]
+    if not sh: cfg['hooks'].pop('SessionStart', None)
+    if not cfg.get('hooks'): cfg.pop('hooks', None)
+with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+PYEOF
+    return 0
+}
+
+run_uninstall() {
+    local base_dir install_dir state_dir
+    [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
+    install_dir="${USER_MCP_PATH:-${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}}"
+    [ "$SCOPE" = "global" ] && state_dir="$install_dir" || state_dir="$base_dir/.ai-dev-kit"
+    VENV_PYTHON="$install_dir/.venv/bin/python"
+
+    # Scope strictly gates locations. The installer writes project artifacts under
+    # the project dir and global artifacts under $HOME; a project uninstall must
+    # never touch $HOME configs (and vice-versa), or it would clobber the other
+    # scope's install. The few tools that always use $HOME even for project scope
+    # (antigravity/windsurf/opencode/kiro) are therefore only cleaned in --global.
+    local skill_roots mcp_targets hook_targets
+    if [ "$SCOPE" = "global" ]; then
+        skill_roots=(
+            "$HOME/.claude/skills" "$HOME/.cursor/skills" "$HOME/.github/skills"
+            "$HOME/.agents/skills" "$HOME/.gemini/skills"
+            "$HOME/.gemini/antigravity/skills" "$HOME/.codeium/windsurf/skills"
+            "$HOME/.config/opencode/skills" "$HOME/.kiro/skills"
+        )
+        mcp_targets=(
+            "$HOME/.claude.json|json:mcpServers"
+            "$HOME/.codex/config.toml|toml"
+            "$HOME/.gemini/settings.json|json:mcpServers"
+            "$HOME/.gemini/antigravity/mcp_config.json|json:mcpServers"
+            "$HOME/.codeium/windsurf/mcp_config.json|json:mcpServers"
+            "$HOME/.kiro/settings/mcp.json|json:mcpServers"
+        )
+        hook_targets=("$HOME/.claude/settings.json")
+    else
+        skill_roots=(
+            "$base_dir/.claude/skills" "$base_dir/.cursor/skills" "$base_dir/.github/skills"
+            "$base_dir/.agents/skills" "$base_dir/.gemini/skills" "$base_dir/.windsurf/skills"
+            "$base_dir/.opencode/skills" "$base_dir/.kiro/skills"
+        )
+        mcp_targets=(
+            "$base_dir/.mcp.json|json:mcpServers"
+            "$base_dir/.cursor/mcp.json|json:mcpServers" "$base_dir/.vscode/mcp.json|json:servers"
+            "$base_dir/.codex/config.toml|toml"
+            "$base_dir/.gemini/settings.json|json:mcpServers"
+            "$base_dir/.kiro/settings/mcp.json|json:mcpServers"
+        )
+        hook_targets=("$base_dir/.claude/settings.json")
+    fi
+
+    # ── Build the plan (paths that actually exist / contain our entries) ──
+    local -a plan_skills=() plan_mcp=() plan_hooks=() plan_runtime=() plan_state=()
+    local root name
+    for root in "${skill_roots[@]}"; do
+        [ -d "$root" ] || continue
+        for name in $UNINSTALL_SKILL_NAMES; do
+            [ -d "$root/$name" ] && plan_skills+=("$root/$name")
+        done
+    done
+    local entry path kind
+    for entry in "${mcp_targets[@]}"; do
+        path="${entry%%|*}"; kind="${entry#*|}"
+        case "$kind" in
+            json:*) [ -f "$path" ] && grep -q '"databricks"' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+            toml)   [ -f "$path" ] && grep -q 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+        esac
+    done
+    for path in "${hook_targets[@]}"; do
+        [ -f "$path" ] && grep -q 'check_update.sh' "$path" 2>/dev/null && plan_hooks+=("$path")
+    done
+    # The shared MCP runtime (~/.ai-dev-kit) is global; only remove it on a global
+    # uninstall, or when the user explicitly points --mcp-path at it. A project
+    # uninstall leaves it so other projects/global keep working.
+    if [ "$SCOPE" = "global" ] || [ -n "$USER_MCP_PATH" ]; then
+        [ -d "$install_dir" ] && plan_runtime+=("$install_dir")
+    fi
+    for path in "$state_dir/.installed-skills" "$state_dir/.skills-profile" "$state_dir/version"; do
+        [ -f "$path" ] && plan_state+=("$path")
+    done
+    # Project-scope leftover marker dir
+    [ "$SCOPE" = "project" ] && [ -d "$base_dir/.ai-dev-kit" ] && plan_state+=("$base_dir/.ai-dev-kit/")
+
+    local total=$(( ${#plan_skills[@]} + ${#plan_mcp[@]} + ${#plan_hooks[@]} + ${#plan_runtime[@]} + ${#plan_state[@]} ))
+    if [ "$total" -eq 0 ]; then
+        ok "Nothing to uninstall for ${B}$SCOPE${N} scope at ${D}${base_dir}${N} — no AI Dev Kit artifacts found."
+        [ "$SCOPE" = "project" ] && msg "${D}Tip: pass --global to remove a global install.${N}"
+        exit 0
+    fi
+
+    step "Uninstall plan (${SCOPE} scope)"
+    [ ${#plan_skills[@]}  -gt 0 ] && { echo -e "  ${B}Skill folders (${#plan_skills[@]}):${N}"; for p in "${plan_skills[@]}"; do echo "    ${p/#$HOME/~}"; done; }
+    [ ${#plan_mcp[@]}     -gt 0 ] && { echo -e "  ${B}MCP config — remove 'databricks' entry (${#plan_mcp[@]}):${N}"; for e in "${plan_mcp[@]}"; do echo "    ${e%%|*}" | sed "s#$HOME#~#"; done; }
+    [ ${#plan_hooks[@]}   -gt 0 ] && { echo -e "  ${B}Claude update hook (${#plan_hooks[@]}):${N}"; for p in "${plan_hooks[@]}"; do echo "    ${p/#$HOME/~}"; done; }
+    [ ${#plan_runtime[@]} -gt 0 ] && { echo -e "  ${B}MCP server runtime:${N}"; for p in "${plan_runtime[@]}"; do echo "    ${p/#$HOME/~}"; done; }
+    [ ${#plan_state[@]}   -gt 0 ] && { echo -e "  ${B}State files:${N}"; for p in "${plan_state[@]}"; do echo "    ${p/#$HOME/~}"; done; }
+    echo ""
+    msg "${D}Config files are backed up to <file>.bak before editing.${N}"
+
+    if [ "$DRY_RUN" = true ]; then
+        ok "Dry run — nothing was changed. Re-run without --dry-run to apply."
+        exit 0
+    fi
+
+    if [ "$ASSUME_YES" != true ]; then
+        printf "  ${Y}Remove these %d item(s)?${N} [y/N] " "$total"
+        local reply; read -r reply </dev/tty || reply=""
+        case "$reply" in [yY]|[yY][eE][sS]) ;; *) die "Aborted — nothing removed." ;; esac
+    fi
+
+    step "Removing"
+    local p e
+    for p in "${plan_skills[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
+    for e in "${plan_mcp[@]}"; do
+        path="${e%%|*}"; kind="${e#*|}"
+        case "$kind" in
+            json:*) uninstall_remove_json_key "$path" "${kind#json:}" && msg "cleaned ${path/#$HOME/~}" ;;
+            toml)   uninstall_remove_toml_block "$path" && msg "cleaned ${path/#$HOME/~}" ;;
+        esac
+    done
+    for p in "${plan_hooks[@]}"; do uninstall_remove_claude_hook "$p" && msg "cleaned hook in ${p/#$HOME/~}"; done
+    for p in "${plan_runtime[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
+    for p in "${plan_state[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
+
+    echo ""
+    ok "AI Dev Kit uninstalled (${SCOPE} scope)."
+    msg "${D}Other scopes (e.g. --global) and per-editor .bak backups were left untouched.${N}"
+    exit 0
+}
+
+if [ "$UNINSTALL" = true ]; then
+    run_uninstall
 fi
 
 # Set configuration URLs after parsing branch argument

--- a/install.sh
+++ b/install.sh
@@ -300,6 +300,28 @@ retrieving-mlflow-traces searching-mlflow-docs
 # discover the actual "name@marketplace" key(s) rather than assuming a marketplace.
 PLUGIN_NAME="databricks-ai-dev-kit"
 
+# Read-only: true only if the EXACT top-level server key ($2) contains a
+# 'databricks' entry — the same thing removal targets. This deliberately does NOT
+# match nested occurrences (e.g. ~/.claude.json's projects.<path>.mcpServers.databricks,
+# which is a project-scoped server we never touch) that a plain grep would flag.
+mcp_json_has_databricks() {
+    local path=$1 top=$2 py=""
+    [ -f "$path" ] || return 1
+    command -v python3 >/dev/null 2>&1 && py=python3
+    [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
+    # No Python: fall back to a loose grep (best effort; may over-match).
+    [ -z "$py" ] && { grep -qF '"databricks"' "$path" 2>/dev/null; return; }
+    "$py" - "$path" "$top" <<'PYEOF'
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+top = cfg.get(sys.argv[2])
+sys.exit(0 if (isinstance(top, dict) and "databricks" in top) else 1)
+PYEOF
+}
+
 # Remove the 'databricks' MCP server entry from a JSON config, preserving all
 # other servers and settings. $2 is the top-level key ('mcpServers' or 'servers').
 uninstall_remove_json_key() {
@@ -398,16 +420,94 @@ plugin_keys_project() { plugin_keys_in "$1/.claude/settings.json" "$1/.claude/se
 # Warn that the plugin also exists in the scope we're NOT uninstalling, and print
 # the command to remove each detected key there too. $1 = newline-separated keys.
 # Leads with a blank line to separate it from whatever preceded it.
-warn_plugin_other_scope() {
-    local other_keys=$1 k
+# Count skill folders and 'databricks' MCP entries under the given roots/targets,
+# plus hook/state/plugin, emitting one "  - ..." summary line each. Shared by the
+# project- and global-scope summaries below. Read-only; always returns 0.
+_leftovers_summary() {
+    local hook=$1 state_dir=$2 plugin_keys=$3; shift 3
+    local root name entry path kind n=0
+    # Remaining args: skill roots, then a "--" separator, then "path|kind" MCP targets.
+    local -a roots=() targets=(); local sep=false a
+    for a in "$@"; do
+        [ "$a" = "--" ] && { sep=true; continue; }
+        $sep && targets+=("$a") || roots+=("$a")
+    done
+    for root in "${roots[@]}"; do
+        [ -d "$root" ] || continue
+        for name in $UNINSTALL_SKILL_NAMES; do [ -d "$root/$name" ] && n=$((n + 1)); done
+    done
+    [ "$n" -gt 0 ] && echo "  - ${n} skill folder(s)"
+    n=0
+    for entry in "${targets[@]}"; do
+        path="${entry%%|*}"; kind="${entry#*|}"
+        [ -f "$path" ] || continue
+        case "$kind" in
+            json:*) mcp_json_has_databricks "$path" "${kind#json:}" && n=$((n + 1)) ;;
+            toml)   grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null && n=$((n + 1)) ;;
+        esac
+    done
+    [ "$n" -gt 0 ] && echo "  - ${n} MCP config file(s) with the 'databricks' server"
+    [ -n "$hook" ] && grep -q 'check_update.sh' "$hook" 2>/dev/null && echo "  - Claude update hook"
+    [ -n "$state_dir" ] && [ -d "$state_dir" ] && echo "  - MCP server runtime / state ($(printf '%s' "$state_dir" | sed "s#$HOME#~#"))"
+    [ -n "$plugin_keys" ] && echo "  - Claude Code plugin: $(printf '%s' "$plugin_keys" | tr '\n' ' ')"
+    return 0  # never let the last test's exit status trip `set -e` in the caller
+}
+
+# Project-scope artifacts under $1 (what a project uninstall from that dir removes).
+project_leftovers_summary() {
+    local dir=$1
+    _leftovers_summary "$dir/.claude/settings.json" "$dir/.ai-dev-kit" "$(plugin_keys_project "$dir")" \
+        "$dir/.claude/skills" "$dir/.cursor/skills" "$dir/.github/skills" \
+        "$dir/.agents/skills" "$dir/.gemini/skills" "$dir/.windsurf/skills" \
+        "$dir/.opencode/skills" "$dir/.kiro/skills" \
+        -- \
+        "$dir/.mcp.json|json:mcpServers" "$dir/.cursor/mcp.json|json:mcpServers" "$dir/.vscode/mcp.json|json:servers" \
+        "$dir/.codex/config.toml|toml" "$dir/.gemini/settings.json|json:mcpServers" \
+        "$dir/opencode.json|json:mcp" "$dir/.kiro/settings/mcp.json|json:mcpServers"
+}
+
+# Global/user-scope artifacts (what a --global uninstall removes).
+global_leftovers_summary() {
+    local install_dir="${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}"
+    _leftovers_summary "$HOME/.claude/settings.json" "$install_dir" "$(plugin_keys_global)" \
+        "$HOME/.claude/skills" "$HOME/.cursor/skills" "$HOME/.github/skills" \
+        "$HOME/.agents/skills" "$HOME/.gemini/skills" "$HOME/.gemini/antigravity/skills" \
+        "$HOME/.codeium/windsurf/skills" "$HOME/.config/opencode/skills" "$HOME/.kiro/skills" \
+        -- \
+        "$HOME/.claude.json|json:mcpServers" "$HOME/.codex/config.toml|toml" "$HOME/.gemini/settings.json|json:mcpServers" \
+        "$HOME/.gemini/antigravity/mcp_config.json|json:mcpServers" "$HOME/.codeium/windsurf/mcp_config.json|json:mcpServers" \
+        "$HOME/.config/opencode/opencode.json|json:mcp" "$HOME/.kiro/settings/mcp.json|json:mcpServers"
+}
+
+# Very noticeable end-of-run box warning that files remain in the OTHER scope.
+# $1 = headline, $2 = detail line, $3 = summary lines, $4 = how-to-remove action.
+leftovers_box() {
+    local headline=$1 detail=$2 summary=$3 action=$4
+    local bar="  ${Y}${B}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
     echo ""
-    if [ "$SCOPE" = "project" ]; then
-        warn "The Claude Code plugin is also installed ${B}globally${N} — this project uninstall leaves it. To remove that too:"
-        while IFS= read -r k; do [ -n "$k" ] && msg "${B}  claude plugin uninstall ${k} --scope user${N} ${D}(or re-run with --global)${N}"; done <<< "$other_keys"
-    else
-        warn "The Claude Code plugin is also installed at ${B}project${N} scope — this global uninstall leaves it. To remove that too:"
-        while IFS= read -r k; do [ -n "$k" ] && msg "${B}  claude plugin uninstall ${k} --scope project${N} ${D}(or re-run --uninstall from the project without --global)${N}"; done <<< "$other_keys"
-    fi
+    echo -e "$bar"
+    echo -e "  ${Y}${B}${headline}${N}"
+    echo -e "$bar"
+    echo -e "  ${D}${detail}${N}"
+    echo -e "$summary"
+    echo -e "  ${Y}${action}${N}"
+    echo -e "$bar"
+}
+
+# Warn (after a global uninstall) that project-scoped files remain in $1.
+warn_project_leftovers() {
+    leftovers_box "⚠  PROJECT-LEVEL AI DEV KIT FILES STILL REMAIN" \
+        "This global uninstall did not touch project-scoped files in: ${B}$1${N}" \
+        "$2" \
+        "Re-run the uninstaller from that folder ${B}without --global${N}${Y} to remove them."
+}
+
+# Warn (after a project uninstall) that global/user-level files remain.
+warn_global_leftovers() {
+    leftovers_box "⚠  GLOBAL AI DEV KIT FILES STILL REMAIN" \
+        "This project uninstall did not touch global (user-level) files:" \
+        "$1" \
+        "Re-run the uninstaller with ${B}--global${N}${Y} to remove them."
 }
 
 # Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
@@ -513,7 +613,7 @@ run_uninstall() {
     for entry in "${mcp_targets[@]}"; do
         path="${entry%%|*}"; kind="${entry#*|}"
         case "$kind" in
-            json:*) [ -f "$path" ] && grep -qF '"databricks"' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+            json:*) mcp_json_has_databricks "$path" "${kind#json:}" && plan_mcp+=("$entry") ;;
             toml)   [ -f "$path" ] && grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
         esac
     done
@@ -532,28 +632,29 @@ run_uninstall() {
     # Project-scope leftover marker dir
     [ "$SCOPE" = "project" ] && [ -d "$base_dir/.ai-dev-kit" ] && plan_state+=("$base_dir/.ai-dev-kit/")
 
-    # Claude Code plugin — detect at BOTH scopes (read-only), collecting the enabled
-    # "name@marketplace" key(s) so any marketplace is matched. We only remove the
-    # current uninstall scope; presence in the other scope is a warning. Project
-    # detection uses the invocation dir ($PWD) — for a global uninstall base_dir is
-    # $HOME, which is not the project we'd be warning about.
-    local plugin_keys="" plugin_other_keys=""
+    # Claude Code plugin at the CURRENT scope — collect the enabled "name@marketplace"
+    # key(s) so any marketplace is matched; these are what we remove.
+    local plugin_keys="" plan_plugin=false plugin_count=0 k
+    if [ "$SCOPE" = "global" ]; then plugin_keys=$(plugin_keys_global); else plugin_keys=$(plugin_keys_project "$base_dir"); fi
+    [ -n "$plugin_keys" ] && { plan_plugin=true; plugin_count=$(printf '%s\n' "$plugin_keys" | grep -c .); }
+
+    # Warn about artifacts left behind in the OTHER scope. A global uninstall looks
+    # for project-scope files in the current folder ($PWD); a project uninstall looks
+    # for global/user-level files. Skip the $PWD scan when $PWD is $HOME (there the
+    # project and global paths coincide and are already handled by the global side).
+    local project_leftovers="" global_leftovers=""
     if [ "$SCOPE" = "global" ]; then
-        plugin_keys=$(plugin_keys_global)
-        plugin_other_keys=$(plugin_keys_project "$PWD")
+        [ "$PWD" != "$HOME" ] && project_leftovers=$(project_leftovers_summary "$PWD")
     else
-        plugin_keys=$(plugin_keys_project "$base_dir")
-        plugin_other_keys=$(plugin_keys_global)
+        [ "$base_dir" != "$HOME" ] && global_leftovers=$(global_leftovers_summary)
     fi
-    local plan_plugin=false plugin_other=false plugin_count=0 k
-    [ -n "$plugin_keys" ]       && { plan_plugin=true;  plugin_count=$(printf '%s\n' "$plugin_keys" | grep -c .); }
-    [ -n "$plugin_other_keys" ] && plugin_other=true
 
     local total=$(( ${#plan_skills[@]} + ${#plan_mcp[@]} + ${#plan_hooks[@]} + ${#plan_runtime[@]} + ${#plan_state[@]} + plugin_count ))
     if [ "$total" -eq 0 ]; then
         ok "Nothing to uninstall for ${B}$SCOPE${N} scope at ${D}${base_dir}${N} — no AI Dev Kit artifacts found."
-        [ "$SCOPE" = "project" ] && msg "${D}Tip: pass --global to remove a global install.${N}"
-        [ "$plugin_other" = true ] && warn_plugin_other_scope "$plugin_other_keys"
+        [ "$SCOPE" = "project" ] && [ -z "$global_leftovers" ] && msg "${D}Tip: pass --global to remove a global install.${N}"
+        [ -n "$project_leftovers" ] && warn_project_leftovers "$PWD" "$project_leftovers"
+        [ -n "$global_leftovers" ]  && warn_global_leftovers "$global_leftovers"
         exit 0
     fi
 
@@ -568,11 +669,12 @@ run_uninstall() {
         while IFS= read -r k; do [ -n "$k" ] && echo -e "    ${k} ${D}(removed via the claude CLI, ${SCOPE} scope)${N}"; done <<< "$plugin_keys"
         echo -e "  ${Y}${B}⚠  Heads up: the AI Dev Kit Claude Code plugin will also be removed.${N}"
     }
-    [ "$plugin_other" = true ] && warn_plugin_other_scope "$plugin_other_keys"
     echo ""
     msg "${D}Config files are backed up to <file>.bak before editing.${N}"
 
     if [ "$DRY_RUN" = true ]; then
+        [ -n "$project_leftovers" ] && warn_project_leftovers "$PWD" "$project_leftovers"
+        [ -n "$global_leftovers" ]  && warn_global_leftovers "$global_leftovers"
         ok "Dry run — nothing was changed. Re-run without --dry-run to apply."
         exit 0
     fi
@@ -606,7 +708,9 @@ run_uninstall() {
 
     echo ""
     ok "AI Dev Kit uninstalled (${SCOPE} scope)."
-    msg "${D}Other scopes (e.g. --global) and per-editor .bak backups were left untouched.${N}"
+    msg "${D}Other scopes and per-editor .bak backups were left untouched.${N}"
+    [ -n "$project_leftovers" ] && warn_project_leftovers "$PWD" "$project_leftovers"
+    [ -n "$global_leftovers" ]  && warn_global_leftovers "$global_leftovers"
     exit 0
 }
 

--- a/install.sh
+++ b/install.sh
@@ -170,7 +170,7 @@ while [ $# -gt 0 ]; do
             echo "  --list-skills         List available skills and profiles, then exit"
             echo "  --experimental        Install from experimental branch (early access features)"
             echo "  -f, --force           Force reinstall"
-            echo "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, and MCP config"
+            echo "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, MCP config, and Claude Code plugin"
             echo "  --dry-run             With --uninstall: print what would be removed, change nothing"
             echo "  -y, --yes             With --uninstall: skip the confirmation prompt"
             echo "  -h, --help            Show this help"
@@ -289,6 +289,15 @@ instrumenting-with-mlflow-tracing mlflow-onboarding querying-mlflow-metrics
 retrieving-mlflow-traces searching-mlflow-docs
 "
 
+# The Claude Code plugin (installed via the marketplace, separate from the skills
+# this script drops directly). Its on-disk state lives across several shared
+# files (~/.claude/plugins/installed_plugins.json, enabledPlugins in
+# settings.json, known_marketplaces.json, the cache dir) that are shared with
+# the user's OTHER plugins — so we never hand-edit them. Detection is read-only;
+# removal is delegated to the official `claude` CLI (or shown as a command).
+PLUGIN_KEY="databricks-ai-dev-kit@databricks-ai-dev-kit"
+PLUGIN_MARKETPLACE="databricks-ai-dev-kit"
+
 # Remove the 'databricks' MCP server entry from a JSON config, preserving all
 # other servers and settings. $2 is the top-level key ('mcpServers' or 'servers').
 uninstall_remove_json_key() {
@@ -371,6 +380,64 @@ if isinstance(sh, list):
 with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
 PYEOF
     return 0
+}
+
+# Read-only detection of the Claude Code plugin per scope. The scope is recorded
+# by which settings.json enables it: user scope in ~/.claude/settings.json, project
+# scope in the project's .claude/settings.json(.local). (installed_plugins.json is
+# user-level and lists ALL scopes together, so it can't distinguish them.)
+plugin_installed_global() {
+    grep -qF "$PLUGIN_KEY" "$HOME/.claude/settings.json" 2>/dev/null
+}
+plugin_installed_project() {
+    local dir=$1 s
+    for s in "$dir/.claude/settings.json" "$dir/.claude/settings.local.json"; do
+        grep -qF "$PLUGIN_KEY" "$s" 2>/dev/null && return 0
+    done
+    return 1
+}
+
+# Warn that the plugin also exists in the scope we're NOT uninstalling, and print
+# the command to remove it there too. Leads with a blank line to separate it from
+# whatever preceded it (the plan, or the "Nothing to uninstall" tip).
+warn_plugin_other_scope() {
+    echo ""
+    if [ "$SCOPE" = "project" ]; then
+        warn "The Claude Code plugin is also installed ${B}globally${N} — this project uninstall leaves it. To remove that too:"
+        msg  "${B}  claude plugin uninstall ${PLUGIN_KEY} --scope user${N} ${D}(or re-run with --global)${N}"
+    else
+        warn "The Claude Code plugin is also installed at ${B}project${N} scope — this global uninstall leaves it. To remove that too:"
+        msg  "${B}  claude plugin uninstall ${PLUGIN_KEY} --scope project${N} ${D}(or re-run --uninstall from the project without --global)${N}"
+    fi
+}
+
+# Remove the plugin from the CURRENT uninstall scope via the official CLI (atomic
+# across the shared plugin state — we never hand-edit it). A project install can be
+# either 'project' (.claude/settings.json) or 'local' (.claude/settings.local.json),
+# so a project uninstall tries both CLI scopes. If nothing could be removed (CLI
+# missing or every attempt failed) this is a hard error that reports whether the
+# rest of the uninstall completed and prints the exact command to run manually.
+# $1 = count of other AI Dev Kit artifacts already removed this run.
+remove_claude_plugin() {
+    local others_removed=$1
+    local scopes cmd_scope
+    if [ "$SCOPE" = "project" ]; then scopes="project local"; cmd_scope="project"; else scopes="user"; cmd_scope="user"; fi
+    if command -v claude >/dev/null 2>&1; then
+        local sc removed=false
+        for sc in $scopes; do
+            # Subcommand name has varied across versions (uninstall vs remove) — try both.
+            if claude plugin uninstall "$PLUGIN_KEY" -y --scope "$sc" >/dev/null 2>&1 \
+               || claude plugin remove "$PLUGIN_KEY" -y --scope "$sc" >/dev/null 2>&1; then
+                msg "removed Claude Code plugin ${PLUGIN_KEY} (${sc} scope)"
+                removed=true
+            fi
+        done
+        [ "$removed" = true ] && return 0
+    fi
+    local partial="" alt=""
+    [ "$others_removed" -gt 0 ] && partial="Skills, MCP server, and config WERE removed (partial uninstall). "
+    [ "$SCOPE" = "project" ] && alt=" (or --scope local)"
+    die "Could not remove the Claude Code plugin. ${partial}Finish it manually: ${B}claude plugin uninstall ${PLUGIN_KEY} --scope ${cmd_scope}${N}${alt}"
 }
 
 run_uninstall() {
@@ -459,10 +526,25 @@ run_uninstall() {
     # Project-scope leftover marker dir
     [ "$SCOPE" = "project" ] && [ -d "$base_dir/.ai-dev-kit" ] && plan_state+=("$base_dir/.ai-dev-kit/")
 
+    # Claude Code plugin — detect at BOTH scopes (read-only). We only remove the
+    # current uninstall scope; presence in the other scope is a warning. Project
+    # detection uses the invocation dir ($PWD) — for a global uninstall base_dir is
+    # $HOME, which is not the project we'd be warning about.
+    local plan_plugin=false plugin_other=false
+    if [ "$SCOPE" = "global" ]; then
+        plugin_installed_global && plan_plugin=true
+        plugin_installed_project "$PWD" && plugin_other=true
+    else
+        plugin_installed_project "$base_dir" && plan_plugin=true
+        plugin_installed_global && plugin_other=true
+    fi
+
     local total=$(( ${#plan_skills[@]} + ${#plan_mcp[@]} + ${#plan_hooks[@]} + ${#plan_runtime[@]} + ${#plan_state[@]} ))
+    [ "$plan_plugin" = true ] && total=$(( total + 1 ))
     if [ "$total" -eq 0 ]; then
         ok "Nothing to uninstall for ${B}$SCOPE${N} scope at ${D}${base_dir}${N} — no AI Dev Kit artifacts found."
         [ "$SCOPE" = "project" ] && msg "${D}Tip: pass --global to remove a global install.${N}"
+        [ "$plugin_other" = true ] && warn_plugin_other_scope
         exit 0
     fi
 
@@ -472,6 +554,12 @@ run_uninstall() {
     [ ${#plan_hooks[@]}   -gt 0 ] && { echo -e "  ${B}Claude update hook (${#plan_hooks[@]}):${N}"; for p in "${plan_hooks[@]}"; do echo "    ${p/#$HOME/~}"; done; }
     [ ${#plan_runtime[@]} -gt 0 ] && { echo -e "  ${B}MCP server runtime:${N}"; for p in "${plan_runtime[@]}"; do echo "    ${p/#$HOME/~}"; done; }
     [ ${#plan_state[@]}   -gt 0 ] && { echo -e "  ${B}State files:${N}"; for p in "${plan_state[@]}"; do echo "    ${p/#$HOME/~}"; done; }
+    [ "$plan_plugin" = true ] && {
+        echo -e "  ${B}Claude Code plugin:${N}"
+        echo -e "    ${PLUGIN_KEY} ${D}(removed via the claude CLI, ${SCOPE} scope)${N}"
+        echo -e "  ${Y}${B}⚠  Heads up: the AI Dev Kit Claude Code plugin will also be removed.${N}"
+    }
+    [ "$plugin_other" = true ] && warn_plugin_other_scope
     echo ""
     msg "${D}Config files are backed up to <file>.bak before editing.${N}"
 
@@ -505,6 +593,7 @@ run_uninstall() {
     for p in "${plan_hooks[@]}"; do uninstall_remove_claude_hook "$p" && msg "cleaned hook in ${p/#$HOME/~}"; done
     for p in "${plan_runtime[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
     for p in "${plan_state[@]}"; do rm -rf "$p" && msg "removed ${p/#$HOME/~}"; done
+    [ "$plan_plugin" = true ] && remove_claude_plugin "$(( total - 1 ))"
 
     echo ""
     ok "AI Dev Kit uninstalled (${SCOPE} scope)."

--- a/install.sh
+++ b/install.sh
@@ -378,10 +378,11 @@ run_uninstall() {
     # Mirror install: if scope wasn't set explicitly, ask (interactive, non --yes)
     # so a user who did a global install isn't silently told "nothing to uninstall
     # for project scope". Non-interactive/--yes keeps the documented 'project' default.
-    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ] && { exec 3</dev/tty; } 2>/dev/null; then
-        printf "  Uninstall scope — [p]roject (this directory) or [g]lobal (\$HOME)? [P/g] "
-        local sreply; read -r sreply <&3 || sreply=""; exec 3<&-
-        case "$sreply" in [gG]|[gG][lL][oO][bB][aA][lL]) SCOPE="global" ;; *) SCOPE="project" ;; esac
+    # Ask for scope with the same selector install uses, unless it was set
+    # explicitly (-g/--global, DEVKIT_SCOPE) or we're non-interactive/--yes.
+    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ]; then
+        SCOPE_PROMPT_TITLE="Select uninstall scope" SCOPE_PROMPT_VERB="Remove from" prompt_scope
+        # renders: "Remove from current directory ..." / "Remove from home directory ..."
     fi
     [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
     install_dir="${USER_MCP_PATH:-${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}}"
@@ -510,10 +511,6 @@ run_uninstall() {
     msg "${D}Other scopes (e.g. --global) and per-editor .bak backups were left untouched.${N}"
     exit 0
 }
-
-if [ "$UNINSTALL" = true ]; then
-    run_uninstall
-fi
 
 # Set configuration URLs after parsing branch argument
 REPO_URL="https://github.com/databricks-solutions/ai-dev-kit.git"
@@ -2039,13 +2036,18 @@ prompt_scope() {
         return
     fi
 
+    # Verb defaults to install wording; uninstall passes "Uninstall"/"Remove" via
+    # SCOPE_PROMPT_TITLE / SCOPE_PROMPT_VERB so the same selector reads correctly.
+    local title="${SCOPE_PROMPT_TITLE:-Select installation scope}"
+    local verb="${SCOPE_PROMPT_VERB:-Install in}"
+
     echo ""
-    echo -e "  ${B}Select installation scope${N}"
-    
+    echo -e "  ${B}${title}${N}"
+
     # Simple radio selector without Confirm button
     local -a labels=("Project" "Global")
     local -a values=("project" "global")
-    local -a hints=("Install in current directory (.cursor/, .claude/, .gemini/)" "Install in home directory (~/.cursor/, ~/.claude/, ~/.gemini/)")
+    local -a hints=("$verb current directory (.cursor/, .claude/, .gemini/)" "$verb home directory (~/.cursor/, ~/.claude/, ~/.gemini/)")
     local count=2
     local selected=0
     local cursor=0
@@ -2339,5 +2341,11 @@ main() {
     # Done
     summary
 }
+
+# Uninstall short-circuits before install runs. Placed here (after all helpers,
+# e.g. prompt_scope / is_interactive, are defined) so run_uninstall can reuse them.
+if [ "$UNINSTALL" = true ]; then
+    run_uninstall
+fi
 
 main "$@"


### PR DESCRIPTION
Adds a proper uninstall path to `install.sh` and `install.ps1` — previously there was **no way to remove AI Dev Kit** (no flag, no docs), leaving skills, the MCP runtime, and `databricks` MCP entries across 8 editors' configs behind.

## Usage
```bash
bash <(curl -sL .../install.sh) --uninstall --dry-run   # preview
bash <(curl -sL .../install.sh) --uninstall             # project scope
bash <(curl -sL .../install.sh) --uninstall --global -y # global, no prompt
```
PowerShell: `.\install.ps1 -Uninstall [-DryRun] [-Global] [-Yes]`. Mirrors install's flags (`-g/--global`, `DEVKIT_SCOPE`, `--mcp-path`/`AIDEVKIT_HOME`).

## What it removes — surgically, scope-gated
- **Skill folders** — swept by the union of **current AND historical** skill names, so old installs are cleaned too (e.g. the removed `databricks-lakebase-provisioned`, renamed `databricks-app-python`, `databricks-synthetic-data-generation`). Only removes dirs matching known names — **a user's own skills survive**.
- **The `databricks` MCP entry** from each editor config (JSON `mcpServers`/`servers`, Codex TOML block) — **preserving all other servers**. Backs up to `<file>.bak` first.
- **The AI Dev Kit `SessionStart` update hook** from Claude `settings.json`, leaving other hooks intact.
- **The MCP runtime** (`~/.ai-dev-kit`) + state files — runtime only on `--global` or explicit `--mcp-path`.

Scope is strict: a project uninstall never touches `$HOME` config and vice-versa, so it can't clobber the other scope's install. Prints a full plan and confirms before deleting; `--dry-run` previews only.

## Testing
- **Bash: verified end-to-end.** On a realistic fake install, confirmed surgical removal — foreign MCP servers, a user's own skill, an unrelated Claude hook, and other TOML sections **all survive**; the historical `databricks-lakebase-provisioned` **is** cleaned; idempotent re-run and empty-scope are graceful; scope isolation confirmed (project run touches no `~/` paths).
- **PowerShell: statically reviewed** (no pwsh available here) — property removal, JSON round-trip (`-Encoding UTF8`, no BOM), hook filtering, and top-level `return` all confirmed idiomatic; clean exit on declined prompt.
- README gains an Uninstall section for both shells.

Note: pushed with `SKIP_SECRET_SCAN=1` for a **pre-existing false positive** unrelated to this diff (a placeholder `postgresql://user:password@...` in `databricks-mcp-app/.env.example`, already on `main`); a whitelist request is open.

🤖 Generated with Claude Code.