### PR TITLE
Print home-relative install paths with ~ prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,11 @@ INCLUDE_PRERELEASES="${INCLUDE_PRERELEASES:-0}"
 OWNER="databricks-solutions"
 REPO="ai-dev-kit"
 
+# Literal "~" for display-only path shortening: "${dir/#$HOME/$TILDE}". Held in
+# a variable because bash 5.2+ tilde-expands a bare ~ in the replacement text
+# (turning it straight back into $HOME), while bash 3.2 does not.
+TILDE="~"
+
 # Branch/tag override. DEVKIT_BRANCH is canonical; AIDEVKIT_BRANCH is accepted
 # as an alias so the bash and PowerShell installers honor the same env var.
 # BRANCH_EXPLICIT tracks whether the user asked for a specific ref (vs the
@@ -2064,7 +2069,7 @@ deliver_agent_b_all() {
             echo "$dir|$skill" >> "$manifest"
             made=$((made + 1))
         done
-        [ "$made" -gt 0 ] && ok "Agent skills ($made, copy) → ${dir#$HOME/}"
+        [ "$made" -gt 0 ] && ok "Agent skills ($made, copy) → ${dir/#$HOME/$TILDE}"
     done < <(agent_skill_target_dirs "$base_dir")
 
     rm -rf "$tmp_dir"
@@ -2127,7 +2132,7 @@ deliver_agent_skills() {
             echo "$dir|$skill" >> "$manifest"
             made=$((made + 1))
         done
-        [ "$made" -gt 0 ] && ok "Agent skills ($made, $mode) → ${dir#$HOME/}"
+        [ "$made" -gt 0 ] && ok "Agent skills ($made, $mode) → ${dir/#$HOME/$TILDE}"
     done < <(agent_skill_target_dirs "$base_dir")
 
     [ -n "$tmp_dir" ] && rm -rf "$tmp_dir"
@@ -2484,7 +2489,7 @@ install_skills() {
                     rm -rf "$dest_dir"
                 fi
             done
-            ok "MLflow skills ($mlflow_count, @ ${MLFLOW_RESOLVED_REF}) → ${dir#$HOME/}"
+            ok "MLflow skills ($mlflow_count, @ ${MLFLOW_RESOLVED_REF}) → ${dir/#$HOME/$TILDE}"
         fi
     done
 


### PR DESCRIPTION
## What

Cosmetic fix to installer success/log output. Three `ok` lines printed their destination with `${dir#$HOME/}`, which strips the `$HOME/` prefix — so global-scope installs logged bare, project-relative-looking strings:

```
✓ Agent skills (42, link) → .gemini/skills
✓ Agent skills (42, link) → .codeium/windsurf/skills
✓ Agent skills (42, link) → .gemini/antigravity/skills
```

Now:

```
✓ Agent skills (42, link) → ~/.gemini/skills
✓ Agent skills (42, link) → ~/.codeium/windsurf/skills
✓ Agent skills (42, link) → ~/.gemini/antigravity/skills
```

This matches the style already used by the uninstall plan output (`install.sh:771`).

Lines changed: **2072**, **2135** (agent skills), **2492** (MLflow skills), plus the new `TILDE` constant at **85**.

## Note on why this isn't a literal `~`

The obvious change is `${dir/#$HOME/~}`, copying the uninstall-plan idiom. That form is **not portable**, and would have been a silent no-op for many users:

| bash | `${dir/#$HOME/~}` |
|---|---|
| 3.2.57 (macOS `/bin/bash`) | `~/.gemini/skills` ✅ |
| 5.2.37 (Homebrew, Linux) | `/Users/me/.gemini/skills` ❌ |

bash 5.2+ tilde-expands a bare `~` in the replacement text, turning it straight back into `$HOME`. Since the installer is commonly run via `curl … | bash` — picking up whichever bash is first on `PATH` — the literal form would leave the confusing output in place on Linux and for Homebrew-bash users. Escaping (`\~`) fails the other way, emitting a literal backslash on 3.2.

Holding the `~` in a variable (`TILDE="~"`) suppresses tilde expansion and is correct on both. Verified on both versions.

The pre-existing `${p/#$HOME/~}` lines in the uninstall path have the same latent issue, but they're out of scope here and left untouched.

## Verification

- `bash -n install.sh` passes on **both** 3.2.57 and 5.2.37.
- Output format confirmed on both versions for `.gemini/skills`, `.codeium/windsurf/skills`, `.gemini/antigravity/skills`, and a non-`$HOME` project path (left absolute, as expected).
- End-to-end run with a sandboxed `$HOME`: log lines print `~/…` while the real directories are still created at the same absolute paths.
- `git diff` touches only display strings plus the new constant — every `mkdir -p "$dir"`, `cp -R`, and `ln -s` destination is unchanged.

## Scope

Display-only. No changes to install destination logic, path construction, scope resolution (`base_dir`), antigravity/windsurf/gemini destination computation, or `install_genie_code_skills.py`.

This pull request and its description were written by Isaac.