### PR TITLE
Extract MCP server install into its own installer; make install.sh/ps1 skills-only

### DIFF
--- a/databricks-mcp-server/README.md
+++ b/databricks-mcp-server/README.md
@@ -55,7 +55,19 @@ python -c "import databricks_mcp_server; print('OK')"
 
 ### Step 3: Configure your MCP client
 
-Point your MCP client at the server's `run_server.py`. Use the Python interpreter from the `.venv` you just created (replace `/path/to/ai-dev-kit` with the absolute path where you cloned the repo).
+**Recommended:** use the bundled installer to build the venv *and* register the server with your MCP clients in one step. It wraps `setup.sh`/`setup.ps1` (the venv build) and writes the client config for you, prompting for scope, which clients to configure, and which Databricks profile to inject.
+
+```bash
+# macOS / Linux
+./databricks-mcp-server/mcp_install.sh
+
+# Windows (PowerShell)
+.\databricks-mcp-server\mcp_install.ps1
+```
+
+It supports Claude Code, Cursor, GitHub Copilot, OpenAI Codex, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro, and can be reverted with `--uninstall` (`-Uninstall` on PowerShell).
+
+**Manual configuration (fallback):** if you'd rather edit the config yourself, point your MCP client at the server's `run_server.py`. Use the Python interpreter from the `.venv` you built in Step 2 (replace `/path/to/ai-dev-kit` with the absolute path where you cloned the repo).
 
 **Claude Code** — add to your project's `.mcp.json` (create the file if it doesn't exist):
 
@@ -65,6 +77,7 @@ Point your MCP client at the server's `run_server.py`. Use the Python interprete
     "databricks": {
       "command": "/path/to/ai-dev-kit/.venv/bin/python",
       "args": ["/path/to/ai-dev-kit/databricks-mcp-server/run_server.py"],
+      "env": {"DATABRICKS_CONFIG_PROFILE": "your-profile"},
       "defer_loading": true
     }
   }
@@ -74,12 +87,12 @@ Point your MCP client at the server's `run_server.py`. Use the Python interprete
 Or register it from the CLI:
 
 ```bash
-claude mcp add-json databricks '{"command":"/path/to/ai-dev-kit/.venv/bin/python","args":["/path/to/ai-dev-kit/databricks-mcp-server/run_server.py"]}'
+claude mcp add-json databricks '{"command":"/path/to/ai-dev-kit/.venv/bin/python","args":["/path/to/ai-dev-kit/databricks-mcp-server/run_server.py"],"env":{"DATABRICKS_CONFIG_PROFILE":"your-profile"}}'
 ```
 
 **Cursor / Genie Code** — use the same JSON in your client's MCP config (e.g. Cursor's `.cursor/mcp.json`).
 
-**Note:** `"defer_loading": true` improves startup time by not loading all tools upfront.
+**Note:** the `env` block pins the Databricks profile the server authenticates with (see Step 4); `"defer_loading": true` improves startup time by not loading all tools upfront.
 
 ### Step 4: Authenticate
 

--- a/databricks-mcp-server/mcp_install.ps1
+++ b/databricks-mcp-server/mcp_install.ps1
@@ -57,7 +57,6 @@ $script:McpEntry  = Join-Path $script:ScriptDir "run_server.py"
 if ($Profile_)       { $script:Profile_ = $Profile_ }
 elseif ($env:DEVKIT_PROFILE) { $script:Profile_ = $env:DEVKIT_PROFILE }
 else                 { $script:Profile_ = "DEFAULT" }
-$script:ProfileProvided = [bool]$Profile_
 
 if ($Global)         { $script:Scope = "global"; $script:ScopeExplicit = $true }
 elseif ($env:DEVKIT_SCOPE) { $script:Scope = $env:DEVKIT_SCOPE; $script:ScopeExplicit = $true }
@@ -550,6 +549,15 @@ function Invoke-PromptScope {
 function Write-McpJsonConfig {
     param([string]$Path, [string]$RootKey, [bool]$Defer)
 
+    # No-clobber parity with the bash installer: only merge into an existing
+    # config when the venv python is present. Without it the server can't run, so
+    # refuse to modify a file that may hold other settings and tell the user to
+    # add the entry manually. A brand-new file is always safe to write.
+    if ((Test-Path $Path) -and -not (Test-Path $script:VenvPython)) {
+        Write-Warn "Cannot merge MCP config into $Path without the venv python at $($script:VenvPython). Add manually."
+        return
+    }
+
     $dir = Split-Path $Path -Parent
     if (-not (Test-Path $dir)) {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
@@ -608,7 +616,9 @@ function Write-McpToml {
 
     if (Test-Path $Path) {
         $content = Get-Content $Path -Raw
-        if ($content -match 'mcp_servers\.databricks') { return }
+        # Anchor to the table header so a match in a comment/value can't be
+        # mistaken for an existing registration (matches the removal loop's anchor).
+        if ($content -match '(?m)^\[mcp_servers\.databricks') { return }
         Copy-Item $Path "$Path.bak" -Force
         Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
     }
@@ -630,6 +640,12 @@ DATABRICKS_CONFIG_PROFILE = "$($script:Profile_)"
 # Write/merge the OpenCode config (root key 'mcp', type 'local', command-as-array).
 function Write-OpenCodeJson {
     param([string]$Path)
+
+    # No-clobber parity with the bash installer (see Write-McpJsonConfig).
+    if ((Test-Path $Path) -and -not (Test-Path $script:VenvPython)) {
+        Write-Warn "Cannot merge MCP config into $Path without the venv python at $($script:VenvPython). Add manually."
+        return
+    }
 
     $dir = Split-Path $Path -Parent
     if (-not (Test-Path $dir)) {
@@ -819,7 +835,7 @@ function Remove-McpJsonKey {
 function Remove-McpTomlBlock {
     param([string]$Path)
     if (-not (Test-Path $Path)) { return $false }
-    if (-not (Select-String -Path $Path -Pattern 'mcp_servers\.databricks' -Quiet)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern '^\[mcp_servers\.databricks' -Quiet)) { return $false }
     if ($script:DryRun) { return $true }
     Copy-Item $Path "$Path.bak" -Force
     $out = New-Object System.Collections.Generic.List[string]
@@ -878,7 +894,7 @@ function Invoke-Uninstall {
         switch ($target.Kind) {
             "json" { if (Test-McpJsonHasDatabricks $target.Path $target.Top) { $plan += $target } }
             "toml" {
-                if ((Test-Path $target.Path) -and (Select-String -Path $target.Path -Pattern 'mcp_servers\.databricks' -Quiet)) {
+                if ((Test-Path $target.Path) -and (Select-String -Path $target.Path -Pattern '^\[mcp_servers\.databricks' -Quiet)) {
                     $plan += $target
                 }
             }

--- a/databricks-mcp-server/mcp_install.ps1
+++ b/databricks-mcp-server/mcp_install.ps1
@@ -1,0 +1,1054 @@
+#
+# Databricks MCP Server - Client Registration Installer (Windows)
+#
+# Builds the MCP server runtime (by delegating to setup.ps1) and registers the
+# `databricks` MCP server with your AI coding tools: Claude Code, Cursor,
+# GitHub Copilot, OpenAI Codex, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+#
+# The venv build is owned by databricks-mcp-server/setup.ps1 — this script never
+# duplicates that logic; it calls setup.ps1 and then writes the editor config
+# files that point at the resulting venv.
+#
+# Usage:
+#   .\databricks-mcp-server\mcp_install.ps1 [OPTIONS]
+#
+# Options:
+#   -Profile NAME     Databricks config profile to inject (default: DEFAULT)
+#   -Global           Register globally (home dir) instead of per-project
+#   -Tools LIST       Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro
+#   -VenvDir DIR      Virtual environment location (default: <this dir>\.venv)
+#   -SkipVenv         Skip the setup.ps1 venv build (assume it already exists)
+#   -Silent           Silent mode (no output except errors)
+#   -Uninstall        Remove only the 'databricks' MCP entry from each client config
+#   -DryRun           Print the plan (install or uninstall) and exit without changes
+#   -Yes              With -Uninstall: skip the confirmation prompt
+#   -Help             Show this help
+#
+# Environment Variables (alternative to flags):
+#   DEVKIT_PROFILE    Databricks config profile
+#   DEVKIT_SCOPE      'project' or 'global'
+#   DEVKIT_TOOLS      Comma-separated list of tools
+#   DEVKIT_SILENT     Set to 'true' for silent mode
+#
+
+param(
+    [string]$Profile_ = "",
+    [switch]$Global,
+    [string]$Tools = "",
+    [string]$VenvDir = "",
+    [switch]$SkipVenv,
+    [switch]$Silent,
+    [switch]$Uninstall,
+    [switch]$DryRun,
+    [switch]$Yes,
+    [switch]$Help
+)
+
+$ErrorActionPreference = "Stop"
+
+# ─── Paths (derived from this script's own location) ────────────
+# The repo is already cloned when this standalone installer runs, so — unlike the
+# unified installer's clone-to-~\.ai-dev-kit flow — paths derive from here, the
+# same way setup.ps1 does.
+$script:ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$script:McpEntry  = Join-Path $script:ScriptDir "run_server.py"
+
+# ─── Defaults (env vars mirror the bash installer) ──────────────
+if ($Profile_)       { $script:Profile_ = $Profile_ }
+elseif ($env:DEVKIT_PROFILE) { $script:Profile_ = $env:DEVKIT_PROFILE }
+else                 { $script:Profile_ = "DEFAULT" }
+$script:ProfileProvided = [bool]$Profile_
+
+if ($Global)         { $script:Scope = "global"; $script:ScopeExplicit = $true }
+elseif ($env:DEVKIT_SCOPE) { $script:Scope = $env:DEVKIT_SCOPE; $script:ScopeExplicit = $true }
+else                 { $script:Scope = "project"; $script:ScopeExplicit = $false }
+
+if ($Silent)         { $script:Silent = $true }
+elseif ($env:DEVKIT_SILENT -in @("true", "1")) { $script:Silent = $true }
+else                 { $script:Silent = $false }
+
+if ($Tools)          { $script:UserTools = $Tools }
+elseif ($env:DEVKIT_TOOLS) { $script:UserTools = $env:DEVKIT_TOOLS }
+else                 { $script:UserTools = "" }
+$script:Tools = ""
+
+if ($VenvDir)        { $script:VenvDir = $VenvDir }
+else                 { $script:VenvDir = Join-Path $script:ScriptDir ".venv" }
+
+$script:SkipVenv   = [bool]$SkipVenv
+$script:Uninstall  = [bool]$Uninstall
+$script:DryRun     = [bool]$DryRun
+$script:AssumeYes  = [bool]$Yes
+
+$script:VenvPython = Join-Path $script:VenvDir "Scripts\python.exe"
+
+# ─── Help ───────────────────────────────────────────────────────
+if ($Help) {
+    Write-Host "Databricks MCP Server - Client Registration Installer (Windows)"
+    Write-Host ""
+    Write-Host "Usage: .\databricks-mcp-server\mcp_install.ps1 [OPTIONS]"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Profile NAME     Databricks config profile to inject (default: DEFAULT)"
+    Write-Host "  -Global           Register globally (home dir) instead of per-project"
+    Write-Host "  -Tools LIST       Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
+    Write-Host "  -VenvDir DIR      Virtual environment location (default: <this dir>\.venv)"
+    Write-Host "  -SkipVenv         Skip the setup.ps1 venv build (assume it already exists)"
+    Write-Host "  -Silent           Silent mode (no output except errors)"
+    Write-Host "  -Uninstall        Remove only the 'databricks' MCP entry from each client config"
+    Write-Host "  -DryRun           Print the plan (install or uninstall) and exit without changes"
+    Write-Host "  -Yes              With -Uninstall: skip the confirmation prompt"
+    Write-Host "  -Help             Show this help"
+    Write-Host ""
+    Write-Host "Environment Variables (alternative to flags):"
+    Write-Host "  DEVKIT_PROFILE    Databricks config profile"
+    Write-Host "  DEVKIT_SCOPE      'project' or 'global'"
+    Write-Host "  DEVKIT_TOOLS      Comma-separated list of tools"
+    Write-Host "  DEVKIT_SILENT     Set to 'true' for silent mode"
+    Write-Host ""
+    Write-Host "The venv build is delegated to databricks-mcp-server/setup.ps1."
+    Write-Host ""
+    exit 0
+}
+
+# ─── Output helpers ─────────────────────────────────────────────
+function Write-Msg  { param([string]$Text) if (-not $script:Silent) { Write-Host "  $Text" } }
+function Write-Ok   { param([string]$Text) if (-not $script:Silent) { Write-Host "  " -NoNewline; Write-Host "✓" -ForegroundColor Green -NoNewline; Write-Host " $Text" } }
+function Write-Warn { param([string]$Text) if (-not $script:Silent) { Write-Host "  " -NoNewline; Write-Host "!" -ForegroundColor Yellow -NoNewline; Write-Host " $Text" } }
+function Write-Die  { param([string]$Text) Write-Host "  " -NoNewline; Write-Host "✗" -ForegroundColor Red -NoNewline; Write-Host " $Text"; exit 1 }
+function Write-Step { param([string]$Text) if (-not $script:Silent) { Write-Host ""; Write-Host $Text -ForegroundColor White } }
+
+# ─── Interactive helpers ────────────────────────────────────────
+function Test-Interactive {
+    if ($script:Silent) { return $false }
+    try {
+        $host.UI.RawUI.KeyAvailable | Out-Null
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Read-Prompt {
+    param([string]$PromptText, [string]$Default)
+
+    if ($script:Silent) { return $Default }
+
+    if (Test-Interactive) {
+        Write-Host "  $PromptText [$Default]: " -NoNewline
+        $result = Read-Host
+        if ([string]::IsNullOrWhiteSpace($result)) { return $Default }
+        return $result
+    } else {
+        return $Default
+    }
+}
+
+# Interactive checkbox selector using arrow keys + space/enter
+# Returns space-separated selected values
+function Select-Checkbox {
+    param(
+        [array]$Items  # Each: @{ Label; Value; State; Hint; Locked }
+    )
+
+    $count  = $Items.Count
+    $cursor = 0
+    $states = @()
+    $locked = @()
+    foreach ($item in $Items) {
+        if ($item.Locked) {
+            $locked += $true
+            $states += $true   # locked items are always selected
+        } else {
+            $locked += $false
+            $states += [bool]$item.State
+        }
+    }
+
+    $isInteractive = Test-Interactive
+
+    if (-not $isInteractive) {
+        # Fallback: show numbered list, accept comma-separated numbers
+        Write-Host ""
+        for ($j = 0; $j -lt $count; $j++) {
+            $mark = if ($states[$j]) { "[X]" } else { "[ ]" }
+            $hint = $Items[$j].Hint
+            Write-Host "  $($j + 1). $mark $($Items[$j].Label)  ($hint)"
+        }
+        Write-Host ""
+        Write-Host "  Enter numbers to toggle (e.g. 1,3), or press Enter to accept defaults: " -NoNewline
+        $input_ = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_)) {
+            for ($j = 0; $j -lt $count; $j++) { $states[$j] = $false }
+            $nums = $input_ -split ',' | ForEach-Object { $_.Trim() }
+            foreach ($n in $nums) {
+                $idx = [int]$n - 1
+                if ($idx -ge 0 -and $idx -lt $count) { $states[$idx] = $true }
+            }
+        }
+        for ($j = 0; $j -lt $count; $j++) { if ($locked[$j]) { $states[$j] = $true } }
+        $selected = @()
+        for ($j = 0; $j -lt $count; $j++) {
+            if ($states[$j]) { $selected += $Items[$j].Value }
+        }
+        return ($selected -join ' ')
+    }
+
+    # Full interactive mode
+    Write-Host ""
+    Write-Host "  Up/Down navigate, Space toggle, Enter on Confirm to finish" -ForegroundColor DarkGray
+    Write-Host ""
+
+    $totalRows = $count + 2  # items + blank + Confirm
+
+    try { [Console]::CursorVisible = $false } catch {}
+
+    $drawCheckbox = {
+        [Console]::SetCursorPosition(0, [Math]::Max(0, [Console]::CursorTop - $totalRows))
+        for ($j = 0; $j -lt $count; $j++) {
+            if ($j -eq $cursor) {
+                Write-Host "  " -NoNewline
+                Write-Host ">" -ForegroundColor Blue -NoNewline
+                Write-Host " " -NoNewline
+            } else {
+                Write-Host "    " -NoNewline
+            }
+            if ($states[$j]) {
+                Write-Host "[" -NoNewline
+                Write-Host "v" -ForegroundColor Green -NoNewline
+                Write-Host "]" -NoNewline
+            } else {
+                Write-Host "[ ]" -NoNewline
+            }
+            $padLabel = $Items[$j].Label.PadRight(16)
+            Write-Host " $padLabel " -NoNewline
+            $hint = $Items[$j].Hint
+            $avail = [Console]::WindowWidth - [Console]::CursorLeft - 1
+            if ($avail -lt 0) { $avail = 0 }
+            if ($hint.Length -gt $avail) { $hint = $hint.Substring(0, $avail) }
+            if ($states[$j]) {
+                Write-Host $hint -ForegroundColor Green -NoNewline
+            } else {
+                Write-Host $hint -ForegroundColor DarkGray -NoNewline
+            }
+            $pos = [Console]::CursorLeft
+            $remaining = [Console]::WindowWidth - $pos - 1
+            if ($remaining -gt 0) { Write-Host (' ' * $remaining) -NoNewline }
+            Write-Host ""
+        }
+        Write-Host (' ' * ([Console]::WindowWidth - 1))
+        if ($cursor -eq $count) {
+            Write-Host "  " -NoNewline
+            Write-Host ">" -ForegroundColor Blue -NoNewline
+            Write-Host " " -NoNewline
+            Write-Host "[ Confirm ]" -ForegroundColor Green -NoNewline
+        } else {
+            Write-Host "    " -NoNewline
+            Write-Host "[ Confirm ]" -ForegroundColor DarkGray -NoNewline
+        }
+        $pos = [Console]::CursorLeft
+        $remaining = [Console]::WindowWidth - $pos - 1
+        if ($remaining -gt 0) { Write-Host (' ' * $remaining) -NoNewline }
+        Write-Host ""
+    }
+
+    for ($j = 0; $j -lt $totalRows; $j++) { Write-Host "" }
+    & $drawCheckbox
+
+    while ($true) {
+        $key = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+
+        switch ($key.VirtualKeyCode) {
+            38 { if ($cursor -gt 0) { $cursor-- } }          # Up
+            40 { if ($cursor -lt $count) { $cursor++ } }     # Down
+            32 { # Space
+                if ($cursor -lt $count -and -not $locked[$cursor]) {
+                    $states[$cursor] = -not $states[$cursor]
+                }
+            }
+            13 { # Enter
+                if ($cursor -lt $count) {
+                    if (-not $locked[$cursor]) { $states[$cursor] = -not $states[$cursor] }
+                } else {
+                    & $drawCheckbox
+                    break
+                }
+            }
+        }
+        if ($key.VirtualKeyCode -eq 13 -and $cursor -eq $count) { break }
+
+        & $drawCheckbox
+    }
+
+    try { [Console]::CursorVisible = $true } catch {}
+
+    $selected = @()
+    for ($j = 0; $j -lt $count; $j++) {
+        if ($states[$j]) { $selected += $Items[$j].Value }
+    }
+    return ($selected -join ' ')
+}
+
+# Interactive radio selector using arrow keys + enter
+# Returns the selected value
+function Select-Radio {
+    param(
+        [array]$Items  # Each: @{ Label; Value; Selected; Hint }
+    )
+
+    $count    = $Items.Count
+    $cursor   = 0
+    $selected = 0
+
+    for ($j = 0; $j -lt $count; $j++) {
+        if ($Items[$j].Selected) { $selected = $j }
+    }
+
+    $isInteractive = Test-Interactive
+
+    if (-not $isInteractive) {
+        Write-Host ""
+        for ($j = 0; $j -lt $count; $j++) {
+            $mark = if ($j -eq $selected) { "(*)" } else { "( )" }
+            $hint = $Items[$j].Hint
+            Write-Host "  $($j + 1). $mark $($Items[$j].Label)  $hint"
+        }
+        Write-Host ""
+        Write-Host "  Enter number to select (or press Enter for default): " -NoNewline
+        $input_ = Read-Host
+        if (-not [string]::IsNullOrWhiteSpace($input_)) {
+            $idx = [int]$input_ - 1
+            if ($idx -ge 0 -and $idx -lt $count) { $selected = $idx }
+        }
+        return $Items[$selected].Value
+    }
+
+    Write-Host ""
+    Write-Host "  Up/Down navigate, Enter confirm" -ForegroundColor DarkGray
+    Write-Host ""
+
+    $totalRows = $count + 2
+
+    try { [Console]::CursorVisible = $false } catch {}
+
+    $drawRadio = {
+        [Console]::SetCursorPosition(0, [Math]::Max(0, [Console]::CursorTop - $totalRows))
+        for ($j = 0; $j -lt $count; $j++) {
+            if ($j -eq $cursor) {
+                Write-Host "  " -NoNewline
+                Write-Host ">" -ForegroundColor Blue -NoNewline
+                Write-Host " " -NoNewline
+            } else {
+                Write-Host "    " -NoNewline
+            }
+            if ($j -eq $selected) {
+                Write-Host "(*)" -ForegroundColor Green -NoNewline
+            } else {
+                Write-Host "( )" -ForegroundColor DarkGray -NoNewline
+            }
+            $padLabel = $Items[$j].Label.PadRight(20)
+            Write-Host " $padLabel " -NoNewline
+            $hint = $Items[$j].Hint
+            $avail = [Console]::WindowWidth - [Console]::CursorLeft - 1
+            if ($avail -lt 0) { $avail = 0 }
+            if ($hint.Length -gt $avail) { $hint = $hint.Substring(0, $avail) }
+            if ($j -eq $selected) {
+                Write-Host $hint -ForegroundColor Green -NoNewline
+            } else {
+                Write-Host $hint -ForegroundColor DarkGray -NoNewline
+            }
+            $pos = [Console]::CursorLeft
+            $remaining = [Console]::WindowWidth - $pos - 1
+            if ($remaining -gt 0) { Write-Host (' ' * $remaining) -NoNewline }
+            Write-Host ""
+        }
+        Write-Host (' ' * ([Console]::WindowWidth - 1))
+        if ($cursor -eq $count) {
+            Write-Host "  " -NoNewline
+            Write-Host ">" -ForegroundColor Blue -NoNewline
+            Write-Host " " -NoNewline
+            Write-Host "[ Confirm ]" -ForegroundColor Green -NoNewline
+        } else {
+            Write-Host "    " -NoNewline
+            Write-Host "[ Confirm ]" -ForegroundColor DarkGray -NoNewline
+        }
+        $pos = [Console]::CursorLeft
+        $remaining = [Console]::WindowWidth - $pos - 1
+        if ($remaining -gt 0) { Write-Host (' ' * $remaining) -NoNewline }
+        Write-Host ""
+    }
+
+    for ($j = 0; $j -lt $totalRows; $j++) { Write-Host "" }
+    & $drawRadio
+
+    while ($true) {
+        $key = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+
+        switch ($key.VirtualKeyCode) {
+            38 { if ($cursor -gt 0) { $cursor-- } }
+            40 { if ($cursor -lt $count) { $cursor++ } }
+            32 { if ($cursor -lt $count) { $selected = $cursor } }
+            13 {
+                if ($cursor -lt $count) { $selected = $cursor }
+                & $drawRadio
+                break
+            }
+        }
+        if ($key.VirtualKeyCode -eq 13) { break }
+
+        & $drawRadio
+    }
+
+    try { [Console]::CursorVisible = $true } catch {}
+
+    return $Items[$selected].Value
+}
+
+# ─── Tool detection & selection ─────────────────────────────────
+function Invoke-DetectTools {
+    if (-not [string]::IsNullOrWhiteSpace($script:UserTools)) {
+        $script:Tools = $script:UserTools -replace ',', ' '
+        return
+    }
+
+    $hasClaude  = $null -ne (Get-Command claude -ErrorAction SilentlyContinue)
+    $hasCursor  = ($null -ne (Get-Command cursor -ErrorAction SilentlyContinue)) -or
+                  (Test-Path "$env:LOCALAPPDATA\Programs\cursor\Cursor.exe")
+    $hasCodex   = $null -ne (Get-Command codex -ErrorAction SilentlyContinue)
+    $hasCopilot = ($null -ne (Get-Command code -ErrorAction SilentlyContinue)) -or
+                  (Test-Path "$env:LOCALAPPDATA\Programs\Microsoft VS Code\Code.exe")
+    $hasGemini  = $null -ne (Get-Command gemini -ErrorAction SilentlyContinue)
+    $hasAntigravity = ($null -ne (Get-Command antigravity -ErrorAction SilentlyContinue)) -or
+                      (Test-Path "$env:LOCALAPPDATA\Programs\Antigravity\Antigravity.exe")
+    $hasWindsurf = ($null -ne (Get-Command windsurf -ErrorAction SilentlyContinue)) -or
+                   (Test-Path "$env:LOCALAPPDATA\Programs\Windsurf\Windsurf.exe")
+    $hasOpencode = $null -ne (Get-Command opencode -ErrorAction SilentlyContinue)
+    $hasKiro    = ($null -ne (Get-Command kiro -ErrorAction SilentlyContinue)) -or
+                  (Test-Path "$env:LOCALAPPDATA\Programs\Kiro\Kiro.exe")
+
+    $claudeState  = $hasClaude;  $claudeHint  = if ($hasClaude)  { "detected" } else { "not found" }
+    $cursorState  = $hasCursor;  $cursorHint  = if ($hasCursor)  { "detected" } else { "not found" }
+    $codexState   = $hasCodex;   $codexHint   = if ($hasCodex)   { "detected" } else { "not found" }
+    $copilotState = $hasCopilot; $copilotHint = if ($hasCopilot) { "detected" } else { "not found" }
+    $geminiState  = $hasGemini;  $geminiHint  = if ($hasGemini)  { "detected" } else { "not found" }
+    $antigravityState = $hasAntigravity; $antigravityHint = if ($hasAntigravity) { "detected" } else { "not found" }
+    $windsurfState = $hasWindsurf; $windsurfHint = if ($hasWindsurf) { "detected" } else { "not found" }
+    $opencodeState = $hasOpencode; $opencodeHint = if ($hasOpencode) { "detected" } else { "not found" }
+    $kiroState    = $hasKiro;    $kiroHint    = if ($hasKiro)    { "detected" } else { "not found" }
+
+    # If nothing detected, default to claude
+    if (-not $hasClaude -and -not $hasCursor -and -not $hasCodex -and -not $hasCopilot -and -not $hasGemini -and -not $hasAntigravity -and -not $hasWindsurf -and -not $hasOpencode -and -not $hasKiro) {
+        $claudeState = $true
+        $claudeHint  = "default"
+    }
+
+    if (-not $script:Silent) {
+        Write-Host ""
+        Write-Host "  Select tools to register the databricks MCP server for:" -ForegroundColor White
+    }
+
+    $items = @(
+        @{ Label = "Claude Code";    Value = "claude";       State = $claudeState;       Hint = $claudeHint }
+        @{ Label = "Cursor";         Value = "cursor";       State = $cursorState;       Hint = $cursorHint }
+        @{ Label = "GitHub Copilot"; Value = "copilot";      State = $copilotState;      Hint = $copilotHint }
+        @{ Label = "OpenAI Codex";   Value = "codex";        State = $codexState;        Hint = $codexHint }
+        @{ Label = "Gemini CLI";     Value = "gemini";       State = $geminiState;       Hint = $geminiHint }
+        @{ Label = "Antigravity";    Value = "antigravity";  State = $antigravityState;  Hint = $antigravityHint }
+        @{ Label = "Windsurf";       Value = "windsurf";     State = $windsurfState;     Hint = $windsurfHint }
+        @{ Label = "OpenCode";       Value = "opencode";     State = $opencodeState;     Hint = $opencodeHint }
+        @{ Label = "Kiro";           Value = "kiro";         State = $kiroState;         Hint = $kiroHint }
+    )
+
+    $result = Select-Checkbox -Items $items
+
+    if ([string]::IsNullOrWhiteSpace($result)) {
+        Write-Warn "No tools selected, defaulting to Claude Code"
+        $result = "claude"
+    }
+
+    $script:Tools = $result
+}
+
+# ─── Databricks profile selection ────────────────────────────
+function Invoke-PromptProfile {
+    # If provided via -Profile flag (non-default), skip prompt
+    if ($script:Profile_ -ne "DEFAULT") { return }
+    if ($script:Silent) { return }
+    if (-not (Test-Interactive)) { return }
+
+    $cfgFile = Join-Path $env:USERPROFILE ".databrickscfg"
+    $profiles = @()
+
+    if (Test-Path $cfgFile) {
+        $lines = Get-Content $cfgFile
+        foreach ($line in $lines) {
+            if ($line -match '^\[([a-zA-Z0-9_-]+)\]$') {
+                $profiles += $Matches[1]
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "  Select Databricks profile" -ForegroundColor White
+
+    if ($profiles.Count -gt 0) {
+        $items = @()
+        $hasDefault = $profiles -contains "DEFAULT"
+        foreach ($p in $profiles) {
+            $sel  = $false
+            $hint = ""
+            if ($p -eq "DEFAULT") { $sel = $true; $hint = "default" }
+            $items += @{ Label = $p; Value = $p; Selected = $sel; Hint = $hint }
+        }
+
+        $items += @{ Label = "Custom profile name..."; Value = "__CUSTOM__"; Selected = $false; Hint = "Enter a custom profile name" }
+
+        if (-not $hasDefault -and $items.Count -gt 1) {
+            $items[0].Selected = $true
+        }
+
+        $selectedProfile = Select-Radio -Items $items
+
+        if ($selectedProfile -eq "__CUSTOM__") {
+            Write-Host ""
+            $script:Profile_ = Read-Prompt -PromptText "Enter profile name" -Default "DEFAULT"
+        } else {
+            $script:Profile_ = $selectedProfile
+        }
+    } else {
+        Write-Host "  No ~/.databrickscfg found. You can authenticate after install." -ForegroundColor DarkGray
+        Write-Host ""
+        $script:Profile_ = Read-Prompt -PromptText "Profile name" -Default "DEFAULT"
+    }
+}
+
+# ─── Scope selection ────────────────────────────────────────────
+function Invoke-PromptScope {
+    param([string]$Title = "Select registration scope")
+
+    if ($script:Silent) { return }
+    if (-not (Test-Interactive)) { return }
+
+    Write-Host ""
+    Write-Host "  $Title" -ForegroundColor White
+
+    $items = @(
+        @{ Label = "Project"; Value = "project"; Selected = $true;  Hint = "Current directory (.mcp.json, etc.)" }
+        @{ Label = "Global";  Value = "global";  Selected = $false; Hint = "Home directory (~/.claude.json, etc.)" }
+    )
+    $script:Scope = Select-Radio -Items $items
+}
+
+# ─── MCP config writers ────────────────────────────────────────
+# Write/merge an MCP server entry into a JSON config.
+#   -Path     target config file
+#   -RootKey  top-level key: "mcpServers" (Claude/Cursor/Gemini/Windsurf/Kiro)
+#             or "servers" (Copilot)
+#   -Defer    include Claude's defer_loading hint
+# Merging is decoupled from whether the venv exists yet, so an existing config
+# is never clobbered. The original is backed up to <file>.bak first.
+function Write-McpJsonConfig {
+    param([string]$Path, [string]$RootKey, [bool]$Defer)
+
+    $dir = Split-Path $Path -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if (Test-Path $Path) {
+        Copy-Item $Path "$Path.bak" -Force
+        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
+    }
+
+    $existing = $null
+    if (Test-Path $Path) {
+        try { $existing = Get-Content $Path -Raw | ConvertFrom-Json } catch { $existing = $null }
+    }
+
+    # Use forward slashes for cross-platform JSON compatibility
+    $pythonPath = $script:VenvPython -replace '\\', '/'
+    $entryPath  = $script:McpEntry -replace '\\', '/'
+
+    if ($existing) {
+        if (-not $existing.$RootKey) {
+            $existing | Add-Member -NotePropertyName $RootKey -NotePropertyValue ([PSCustomObject]@{}) -Force
+        }
+        $dbProps = [ordered]@{ command = $pythonPath; args = @($entryPath) }
+        if ($Defer) { $dbProps.defer_loading = $true }
+        $dbProps.env = [PSCustomObject]@{ DATABRICKS_CONFIG_PROFILE = $script:Profile_ }
+        $existing.$RootKey | Add-Member -NotePropertyName "databricks" -NotePropertyValue ([PSCustomObject]$dbProps) -Force
+        $existing | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
+    } else {
+        $deferLine = if ($Defer) { "`n      `"defer_loading`": true," } else { "" }
+        $json = @"
+{
+  "$RootKey": {
+    "databricks": {
+      "command": "$pythonPath",
+      "args": ["$entryPath"],$deferLine
+      "env": {"DATABRICKS_CONFIG_PROFILE": "$($script:Profile_)"}
+    }
+  }
+}
+"@
+        Set-Content -Path $Path -Value $json -Encoding UTF8
+    }
+}
+
+# Write/merge the Codex TOML config. Unlike the historical unified installer,
+# this includes the profile env block ([mcp_servers.databricks.env]) so Codex
+# picks up the same DATABRICKS_CONFIG_PROFILE as every other client.
+function Write-McpToml {
+    param([string]$Path)
+
+    $dir = Split-Path $Path -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if (Test-Path $Path) {
+        $content = Get-Content $Path -Raw
+        if ($content -match 'mcp_servers\.databricks') { return }
+        Copy-Item $Path "$Path.bak" -Force
+        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
+    }
+
+    $pythonPath = $script:VenvPython -replace '\\', '/'
+    $entryPath  = $script:McpEntry -replace '\\', '/'
+    $tomlBlock = @"
+
+[mcp_servers.databricks]
+command = "$pythonPath"
+args = ["$entryPath"]
+
+[mcp_servers.databricks.env]
+DATABRICKS_CONFIG_PROFILE = "$($script:Profile_)"
+"@
+    Add-Content -Path $Path -Value $tomlBlock -Encoding UTF8
+}
+
+# Write/merge the OpenCode config (root key 'mcp', type 'local', command-as-array).
+function Write-OpenCodeJson {
+    param([string]$Path)
+
+    $dir = Split-Path $Path -Parent
+    if (-not (Test-Path $dir)) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+
+    if (Test-Path $Path) {
+        Copy-Item $Path "$Path.bak" -Force
+        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
+    }
+
+    $existing = $null
+    if (Test-Path $Path) {
+        try { $existing = Get-Content $Path -Raw | ConvertFrom-Json } catch { $existing = $null }
+    }
+
+    if ($existing) {
+        if (-not $existing.'$schema') {
+            $existing | Add-Member -NotePropertyName '$schema' -NotePropertyValue 'https://opencode.ai/config.json' -Force
+        }
+        if (-not $existing.mcp) {
+            $existing | Add-Member -NotePropertyName "mcp" -NotePropertyValue ([PSCustomObject]@{}) -Force
+        }
+        $dbEntry = [PSCustomObject]@{
+            type        = "local"
+            command     = @($script:VenvPython -replace '\\', '/', $script:McpEntry -replace '\\', '/')
+            environment = [PSCustomObject]@{ DATABRICKS_CONFIG_PROFILE = $script:Profile_ }
+            enabled     = $true
+        }
+        $existing.mcp | Add-Member -NotePropertyName "databricks" -NotePropertyValue $dbEntry -Force
+        $existing | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
+    } else {
+        $pythonPath = $script:VenvPython -replace '\\', '/'
+        $entryPath  = $script:McpEntry -replace '\\', '/'
+        $json = @"
+{
+  "`$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "databricks": {
+      "type": "local",
+      "command": ["$pythonPath", "$entryPath"],
+      "environment": {"DATABRICKS_CONFIG_PROFILE": "$($script:Profile_)"},
+      "enabled": true
+    }
+  }
+}
+"@
+        Set-Content -Path $Path -Value $json -Encoding UTF8
+    }
+}
+
+function Write-McpConfigs {
+    param([string]$BaseDir)
+
+    Write-Step "Registering the databricks MCP server"
+
+    foreach ($tool in ($script:Tools -split ' ')) {
+        switch ($tool) {
+            "claude" {
+                if ($script:Scope -eq "global") {
+                    Write-McpJsonConfig (Join-Path $env:USERPROFILE ".claude.json") "mcpServers" $true
+                } else {
+                    Write-McpJsonConfig (Join-Path $BaseDir ".mcp.json") "mcpServers" $true
+                }
+                Write-Ok "Claude MCP config"
+            }
+            "cursor" {
+                if ($script:Scope -eq "global") {
+                    Write-Warn "Cursor global: manual MCP configuration required"
+                    Write-Msg "  1. Open Cursor -> Settings -> Cursor Settings -> Tools & MCP"
+                    Write-Msg "  2. Click New MCP Server"
+                    Write-Msg "  3. Add the following JSON config:"
+                    Write-Msg "     {"
+                    Write-Msg "       `"mcpServers`": {"
+                    Write-Msg "         `"databricks`": {"
+                    Write-Msg "           `"command`": `"$($script:VenvPython)`","
+                    Write-Msg "           `"args`": [`"$($script:McpEntry)`"],"
+                    Write-Msg "           `"env`": {`"DATABRICKS_CONFIG_PROFILE`": `"$($script:Profile_)`"}"
+                    Write-Msg "         }"
+                    Write-Msg "       }"
+                    Write-Msg "     }"
+                } else {
+                    Write-McpJsonConfig (Join-Path $BaseDir ".cursor\mcp.json") "mcpServers" $true
+                    Write-Ok "Cursor MCP config"
+                }
+                Write-Warn "Cursor: MCP servers are disabled by default."
+                Write-Msg "  Enable in: Cursor -> Settings -> Cursor Settings -> Tools & MCP -> Toggle 'databricks'"
+            }
+            "copilot" {
+                if ($script:Scope -eq "global") {
+                    Write-Warn "Copilot global: configure MCP in VS Code settings (Ctrl+Shift+P -> 'MCP: Open User Configuration')"
+                    Write-Msg "  Command: $($script:VenvPython) | Args: $($script:McpEntry)"
+                } else {
+                    Write-McpJsonConfig (Join-Path $BaseDir ".vscode\mcp.json") "servers" $false
+                    Write-Ok "Copilot MCP config (.vscode/mcp.json)"
+                }
+                Write-Warn "Copilot: MCP servers must be enabled manually."
+                Write-Msg "  In Copilot Chat, click 'Configure Tools' (tool icon, bottom-right) and enable 'databricks'"
+            }
+            "codex" {
+                if ($script:Scope -eq "global") {
+                    Write-McpToml (Join-Path $env:USERPROFILE ".codex\config.toml")
+                } else {
+                    Write-McpToml (Join-Path $BaseDir ".codex\config.toml")
+                }
+                Write-Ok "Codex MCP config"
+            }
+            "gemini" {
+                if ($script:Scope -eq "global") {
+                    Write-McpJsonConfig (Join-Path $env:USERPROFILE ".gemini\settings.json") "mcpServers" $false
+                } else {
+                    Write-McpJsonConfig (Join-Path $BaseDir ".gemini\settings.json") "mcpServers" $false
+                }
+                Write-Ok "Gemini CLI MCP config"
+            }
+            "antigravity" {
+                if ($script:Scope -eq "project") {
+                    Write-Warn "Antigravity only supports global MCP configuration."
+                    Write-Msg "  Config written to ~/.gemini/antigravity/mcp_config.json"
+                }
+                Write-McpJsonConfig (Join-Path $env:USERPROFILE ".gemini\antigravity\mcp_config.json") "mcpServers" $false
+                Write-Ok "Antigravity MCP config"
+            }
+            "windsurf" {
+                if ($script:Scope -eq "project") {
+                    Write-Warn "Windsurf only supports global MCP configuration."
+                    Write-Msg "  Config written to ~/.codeium/windsurf/mcp_config.json"
+                }
+                Write-McpJsonConfig (Join-Path $env:USERPROFILE ".codeium\windsurf\mcp_config.json") "mcpServers" $true
+                Write-Ok "Windsurf MCP config"
+            }
+            "opencode" {
+                if ($script:Scope -eq "global") {
+                    Write-OpenCodeJson (Join-Path $env:USERPROFILE ".config\opencode\opencode.json")
+                } else {
+                    Write-OpenCodeJson (Join-Path $BaseDir "opencode.json")
+                }
+                Write-Ok "OpenCode MCP config"
+            }
+            "kiro" {
+                if ($script:Scope -eq "global") {
+                    $kiroSettings = Join-Path $env:USERPROFILE ".kiro\settings"
+                } else {
+                    $kiroSettings = Join-Path $BaseDir ".kiro\settings"
+                }
+                if (-not (Test-Path $kiroSettings)) { New-Item -ItemType Directory -Path $kiroSettings -Force | Out-Null }
+                Write-McpJsonConfig (Join-Path $kiroSettings "mcp.json") "mcpServers" $true
+                Write-Ok "Kiro MCP config"
+            }
+            default {
+                Write-Warn "Unknown tool '$tool' — skipping"
+            }
+        }
+    }
+}
+
+# ─── Uninstall (deregistration) ────────────────────────────────
+# Read-only: true only if the EXACT top-level server key ($Top) contains a
+# 'databricks' entry — the same thing removal targets.
+function Test-McpJsonHasDatabricks {
+    param([string]$Path, [string]$Top)
+    if (-not (Test-Path $Path)) { return $false }
+    try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
+    return ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks')
+}
+
+# Remove the 'databricks' MCP server entry from a JSON config, preserving all
+# other servers and settings. $Top is the top-level key ('mcpServers'/'servers'/'mcp').
+function Remove-McpJsonKey {
+    param([string]$Path, [string]$Top)
+    if (-not (Test-Path $Path)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern '"databricks"' -Quiet)) { return $false }
+    if ($script:DryRun) { return $true }
+    try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { return $false }
+    if (-not ($cfg.$Top -and $cfg.$Top.PSObject.Properties.Name -contains 'databricks')) {
+        return $false
+    }
+    Copy-Item $Path "$Path.bak" -Force
+    $cfg.$Top.PSObject.Properties.Remove('databricks')
+    if (-not $cfg.$Top.PSObject.Properties.Name) { $cfg.PSObject.Properties.Remove($Top) }
+    $cfg | ConvertTo-Json -Depth 100 | Set-Content $Path -Encoding UTF8
+    return $true
+}
+
+# Remove the [mcp_servers.databricks] block (and its dotted subtables, e.g.
+# [mcp_servers.databricks.env]) from a Codex TOML config.
+function Remove-McpTomlBlock {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $false }
+    if (-not (Select-String -Path $Path -Pattern 'mcp_servers\.databricks' -Quiet)) { return $false }
+    if ($script:DryRun) { return $true }
+    Copy-Item $Path "$Path.bak" -Force
+    $out = New-Object System.Collections.Generic.List[string]
+    $skip = $false
+    foreach ($line in Get-Content "$Path.bak") {
+        if ($line -match '^\[mcp_servers\.databricks(\.|\])') { $skip = $true; continue }
+        if ($line -match '^\[') { $skip = $false }
+        if (-not $skip) { $out.Add($line) }
+    }
+    $out | Set-Content $Path -Encoding UTF8
+    return $true
+}
+
+# Build the list of per-scope client config targets.
+function Get-McpTargetsForScope {
+    param([string]$BaseDir)
+    if ($script:Scope -eq "global") {
+        return @(
+            @{ Path=(Join-Path $env:USERPROFILE ".claude.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $env:USERPROFILE ".codex\config.toml"); Kind="toml" },
+            @{ Path=(Join-Path $env:USERPROFILE ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $env:USERPROFILE ".gemini\antigravity\mcp_config.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $env:USERPROFILE ".codeium\windsurf\mcp_config.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $env:USERPROFILE ".config\opencode\opencode.json"); Kind="json"; Top="mcp" },
+            @{ Path=(Join-Path $env:USERPROFILE ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+        )
+    } else {
+        return @(
+            @{ Path=(Join-Path $BaseDir ".mcp.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $BaseDir ".cursor\mcp.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $BaseDir ".vscode\mcp.json"); Kind="json"; Top="servers" },
+            @{ Path=(Join-Path $BaseDir ".codex\config.toml"); Kind="toml" },
+            @{ Path=(Join-Path $BaseDir ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
+            @{ Path=(Join-Path $BaseDir "opencode.json"); Kind="json"; Top="mcp" },
+            @{ Path=(Join-Path $BaseDir ".kiro\settings\mcp.json"); Kind="json"; Top="mcpServers" }
+        )
+    }
+}
+
+function Invoke-Uninstall {
+    if (-not $script:Silent) {
+        Write-Host ""
+        Write-Host "Databricks MCP Server — Deregister" -ForegroundColor White
+        Write-Host "--------------------------------"
+    }
+
+    # Mirror install: if scope wasn't set explicitly, ask (interactive, non -Yes).
+    if (-not $script:ScopeExplicit -and -not $script:AssumeYes) {
+        Invoke-PromptScope -Title "Select deregistration scope"
+    }
+    $baseDir = if ($script:Scope -eq "global") { $env:USERPROFILE } else { (Get-Location).Path }
+
+    # Build the plan (only targets that actually contain our 'databricks' entry)
+    $plan = @()
+    foreach ($target in (Get-McpTargetsForScope $baseDir)) {
+        switch ($target.Kind) {
+            "json" { if (Test-McpJsonHasDatabricks $target.Path $target.Top) { $plan += $target } }
+            "toml" {
+                if ((Test-Path $target.Path) -and (Select-String -Path $target.Path -Pattern 'mcp_servers\.databricks' -Quiet)) {
+                    $plan += $target
+                }
+            }
+        }
+    }
+
+    if ($plan.Count -eq 0) {
+        Write-Ok "Nothing to deregister for $($script:Scope) scope at $baseDir — no 'databricks' MCP entry found."
+        if ($script:Scope -eq "project") { Write-Msg "Tip: pass -Global to remove a global registration." }
+        exit 0
+    }
+
+    Write-Step "Deregister plan ($($script:Scope) scope)"
+    Write-Host "  MCP config — remove 'databricks' entry ($($plan.Count)):" -ForegroundColor White
+    foreach ($target in $plan) { Write-Host "    $($target.Path)" }
+    Write-Host ""
+    Write-Msg "Config files are backed up to <file>.bak before editing."
+
+    if ($script:DryRun) {
+        Write-Ok "Dry run — nothing was changed. Re-run without -DryRun to apply."
+        exit 0
+    }
+
+    if (-not $script:AssumeYes) {
+        if (Test-Interactive) {
+            Write-Host "  Remove these $($plan.Count) item(s)? [y/N] " -ForegroundColor Yellow -NoNewline
+            $reply = Read-Host
+        } else {
+            Write-Die "No terminal to confirm on. Re-run with -Yes to proceed non-interactively (or -DryRun to preview)."
+        }
+        if ($reply -notin @("y", "Y", "yes", "Yes", "YES")) { Write-Die "Aborted — nothing removed." }
+    }
+
+    Write-Step "Removing"
+    foreach ($target in $plan) {
+        switch ($target.Kind) {
+            "json" { if (Remove-McpJsonKey $target.Path $target.Top) { Write-Msg "cleaned $($target.Path)" } }
+            "toml" { if (Remove-McpTomlBlock $target.Path) { Write-Msg "cleaned $($target.Path)" } }
+        }
+    }
+
+    Write-Host ""
+    Write-Ok "databricks MCP server deregistered ($($script:Scope) scope)."
+    Write-Msg "Per-editor .bak backups were left untouched."
+    exit 0
+}
+
+# ─── Build the venv by delegating to setup.ps1 (single source of truth) ──
+function Invoke-SetupMcp {
+    Write-Step "Setting up MCP server"
+
+    $setupScript = Join-Path $script:ScriptDir "setup.ps1"
+    if (-not (Test-Path $setupScript)) { Write-Die "MCP setup script not found at $setupScript" }
+
+    Write-Msg "Building MCP server environment (databricks-mcp-server/setup.ps1)..."
+    $setupArgs = @("-VenvDir", $script:VenvDir)
+    if ($script:Silent) { $setupArgs += "-Quiet" }
+    & $setupScript @setupArgs
+    if ($LASTEXITCODE -ne 0) { Write-Die "MCP server setup failed" }
+    Write-Ok "MCP server ready"
+}
+
+# ─── Summary / post-hints ──────────────────────────────────────
+function Show-Summary {
+    if ($script:Silent) { return }
+    Write-Host ""
+    Write-Host "MCP registration complete!" -ForegroundColor Green
+    Write-Host "--------------------------------"
+    Write-Msg "Server:  $($script:McpEntry)"
+    Write-Msg "Python:  $($script:VenvPython)"
+    Write-Msg "Profile: $($script:Profile_)"
+    Write-Msg "Scope:   $($script:Scope)"
+    Write-Msg "Tools:   $(($script:Tools -split ' ') -join ', ')"
+    Write-Host ""
+    Write-Msg "Next steps:"
+    $step = 1
+    if ($script:Tools -match 'cursor') {
+        Write-Msg "$step. Enable MCP in Cursor: Cursor -> Settings -> Cursor Settings -> Tools & MCP -> Toggle 'databricks'"
+        $step++
+    }
+    if ($script:Tools -match 'copilot') {
+        Write-Msg "$step. In Copilot Chat, click 'Configure Tools' (tool icon, bottom-right) and enable 'databricks'"
+        $step++
+    }
+    if ($script:Tools -match 'windsurf') {
+        Write-Msg "$step. Restart Windsurf to pick up the databricks MCP server (Windsurf -> Settings -> Windsurf Settings -> MCP)"
+        $step++
+    }
+    if ($script:Tools -match 'antigravity') {
+        Write-Msg "$step. Open your project in Antigravity to use the databricks MCP tools"
+        $step++
+    }
+    Write-Msg "$step. Open your project in your tool of choice and start prompting"
+    Write-Host ""
+}
+
+# ─── Main ──────────────────────────────────────────────────────
+function Invoke-Main {
+    if ($script:Uninstall) {
+        Invoke-Uninstall
+    }
+
+    if (-not $script:Silent) {
+        Write-Host ""
+        Write-Host "Databricks MCP Server — Client Registration" -ForegroundColor White
+        Write-Host "--------------------------------"
+    }
+
+    # uv is required by setup.ps1; check early with a helpful message.
+    if (-not $script:SkipVenv -and $null -eq (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Die "uv is required but not found on your PATH.
+   Install it with: powershell -c ""irm https://astral.sh/uv/install.ps1 | iex""
+   Then re-run this installer."
+    }
+
+    # ── Tool selection ──
+    Write-Step "Selecting tools"
+    Invoke-DetectTools
+    Write-Ok "Selected: $(($script:Tools -split ' ') -join ', ')"
+
+    # ── Profile selection ──
+    Write-Step "Databricks profile"
+    Invoke-PromptProfile
+    Write-Ok "Profile: $($script:Profile_)"
+
+    # ── Scope selection ──
+    if (-not $script:ScopeExplicit) {
+        Invoke-PromptScope
+        Write-Ok "Scope: $($script:Scope)"
+    }
+
+    # ── Confirm ──
+    if (-not $script:Silent) {
+        Write-Host ""
+        Write-Host "  Summary" -ForegroundColor White
+        Write-Host "  ------------------------------------"
+        Write-Host "  Tools:    " -NoNewline; Write-Host (($script:Tools -split ' ') -join ', ') -ForegroundColor Green
+        Write-Host "  Profile:  " -NoNewline; Write-Host $script:Profile_ -ForegroundColor Green
+        Write-Host "  Scope:    " -NoNewline; Write-Host $script:Scope -ForegroundColor Green
+        Write-Host "  Venv:     " -NoNewline; Write-Host $script:VenvDir -ForegroundColor Green
+        Write-Host ""
+    }
+
+    if ($script:DryRun) {
+        Write-Ok "Dry run — nothing was changed. Re-run without -DryRun to apply."
+        exit 0
+    }
+
+    if (-not $script:Silent -and (Test-Interactive)) {
+        $confirm = Read-Prompt -PromptText "Proceed with MCP registration? (y/n)" -Default "y"
+        if ($confirm -notin @("y", "Y", "yes", "Yes", "YES")) {
+            Write-Host ""
+            Write-Msg "Registration cancelled."
+            exit 0
+        }
+    }
+
+    # ── Build the venv (delegated to setup.ps1) ──
+    if (-not $script:SkipVenv) {
+        Invoke-SetupMcp
+    }
+    if (-not (Test-Path $script:VenvPython)) {
+        Write-Warn "venv python not found at $($script:VenvPython) — configs will still be written, but build the venv with setup.ps1 before use."
+    }
+
+    # ── Write client configs ──
+    $baseDir = if ($script:Scope -eq "global") { $env:USERPROFILE } else { (Get-Location).Path }
+    Write-McpConfigs $baseDir
+
+    Show-Summary
+}
+
+Invoke-Main

--- a/databricks-mcp-server/mcp_install.sh
+++ b/databricks-mcp-server/mcp_install.sh
@@ -55,8 +55,10 @@ DRY_RUN=false
 ASSUME_YES=false
 
 # Convert string booleans from env vars to actual booleans
-[ "$SILENT" = "true" ] || [ "$SILENT" = "1" ] && SILENT=true || SILENT=false
-[ -n "${DEVKIT_SCOPE:-}" ] && SCOPE_EXPLICIT=true
+if [ "$SILENT" = "true" ] || [ "$SILENT" = "1" ]; then SILENT=true; else SILENT=false; fi
+# Guarded so a false test can't abort the script under `set -e` on older bash
+# (e.g. macOS /bin/bash 3.2), where a bare `[ ... ] && VAR=...` at top level exits.
+if [ -n "${DEVKIT_SCOPE:-}" ]; then SCOPE_EXPLICIT=true; fi
 
 # Colors
 G='\033[0;32m' Y='\033[1;33m' R='\033[0;31m' B='\033[1m' D='\033[2m' N='\033[0m'
@@ -567,7 +569,9 @@ EOF
 write_mcp_toml() {
     local path=$1
     mkdir -p "$(dirname "$path")"
-    grep -q "mcp_servers.databricks" "$path" 2>/dev/null && return
+    # Anchor to the table header so a match in a comment/value can't be mistaken
+    # for an existing registration (matches the removal awk's anchor).
+    grep -qE '^\[mcp_servers\.databricks' "$path" 2>/dev/null && return
     if [ -f "$path" ]; then
         cp "$path" "${path}.bak"
         msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
@@ -765,7 +769,7 @@ PYEOF
 uninstall_remove_toml_block() {
     local path=$1
     [ -f "$path" ] || return 1
-    grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null || return 1
+    grep -qE '^\[mcp_servers\.databricks' "$path" 2>/dev/null || return 1
     if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
     cp "$path" "${path}.bak"
     awk '
@@ -842,7 +846,7 @@ run_uninstall() {
         path="${entry%%|*}"; kind="${entry#*|}"
         case "$kind" in
             json:*) mcp_json_has_databricks "$path" "${kind#json:}" && plan_mcp+=("$entry") ;;
-            toml)   [ -f "$path" ] && grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+            toml)   [ -f "$path" ] && grep -qE '^\[mcp_servers\.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
         esac
     done < <(mcp_targets_for_scope "$base_dir")
 

--- a/databricks-mcp-server/mcp_install.sh
+++ b/databricks-mcp-server/mcp_install.sh
@@ -1,0 +1,1017 @@
+#!/bin/bash
+#
+# Databricks MCP Server - Client Registration Installer
+#
+# Builds the MCP server runtime (by delegating to setup.sh) and registers the
+# `databricks` MCP server with your AI coding tools: Claude Code, Cursor,
+# GitHub Copilot, OpenAI Codex, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+#
+# The venv build is owned by databricks-mcp-server/setup.sh — this script never
+# duplicates that logic; it calls setup.sh and then writes the editor config
+# files that point at the resulting venv.
+#
+# Usage:
+#   bash databricks-mcp-server/mcp_install.sh [OPTIONS]
+#
+# Options:
+#   -p, --profile NAME   Databricks config profile to inject (default: DEFAULT)
+#   -g, --global         Register globally (home dir) instead of per-project
+#   --tools LIST         Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro
+#   --venv-dir DIR       Virtual environment location (default: <this dir>/.venv)
+#   --skip-venv          Skip the setup.sh venv build (assume it already exists)
+#   --silent             Silent mode (no output except errors)
+#   --uninstall          Remove only the 'databricks' MCP entry from each client config
+#   --dry-run            Print the plan (install or uninstall) and exit without changes
+#   -y, --yes            With --uninstall: skip the confirmation prompt
+#   -h, --help           Show this help
+#
+# Environment Variables (alternative to flags):
+#   DEVKIT_PROFILE       Databricks config profile
+#   DEVKIT_SCOPE         'project' or 'global'
+#   DEVKIT_TOOLS         Comma-separated list of tools
+#   DEVKIT_SILENT        Set to 'true' for silent mode
+#
+
+set -e
+
+# ─── Paths (derived from this script's own location) ────────────
+# The repo is already cloned when this standalone installer runs, so — unlike the
+# unified installer's clone-to-~/.ai-dev-kit flow — paths derive from here, the
+# same way setup.sh does.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_ENTRY="$SCRIPT_DIR/run_server.py"
+
+# Defaults (can be overridden by environment variables or command-line arguments)
+PROFILE="${DEVKIT_PROFILE:-DEFAULT}"
+SCOPE="${DEVKIT_SCOPE:-project}"
+SCOPE_EXPLICIT=false
+SILENT="${DEVKIT_SILENT:-false}"
+TOOLS="${DEVKIT_TOOLS:-}"
+USER_TOOLS=""
+VENV_DIR="$SCRIPT_DIR/.venv"
+SKIP_VENV=false
+UNINSTALL=false
+DRY_RUN=false
+ASSUME_YES=false
+
+# Convert string booleans from env vars to actual booleans
+[ "$SILENT" = "true" ] || [ "$SILENT" = "1" ] && SILENT=true || SILENT=false
+[ -n "${DEVKIT_SCOPE:-}" ] && SCOPE_EXPLICIT=true
+
+# Colors
+G='\033[0;32m' Y='\033[1;33m' R='\033[0;31m' B='\033[1m' D='\033[2m' N='\033[0m'
+
+# Output helpers
+msg()  { [ "$SILENT" = true ] || echo -e "  $*"; }
+ok()   { [ "$SILENT" = true ] || echo -e "  ${G}✓${N} $*"; }
+warn() { [ "$SILENT" = true ] || echo -e "  ${Y}!${N} $*"; }
+die()  { echo -e "  ${R}✗${N} $*" >&2; exit 1; }  # Always show errors
+step() { [ "$SILENT" = true ] || echo -e "\n${B}$*${N}"; }
+
+# Parse arguments
+while [ $# -gt 0 ]; do
+    case $1 in
+        -p|--profile)  PROFILE="$2"; shift 2 ;;
+        -g|--global)   SCOPE="global"; SCOPE_EXPLICIT=true; shift ;;
+        --tools)       USER_TOOLS="$2"; shift 2 ;;
+        --venv-dir)    VENV_DIR="$2"; shift 2 ;;
+        --skip-venv)   SKIP_VENV=true; shift ;;
+        --silent)      SILENT=true; shift ;;
+        --uninstall)   UNINSTALL=true; shift ;;
+        --dry-run)     DRY_RUN=true; shift ;;
+        -y|--yes)      ASSUME_YES=true; shift ;;
+        -h|--help)
+            echo "Databricks MCP Server - Client Registration Installer"
+            echo ""
+            echo "Usage: bash databricks-mcp-server/mcp_install.sh [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  -p, --profile NAME   Databricks config profile to inject (default: DEFAULT)"
+            echo "  -g, --global         Register globally (home dir) instead of per-project"
+            echo "  --tools LIST         Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
+            echo "  --venv-dir DIR       Virtual environment location (default: <this dir>/.venv)"
+            echo "  --skip-venv          Skip the setup.sh venv build (assume it already exists)"
+            echo "  --silent             Silent mode (no output except errors)"
+            echo "  --uninstall          Remove only the 'databricks' MCP entry from each client config"
+            echo "  --dry-run            Print the plan (install or uninstall) and exit without changes"
+            echo "  -y, --yes            With --uninstall: skip the confirmation prompt"
+            echo "  -h, --help           Show this help"
+            echo ""
+            echo "Environment Variables (alternative to flags):"
+            echo "  DEVKIT_PROFILE       Databricks config profile"
+            echo "  DEVKIT_SCOPE         'project' or 'global'"
+            echo "  DEVKIT_TOOLS         Comma-separated list of tools"
+            echo "  DEVKIT_SILENT        Set to 'true' for silent mode"
+            echo ""
+            echo "The venv build is delegated to databricks-mcp-server/setup.sh."
+            echo ""
+            exit 0 ;;
+        *) die "Unknown option: $1 (use -h for help)" ;;
+    esac
+done
+
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+# ─── Interactive helpers ────────────────────────────────────────
+# Reads from /dev/tty so prompts work even when piped via curl | bash
+
+# True if we have an interactive tty we can read from.
+is_interactive() {
+    [ -t 0 ] || ( : < /dev/tty ) 2>/dev/null
+}
+
+# Simple text prompt with default value
+prompt() {
+    local prompt_text=$1
+    local default_value=$2
+    local result=""
+
+    if [ "$SILENT" = true ]; then
+        echo "$default_value"
+        return
+    fi
+
+    if ( : < /dev/tty ) 2>/dev/null; then
+        printf "  %b [%s]: " "$prompt_text" "$default_value" > /dev/tty
+        read -r result < /dev/tty
+    elif [ -t 0 ]; then
+        printf "  %b [%s]: " "$prompt_text" "$default_value"
+        read -r result
+    else
+        echo "$default_value"
+        return
+    fi
+
+    if [ -z "$result" ]; then
+        echo "$default_value"
+    else
+        echo "$result"
+    fi
+}
+
+# Interactive checkbox selector using arrow keys + space/enter + "Confirm" button
+# Outputs space-separated selected values to stdout
+# Args: "Label|value|on_or_off|hint[|lock]" ...
+#   A 5th "lock" field marks the item as always-on and non-toggleable.
+checkbox_select() {
+    local -a labels=()
+    local -a values=()
+    local -a states=()
+    local -a hints=()
+    local -a locked=()
+    local count=0
+
+    for item in "$@"; do
+        IFS='|' read -r label value state hint lock <<< "$item"
+        labels+=("$label")
+        values+=("$value")
+        hints+=("$hint")
+        if [ "$lock" = "lock" ]; then
+            locked+=(1)
+            states+=(1)
+        else
+            locked+=(0)
+            [ "$state" = "on" ] && states+=(1) || states+=(0)
+        fi
+        count=$((count + 1))
+    done
+
+    local cursor=0
+    local total_rows=$((count + 2))
+
+    _checkbox_draw() {
+        local i
+        for i in $(seq 0 $((count - 1))); do
+            local check=" "
+            [ "${states[$i]}" = "1" ] && check="\033[0;32m✓\033[0m"
+            local arrow="  "
+            [ "$i" = "$cursor" ] && arrow="\033[0;34m❯\033[0m "
+            local hint_style="\033[2m"
+            [ "${states[$i]}" = "1" ] && hint_style="\033[0;32m"
+            printf "\033[2K  %b[%b] %-16s %b%s\033[0m\n" "$arrow" "$check" "${labels[$i]}" "$hint_style" "${hints[$i]}" > /dev/tty
+        done
+        printf "\033[2K\n" > /dev/tty
+        if [ "$cursor" = "$count" ]; then
+            printf "\033[2K  \033[0;34m❯\033[0m \033[1;32m[ Confirm ]\033[0m\n" > /dev/tty
+        else
+            printf "\033[2K    \033[2m[ Confirm ]\033[0m\n" > /dev/tty
+        fi
+    }
+
+    printf "\n  \033[2m↑/↓ navigate · space/enter select · enter on Confirm to finish\033[0m\n\n" > /dev/tty
+
+    # Hide cursor and disable line wrap (DECAWM). With wrap off the terminal
+    # clips overlong lines to one row, so the cursor-up redraw can't desync.
+    printf "\033[?25l\033[?7l" > /dev/tty
+    trap 'printf "\033[?25h\033[?7h" > /dev/tty 2>/dev/null' EXIT
+
+    _checkbox_draw
+
+    while true; do
+        printf "\033[%dA" "$total_rows" > /dev/tty
+        _checkbox_draw
+
+        local key=""
+        IFS= read -rsn1 key < /dev/tty 2>/dev/null
+
+        if [ "$key" = $'\x1b' ]; then
+            local s1="" s2=""
+            read -rsn1 s1 < /dev/tty 2>/dev/null
+            read -rsn1 s2 < /dev/tty 2>/dev/null
+            if [ "$s1" = "[" ]; then
+                case "$s2" in
+                    A) [ "$cursor" -gt 0 ] && cursor=$((cursor - 1)) ;;
+                    B) [ "$cursor" -lt "$count" ] && cursor=$((cursor + 1)) ;;
+                esac
+            fi
+        elif [ "$key" = " " ] || [ "$key" = "" ]; then
+            if [ "$cursor" -lt "$count" ]; then
+                if [ "${locked[$cursor]}" = "1" ]; then
+                    :
+                elif [ "${states[$cursor]}" = "1" ]; then
+                    states[$cursor]=0
+                else
+                    states[$cursor]=1
+                fi
+            else
+                printf "\033[%dA" "$total_rows" > /dev/tty
+                _checkbox_draw
+                break
+            fi
+        fi
+    done
+
+    printf "\033[?25h\033[?7h" > /dev/tty
+    trap - EXIT
+
+    local selected=""
+    for i in $(seq 0 $((count - 1))); do
+        if [ "${states[$i]}" = "1" ]; then
+            selected="${selected:+$selected }${values[$i]}"
+        fi
+    done
+
+    echo "$selected"
+}
+
+# Interactive single-select using arrow keys + enter + "Confirm" button
+# Outputs the selected value to stdout
+# Args: "Label|value|selected|hint" ...  (exactly one should have selected=on)
+radio_select() {
+    local -a labels=()
+    local -a values=()
+    local -a hints=()
+    local count=0
+    local selected=0
+
+    for item in "$@"; do
+        IFS='|' read -r label value state hint <<< "$item"
+        labels+=("$label")
+        values+=("$value")
+        hints+=("$hint")
+        [ "$state" = "on" ] && selected=$count
+        count=$((count + 1))
+    done
+
+    local cursor=0
+    local total_rows=$((count + 2))
+
+    _radio_draw() {
+        local i
+        for i in $(seq 0 $((count - 1))); do
+            local dot="○"
+            local dot_color="\033[2m"
+            [ "$i" = "$selected" ] && dot="●" && dot_color="\033[0;32m"
+            local arrow="  "
+            [ "$i" = "$cursor" ] && arrow="\033[0;34m❯\033[0m "
+            local hint_style="\033[2m"
+            [ "$i" = "$selected" ] && hint_style="\033[0;32m"
+            printf "\033[2K  %b%b%b %-20s %b%s\033[0m\n" "$arrow" "$dot_color" "$dot" "${labels[$i]}" "$hint_style" "${hints[$i]}" > /dev/tty
+        done
+        printf "\033[2K\n" > /dev/tty
+        if [ "$cursor" = "$count" ]; then
+            printf "\033[2K  \033[0;34m❯\033[0m \033[1;32m[ Confirm ]\033[0m\n" > /dev/tty
+        else
+            printf "\033[2K    \033[2m[ Confirm ]\033[0m\n" > /dev/tty
+        fi
+    }
+
+    printf "\n  \033[2m↑/↓ navigate · enter confirm · space preview\033[0m\n\n" > /dev/tty
+    printf "\033[?25l\033[?7l" > /dev/tty
+    trap 'printf "\033[?25h\033[?7h" > /dev/tty 2>/dev/null' EXIT
+
+    _radio_draw
+
+    while true; do
+        printf "\033[%dA" "$total_rows" > /dev/tty
+        _radio_draw
+
+        local key=""
+        IFS= read -rsn1 key < /dev/tty 2>/dev/null
+
+        if [ "$key" = $'\x1b' ]; then
+            local s1="" s2=""
+            read -rsn1 s1 < /dev/tty 2>/dev/null
+            read -rsn1 s2 < /dev/tty 2>/dev/null
+            if [ "$s1" = "[" ]; then
+                case "$s2" in
+                    A) [ "$cursor" -gt 0 ] && cursor=$((cursor - 1)) ;;
+                    B) [ "$cursor" -lt "$count" ] && cursor=$((cursor + 1)) ;;
+                esac
+            fi
+        elif [ "$key" = "" ]; then
+            if [ "$cursor" -lt "$count" ]; then
+                selected=$cursor
+            fi
+            printf "\033[%dA" "$total_rows" > /dev/tty
+            _radio_draw
+            break
+        elif [ "$key" = " " ]; then
+            if [ "$cursor" -lt "$count" ]; then
+                selected=$cursor
+            fi
+        fi
+    done
+
+    printf "\033[?25h\033[?7h" > /dev/tty
+    trap - EXIT
+
+    echo "${values[$selected]}"
+}
+
+# ─── Tool detection & selection ─────────────────────────────────
+detect_tools() {
+    # If provided via --tools flag or TOOLS env var, skip detection and prompts
+    if [ -n "$USER_TOOLS" ]; then
+        TOOLS=$(echo "$USER_TOOLS" | tr ',' ' ')
+        return
+    elif [ -n "$TOOLS" ]; then
+        TOOLS=$(echo "$TOOLS" | tr ',' ' ')
+        return
+    fi
+
+    # Auto-detect what's installed
+    local has_claude=false
+    local has_cursor=false
+    local has_codex=false
+    local has_copilot=false
+    local has_gemini=false
+    local has_antigravity=false
+    local has_windsurf=false
+    local has_opencode=false
+    local has_kiro=false
+
+    command -v claude >/dev/null 2>&1 && has_claude=true
+    { [ -d "/Applications/Cursor.app" ] || command -v cursor >/dev/null 2>&1; } && has_cursor=true
+    command -v codex >/dev/null 2>&1 && has_codex=true
+    { [ -d "/Applications/Visual Studio Code.app" ] || command -v code >/dev/null 2>&1; } && has_copilot=true
+    { command -v gemini >/dev/null 2>&1 || [ -f "$HOME/.gemini/local/gemini" ]; } && has_gemini=true
+    { [ -d "/Applications/Antigravity.app" ] || command -v antigravity >/dev/null 2>&1; } && has_antigravity=true
+    { [ -d "/Applications/Windsurf.app" ] || command -v windsurf >/dev/null 2>&1; } && has_windsurf=true
+    command -v opencode >/dev/null 2>&1 && has_opencode=true
+    { [ -d "/Applications/Kiro.app" ] || command -v kiro >/dev/null 2>&1; } && has_kiro=true
+
+    local claude_state="off" cursor_state="off" codex_state="off" copilot_state="off" gemini_state="off" antigravity_state="off" windsurf_state="off" opencode_state="off" kiro_state="off"
+    local claude_hint="not found" cursor_hint="not found" codex_hint="not found" copilot_hint="not found" gemini_hint="not found" antigravity_hint="not found" windsurf_hint="not found" opencode_hint="not found" kiro_hint="not found"
+    [ "$has_claude" = true ]        && claude_state="on"        && claude_hint="detected"
+    [ "$has_cursor" = true ]        && cursor_state="on"        && cursor_hint="detected"
+    [ "$has_codex" = true ]         && codex_state="on"         && codex_hint="detected"
+    [ "$has_copilot" = true ]       && copilot_state="on"       && copilot_hint="detected"
+    [ "$has_gemini" = true ]        && gemini_state="on"        && gemini_hint="detected"
+    [ "$has_antigravity" = true ]   && antigravity_state="on"   && antigravity_hint="detected"
+    [ "$has_windsurf" = true ]      && windsurf_state="on"      && windsurf_hint="detected"
+    [ "$has_opencode" = true ]      && opencode_state="on"      && opencode_hint="detected"
+    [ "$has_kiro" = true ]          && kiro_state="on"          && kiro_hint="detected"
+
+    # If nothing detected, pre-select claude as default
+    if [ "$has_claude" = false ] && [ "$has_cursor" = false ] && [ "$has_codex" = false ] && [ "$has_copilot" = false ] && [ "$has_gemini" = false ] && [ "$has_antigravity" = false ] && [ "$has_windsurf" = false ] && [ "$has_opencode" = false ] && [ "$has_kiro" = false ]; then
+        claude_state="on"
+        claude_hint="default"
+    fi
+
+    if [ "$SILENT" = false ] && is_interactive; then
+        echo ""
+        echo -e "  ${B}Select tools to register the databricks MCP server for:${N}"
+
+        TOOLS=$(checkbox_select \
+            "Claude Code|claude|${claude_state}|${claude_hint}" \
+            "Cursor|cursor|${cursor_state}|${cursor_hint}" \
+            "GitHub Copilot|copilot|${copilot_state}|${copilot_hint}" \
+            "OpenAI Codex|codex|${codex_state}|${codex_hint}" \
+            "Gemini CLI|gemini|${gemini_state}|${gemini_hint}" \
+            "Antigravity|antigravity|${antigravity_state}|${antigravity_hint}" \
+            "Windsurf|windsurf|${windsurf_state}|${windsurf_hint}" \
+            "OpenCode|opencode|${opencode_state}|${opencode_hint}" \
+            "Kiro|kiro|${kiro_state}|${kiro_hint}" \
+        )
+    else
+        local tools=""
+        [ "$has_claude" = true ]        && tools="claude"
+        [ "$has_cursor" = true ]        && tools="${tools:+$tools }cursor"
+        [ "$has_copilot" = true ]       && tools="${tools:+$tools }copilot"
+        [ "$has_codex" = true ]         && tools="${tools:+$tools }codex"
+        [ "$has_gemini" = true ]        && tools="${tools:+$tools }gemini"
+        [ "$has_antigravity" = true ]   && tools="${tools:+$tools }antigravity"
+        [ "$has_windsurf" = true ]      && tools="${tools:+$tools }windsurf"
+        [ "$has_opencode" = true ]      && tools="${tools:+$tools }opencode"
+        [ "$has_kiro" = true ]          && tools="${tools:+$tools }kiro"
+        [ -z "$tools" ] && tools="claude"
+        TOOLS="$tools"
+    fi
+
+    if [ -z "$TOOLS" ]; then
+        warn "No tools selected, defaulting to Claude Code"
+        TOOLS="claude"
+    fi
+}
+
+# ─── Databricks profile selection ─────────────────────────────
+prompt_profile() {
+    # If provided via --profile flag (non-default), skip prompt
+    if [ "$PROFILE" != "DEFAULT" ]; then
+        return
+    fi
+
+    if [ "$SILENT" = true ] || ! is_interactive; then
+        return
+    fi
+
+    local cfg_file="$HOME/.databrickscfg"
+    local -a profiles=()
+
+    if [ -f "$cfg_file" ]; then
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^\[([a-zA-Z0-9_-]+)\]$ ]]; then
+                profiles+=("${BASH_REMATCH[1]}")
+            fi
+        done < "$cfg_file"
+    fi
+
+    echo ""
+    echo -e "  ${B}Select Databricks profile${N}"
+
+    if [ ${#profiles[@]} -gt 0 ] && is_interactive; then
+        local -a items=()
+        for p in "${profiles[@]}"; do
+            local state="off"
+            local hint=""
+            [ "$p" = "DEFAULT" ] && state="on" && hint="default"
+            items+=("${p}|${p}|${state}|${hint}")
+        done
+
+        items+=("Custom profile name...|__CUSTOM__|off|Enter a custom profile name")
+
+        local has_default=false
+        for p in "${profiles[@]}"; do
+            [ "$p" = "DEFAULT" ] && has_default=true
+        done
+        if [ "$has_default" = false ]; then
+            items[0]=$(echo "${items[0]}" | sed 's/|off|/|on|/')
+        fi
+
+        local selected_profile
+        selected_profile=$(radio_select "${items[@]}")
+
+        if [ "$selected_profile" = "__CUSTOM__" ]; then
+            echo ""
+            local custom_name
+            custom_name=$(prompt "Enter profile name" "DEFAULT")
+            PROFILE="$custom_name"
+        else
+            PROFILE="$selected_profile"
+        fi
+    else
+        echo -e "  ${D}No ~/.databrickscfg found. You can authenticate after install.${N}"
+        echo ""
+        local selected
+        selected=$(prompt "Profile name" "DEFAULT")
+        PROFILE="$selected"
+    fi
+}
+
+# ─── Scope selection ────────────────────────────────────────────
+prompt_scope() {
+    if [ "$SILENT" = true ] || ! is_interactive; then
+        return
+    fi
+
+    local title="${SCOPE_PROMPT_TITLE:-Select registration scope}"
+
+    echo ""
+    echo -e "  ${B}${title}${N}"
+
+    SCOPE=$(radio_select \
+        "Project|project|on|Current directory (.mcp.json, etc.)" \
+        "Global|global|off|Home directory (~/.claude.json, etc.)" \
+    )
+}
+
+# ─── MCP config writers ────────────────────────────────────────
+# Write/merge an MCP server entry into a JSON config.
+#   $1 path        target config file
+#   $2 root_key    top-level key: "mcpServers" (Claude/Cursor/Gemini/Windsurf/Kiro)
+#                  or "servers" (Copilot)
+#   $3 defer       "true" to include Claude's defer_loading hint, else "false"
+# Merges into any existing config with Python, preserving other servers, and
+# backs up the original to <file>.bak first.
+write_mcp_json_config() {
+    local path=$1 root_key=$2 defer=$3
+    mkdir -p "$(dirname "$path")"
+
+    if [ -f "$path" ]; then
+        cp "$path" "${path}.bak"
+        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
+    fi
+
+    local defer_py="" defer_json=""
+    if [ "$defer" = "true" ]; then
+        defer_py="'defer_loading': True, "
+        defer_json='
+      "defer_loading": true,'
+    fi
+
+    if [ -f "$VENV_PYTHON" ]; then
+        "$VENV_PYTHON" -c "
+import json
+try:
+    with open('$path') as f: cfg = json.load(f)
+except: cfg = {}
+cfg.setdefault('$root_key', {})['databricks'] = {'command': '$VENV_PYTHON', 'args': ['$MCP_ENTRY'], ${defer_py}'env': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'}}
+with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+" 2>/dev/null && return
+    fi
+
+    # Fallback: only safe for new files — refuse to overwrite existing files
+    # that may contain other settings (e.g. ~/.claude.json)
+    if [ -f "$path" ]; then
+        warn "Cannot merge MCP config into $path without Python. Add manually."
+        return
+    fi
+
+    cat > "$path" << EOF
+{
+  "$root_key": {
+    "databricks": {
+      "command": "$VENV_PYTHON",
+      "args": ["$MCP_ENTRY"],${defer_json}
+      "env": {"DATABRICKS_CONFIG_PROFILE": "$PROFILE"}
+    }
+  }
+}
+EOF
+}
+
+# Write/merge the Codex TOML config. Unlike the historical unified installer,
+# this includes the profile env block ([mcp_servers.databricks.env]) so Codex
+# picks up the same DATABRICKS_CONFIG_PROFILE as every other client.
+write_mcp_toml() {
+    local path=$1
+    mkdir -p "$(dirname "$path")"
+    grep -q "mcp_servers.databricks" "$path" 2>/dev/null && return
+    if [ -f "$path" ]; then
+        cp "$path" "${path}.bak"
+        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
+    fi
+    cat >> "$path" << EOF
+
+[mcp_servers.databricks]
+command = "$VENV_PYTHON"
+args = ["$MCP_ENTRY"]
+
+[mcp_servers.databricks.env]
+DATABRICKS_CONFIG_PROFILE = "$PROFILE"
+EOF
+}
+
+# Write/merge the OpenCode config (root key 'mcp', type 'local', command-as-array).
+write_opencode_json() {
+    local path=$1
+    mkdir -p "$(dirname "$path")"
+
+    if [ -f "$path" ]; then
+        cp "$path" "${path}.bak"
+        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
+    fi
+
+    if [ -f "$VENV_PYTHON" ]; then
+        "$VENV_PYTHON" -c "
+import json
+try:
+    with open('$path') as f: cfg = json.load(f)
+except: cfg = {}
+cfg.setdefault('\$schema', 'https://opencode.ai/config.json')
+cfg.setdefault('mcp', {})['databricks'] = {
+    'type': 'local',
+    'command': ['$VENV_PYTHON', '$MCP_ENTRY'],
+    'environment': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'},
+    'enabled': True
+}
+with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+" 2>/dev/null && return
+    fi
+
+    if [ -f "$path" ]; then
+        warn "Cannot merge MCP config into $path without Python. Add manually."
+        return
+    fi
+
+    cat > "$path" << EOF
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "databricks": {
+      "type": "local",
+      "command": ["$VENV_PYTHON", "$MCP_ENTRY"],
+      "environment": {"DATABRICKS_CONFIG_PROFILE": "$PROFILE"},
+      "enabled": true
+    }
+  }
+}
+EOF
+}
+
+write_mcp_configs() {
+    step "Registering the databricks MCP server"
+
+    local base_dir=$1
+    for tool in $TOOLS; do
+        case $tool in
+            claude)
+                [ "$SCOPE" = "global" ] && write_mcp_json_config "$HOME/.claude.json" mcpServers true || write_mcp_json_config "$base_dir/.mcp.json" mcpServers true
+                ok "Claude MCP config"
+                ;;
+            cursor)
+                if [ "$SCOPE" = "global" ]; then
+                    warn "Cursor global: manual MCP configuration required"
+                    msg "  1. Open ${B}Cursor → Settings → Cursor Settings → Tools & MCP${N}"
+                    msg "  2. Click ${B}New MCP Server${N}"
+                    msg "  3. Add the following JSON config:"
+                    msg "     {"
+                    msg "       \"mcpServers\": {"
+                    msg "         \"databricks\": {"
+                    msg "           \"command\": \"$VENV_PYTHON\","
+                    msg "           \"args\": [\"$MCP_ENTRY\"],"
+                    msg "           \"env\": {\"DATABRICKS_CONFIG_PROFILE\": \"$PROFILE\"}"
+                    msg "         }"
+                    msg "       }"
+                    msg "     }"
+                else
+                    write_mcp_json_config "$base_dir/.cursor/mcp.json" mcpServers true
+                    ok "Cursor MCP config"
+                fi
+                warn "Cursor: MCP servers are disabled by default."
+                msg "  Enable in: ${B}Cursor → Settings → Cursor Settings → Tools & MCP → Toggle 'databricks'${N}"
+                ;;
+            copilot)
+                if [ "$SCOPE" = "global" ]; then
+                    warn "Copilot global: configure MCP in VS Code settings (Ctrl+Shift+P → 'MCP: Open User Configuration')"
+                    msg "  Command: $VENV_PYTHON | Args: $MCP_ENTRY"
+                else
+                    write_mcp_json_config "$base_dir/.vscode/mcp.json" servers false
+                    ok "Copilot MCP config (.vscode/mcp.json)"
+                fi
+                warn "Copilot: MCP servers must be enabled manually."
+                msg "  In Copilot Chat, click ${B}Configure Tools${N} (tool icon, bottom-right) and enable ${B}databricks${N}"
+                ;;
+            codex)
+                [ "$SCOPE" = "global" ] && write_mcp_toml "$HOME/.codex/config.toml" || write_mcp_toml "$base_dir/.codex/config.toml"
+                ok "Codex MCP config"
+                ;;
+            gemini)
+                if [ "$SCOPE" = "global" ]; then
+                    write_mcp_json_config "$HOME/.gemini/settings.json" mcpServers false
+                else
+                    write_mcp_json_config "$base_dir/.gemini/settings.json" mcpServers false
+                fi
+                ok "Gemini CLI MCP config"
+                ;;
+            antigravity)
+                if [ "$SCOPE" = "project" ]; then
+                    warn "Antigravity only supports global MCP configuration."
+                    msg "  Config written to ${B}~/.gemini/antigravity/mcp_config.json${N}"
+                fi
+                write_mcp_json_config "$HOME/.gemini/antigravity/mcp_config.json" mcpServers false
+                ok "Antigravity MCP config"
+                ;;
+            windsurf)
+                if [ "$SCOPE" = "project" ]; then
+                    warn "Windsurf only supports global MCP configuration."
+                    msg "  Config written to ${B}~/.codeium/windsurf/mcp_config.json${N}"
+                fi
+                write_mcp_json_config "$HOME/.codeium/windsurf/mcp_config.json" mcpServers true
+                ok "Windsurf MCP config"
+                ;;
+            opencode)
+                if [ "$SCOPE" = "global" ]; then
+                    write_opencode_json "$HOME/.config/opencode/opencode.json"
+                else
+                    write_opencode_json "$base_dir/opencode.json"
+                fi
+                ok "OpenCode MCP config"
+                ;;
+            kiro)
+                if [ "$SCOPE" = "global" ]; then
+                    mkdir -p "$HOME/.kiro/settings"
+                    write_mcp_json_config "$HOME/.kiro/settings/mcp.json" mcpServers true
+                else
+                    mkdir -p "$base_dir/.kiro/settings"
+                    write_mcp_json_config "$base_dir/.kiro/settings/mcp.json" mcpServers true
+                fi
+                ok "Kiro MCP config"
+                ;;
+            *)
+                warn "Unknown tool '$tool' — skipping"
+                ;;
+        esac
+    done
+}
+
+# ─── Uninstall (deregistration) ────────────────────────────────
+# Remove the 'databricks' MCP server entry from a JSON config, preserving all
+# other servers and settings. $2 is the top-level key ('mcpServers' or 'servers').
+uninstall_remove_json_key() {
+    local path=$1 top=$2
+    [ -f "$path" ] || return 1
+    grep -qF '"databricks"' "$path" 2>/dev/null || return 1
+    if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
+    local py=""
+    command -v python3 >/dev/null 2>&1 && py=python3
+    [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
+    if [ -z "$py" ]; then warn "No Python to edit $path — remove the 'databricks' entry manually."; return 1; fi
+    cp "$path" "${path}.bak"
+    if "$py" - "$path" "$top" <<'PYEOF'
+import json, sys
+path, top = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f: cfg = json.load(f)
+except Exception: sys.exit(2)
+if not (isinstance(cfg.get(top), dict) and 'databricks' in cfg[top]):
+    sys.exit(1)  # nothing to remove
+cfg[top].pop('databricks', None)
+if not cfg[top]: cfg.pop(top, None)
+with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
+sys.exit(0)
+PYEOF
+    then
+        return 0
+    else
+        rm -f "${path}.bak"   # nothing changed — don't leave a spurious backup
+        return 1
+    fi
+}
+
+# Remove the [mcp_servers.databricks] block (and its dotted subtables, e.g.
+# [mcp_servers.databricks.env]) from a Codex TOML config.
+uninstall_remove_toml_block() {
+    local path=$1
+    [ -f "$path" ] || return 1
+    grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null || return 1
+    if [ "$DRY_RUN" = true ]; then echo "$path"; return 0; fi
+    cp "$path" "${path}.bak"
+    awk '
+        /^\[mcp_servers\.databricks(\.|\])/ { skip=1; next }
+        /^\[/ { skip=0 }
+        !skip { print }
+    ' "${path}.bak" > "$path"
+    return 0
+}
+
+# Same top-level key check used by removal, so the plan matches what removal does.
+mcp_json_has_databricks() {
+    local path=$1 top=$2 py=""
+    [ -f "$path" ] || return 1
+    command -v python3 >/dev/null 2>&1 && py=python3
+    [ -z "$py" ] && [ -f "$VENV_PYTHON" ] && py="$VENV_PYTHON"
+    [ -z "$py" ] && { grep -qF '"databricks"' "$path" 2>/dev/null; return; }
+    "$py" - "$path" "$top" <<'PYEOF'
+import json, sys
+try:
+    cfg = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+top = cfg.get(sys.argv[2])
+sys.exit(0 if (isinstance(top, dict) and "databricks" in top) else 1)
+PYEOF
+}
+
+# Build the list of per-scope client config targets ("path|kind").
+mcp_targets_for_scope() {
+    local base_dir=$1
+    if [ "$SCOPE" = "global" ]; then
+        cat <<EOF
+$HOME/.claude.json|json:mcpServers
+$HOME/.codex/config.toml|toml
+$HOME/.gemini/settings.json|json:mcpServers
+$HOME/.gemini/antigravity/mcp_config.json|json:mcpServers
+$HOME/.codeium/windsurf/mcp_config.json|json:mcpServers
+$HOME/.config/opencode/opencode.json|json:mcp
+$HOME/.kiro/settings/mcp.json|json:mcpServers
+EOF
+    else
+        cat <<EOF
+$base_dir/.mcp.json|json:mcpServers
+$base_dir/.cursor/mcp.json|json:mcpServers
+$base_dir/.vscode/mcp.json|json:servers
+$base_dir/.codex/config.toml|toml
+$base_dir/.gemini/settings.json|json:mcpServers
+$base_dir/opencode.json|json:mcp
+$base_dir/.kiro/settings/mcp.json|json:mcpServers
+EOF
+    fi
+}
+
+run_uninstall() {
+    if [ "$SILENT" = false ]; then
+        echo ""
+        echo -e "${B}Databricks MCP Server — Deregister${N}"
+        echo "────────────────────────────────"
+    fi
+
+    # Mirror install: if scope wasn't set explicitly, ask (interactive, non --yes).
+    if [ "$SCOPE_EXPLICIT" = false ] && [ "$ASSUME_YES" != true ]; then
+        SCOPE_PROMPT_TITLE="Select deregistration scope" prompt_scope
+    fi
+    local base_dir
+    [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
+
+    # Build the plan (only targets that actually contain our 'databricks' entry)
+    local -a plan_mcp=()
+    local entry path kind
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        path="${entry%%|*}"; kind="${entry#*|}"
+        case "$kind" in
+            json:*) mcp_json_has_databricks "$path" "${kind#json:}" && plan_mcp+=("$entry") ;;
+            toml)   [ -f "$path" ] && grep -qF 'mcp_servers.databricks' "$path" 2>/dev/null && plan_mcp+=("$entry") ;;
+        esac
+    done < <(mcp_targets_for_scope "$base_dir")
+
+    if [ ${#plan_mcp[@]} -eq 0 ]; then
+        ok "Nothing to deregister for ${B}$SCOPE${N} scope at ${D}${base_dir}${N} — no 'databricks' MCP entry found."
+        [ "$SCOPE" = "project" ] && msg "${D}Tip: pass --global to remove a global registration.${N}"
+        exit 0
+    fi
+
+    step "Deregister plan (${SCOPE} scope)"
+    echo -e "  ${B}MCP config — remove 'databricks' entry (${#plan_mcp[@]}):${N}"
+    for entry in "${plan_mcp[@]}"; do echo "    ${entry%%|*}" | sed "s#$HOME#~#"; done
+    echo ""
+    msg "${D}Config files are backed up to <file>.bak before editing.${N}"
+
+    if [ "$DRY_RUN" = true ]; then
+        ok "Dry run — nothing was changed. Re-run without --dry-run to apply."
+        exit 0
+    fi
+
+    if [ "$ASSUME_YES" != true ]; then
+        local reply=""
+        if { exec 3</dev/tty; } 2>/dev/null; then
+            printf "  ${Y}Remove these %d item(s)?${N} [y/N] " "${#plan_mcp[@]}"
+            read -r reply <&3 || reply=""
+            exec 3<&-
+        else
+            die "No terminal to confirm on. Re-run with -y/--yes to proceed non-interactively (or --dry-run to preview)."
+        fi
+        case "$reply" in [yY]|[yY][eE][sS]) ;; *) die "Aborted — nothing removed." ;; esac
+    fi
+
+    step "Removing"
+    for entry in "${plan_mcp[@]}"; do
+        path="${entry%%|*}"; kind="${entry#*|}"
+        case "$kind" in
+            json:*) uninstall_remove_json_key "$path" "${kind#json:}" && msg "cleaned ${path/#$HOME/~}" ;;
+            toml)   uninstall_remove_toml_block "$path" && msg "cleaned ${path/#$HOME/~}" ;;
+        esac
+    done
+
+    echo ""
+    ok "databricks MCP server deregistered (${SCOPE} scope)."
+    msg "${D}Per-editor .bak backups were left untouched.${N}"
+    exit 0
+}
+
+# ─── Build the venv by delegating to setup.sh (single source of truth) ──
+setup_mcp() {
+    step "Setting up MCP server"
+
+    local setup_script="$SCRIPT_DIR/setup.sh"
+    [ -f "$setup_script" ] || die "MCP setup script not found at $setup_script"
+
+    msg "Building MCP server environment (databricks-mcp-server/setup.sh)..."
+    local quiet_flag=""
+    [ "$SILENT" = true ] && quiet_flag="--quiet"
+    bash "$setup_script" --venv-dir "$VENV_DIR" $quiet_flag || die "MCP server setup failed"
+    ok "MCP server ready"
+}
+
+# ─── Summary / post-hints ──────────────────────────────────────
+summary() {
+    [ "$SILENT" = true ] && return
+    echo ""
+    echo -e "${G}${B}MCP registration complete!${N}"
+    echo "────────────────────────────────"
+    msg "Server:  $MCP_ENTRY"
+    msg "Python:  $VENV_PYTHON"
+    msg "Profile: $PROFILE"
+    msg "Scope:   $SCOPE"
+    msg "Tools:   $(echo "$TOOLS" | tr ' ' ', ')"
+    echo ""
+    msg "${B}Next steps:${N}"
+    local step=1
+    if echo "$TOOLS" | grep -q cursor; then
+        msg "${step}. Enable MCP in Cursor: ${B}Cursor → Settings → Cursor Settings → Tools & MCP → Toggle 'databricks'${N}"
+        step=$((step + 1))
+    fi
+    if echo "$TOOLS" | grep -q copilot; then
+        msg "${step}. In Copilot Chat, click ${B}Configure Tools${N} (tool icon, bottom-right) and enable ${B}databricks${N}"
+        step=$((step + 1))
+    fi
+    if echo "$TOOLS" | grep -q windsurf; then
+        msg "${step}. Restart Windsurf to pick up the ${B}databricks${N} MCP server (Windsurf → Settings → Windsurf Settings → MCP)"
+        step=$((step + 1))
+    fi
+    if echo "$TOOLS" | grep -q antigravity; then
+        msg "${step}. Open your project in Antigravity to use the ${B}databricks${N} MCP tools"
+        step=$((step + 1))
+    fi
+    msg "${step}. Open your project in your tool of choice and start prompting"
+    echo ""
+}
+
+# ─── Main ──────────────────────────────────────────────────────
+main() {
+    if [ "$UNINSTALL" = true ]; then
+        run_uninstall
+    fi
+
+    if [ "$SILENT" = false ]; then
+        echo ""
+        echo -e "${B}Databricks MCP Server — Client Registration${N}"
+        echo "────────────────────────────────"
+    fi
+
+    # uv is required by setup.sh; check early with a helpful message.
+    if [ "$SKIP_VENV" = false ] && ! command -v uv >/dev/null 2>&1; then
+        die "uv is required but not found on your PATH.
+   Install it with: ${B}curl -LsSf https://astral.sh/uv/install.sh | sh${N}
+   Then re-run this installer."
+    fi
+
+    # ── Tool selection ──
+    step "Selecting tools"
+    detect_tools
+    ok "Selected: $(echo "$TOOLS" | tr ' ' ', ')"
+
+    # ── Profile selection ──
+    step "Databricks profile"
+    prompt_profile
+    ok "Profile: $PROFILE"
+
+    # ── Scope selection ──
+    if [ "$SCOPE_EXPLICIT" = false ]; then
+        prompt_scope
+        ok "Scope: $SCOPE"
+    fi
+
+    # ── Confirm ──
+    if [ "$SILENT" = false ]; then
+        echo ""
+        echo -e "  ${B}Summary${N}"
+        echo -e "  ────────────────────────────────────"
+        echo -e "  Tools:    ${G}$(echo "$TOOLS" | tr ' ' ', ')${N}"
+        echo -e "  Profile:  ${G}${PROFILE}${N}"
+        echo -e "  Scope:    ${G}${SCOPE}${N}"
+        echo -e "  Venv:     ${G}${VENV_DIR}${N}"
+        echo ""
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        ok "Dry run — nothing was changed. Re-run without --dry-run to apply."
+        exit 0
+    fi
+
+    if [ "$SILENT" = false ] && is_interactive; then
+        local confirm
+        confirm=$(prompt "Proceed with MCP registration? ${D}(y/n)${N}" "y")
+        if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ] && [ "$confirm" != "yes" ]; then
+            echo ""
+            msg "Registration cancelled."
+            exit 0
+        fi
+    fi
+
+    # ── Build the venv (delegated to setup.sh) ──
+    if [ "$SKIP_VENV" = false ]; then
+        setup_mcp
+    fi
+    [ -f "$VENV_PYTHON" ] || warn "venv python not found at $VENV_PYTHON — configs will still be written, but build the venv with setup.sh before use."
+
+    # ── Write client configs ──
+    local base_dir
+    [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
+    write_mcp_configs "$base_dir"
+
+    summary
+}
+
+main "$@"

--- a/install.ps1
+++ b/install.ps1
@@ -293,6 +293,12 @@ function Write-Err  {
 }
 function Write-Step { param([string]$Text) if (-not $script:Silent) { Write-Host ""; Write-Host "$Text" -ForegroundColor White } }
 
+# Deprecation notice for the removed MCP flags/env. Always written to stderr
+# (even in silent mode) since the user explicitly passed a now-removed option.
+function Show-McpMovedNotice {
+    [Console]::Error.WriteLine("  ! MCP setup has moved out of this installer. Run databricks-mcp-server\mcp_install.ps1 (or mcp_install.sh on macOS/Linux) to install and register the Databricks MCP server.")
+}
+
 # Deprecation notice - shown on every install/upgrade while skills still ship
 # from this repo. The next major release installs skills via the Databricks CLI
 # from the official databricks/databricks-agent-skills set.
@@ -317,9 +323,14 @@ while ($i -lt $args.Count) {
         { $_ -in "-p", "--profile" }  { $script:Profile_ = $args[$i + 1]; $script:ProfileProvided = $true; $i += 2 }
         { $_ -in "-g", "--global", "-Global" }  { $script:Scope = "global"; $script:ScopeExplicit = $true; $i++ }
         { $_ -in "--skills-only", "-SkillsOnly" } { $i++ }  # accepted for backward compat (skills-only is now the only mode)
-        { $_ -in "--mcp", "-Mcp", "--mcp-only", "-McpOnly", "--mcp-path", "-McpPath" } {
-            Write-Err "The MCP server has moved to its own installer. Run: .\databricks-mcp-server\mcp_install.ps1 (or mcp_install.sh on macOS/Linux)."
-        }
+        # Removed MCP flags — handled gracefully. --mcp warns and continues with
+        # the normal (skills-only) install; --mcp-path also consumes its value so
+        # arg-parsing doesn't choke on the now-unknown argument.
+        { $_ -in "--mcp", "-Mcp" }             { Show-McpMovedNotice; $i++ }
+        { $_ -in "--mcp-path", "-McpPath" }    { Show-McpMovedNotice; $i += 2 }
+        # --mcp-only had no non-MCP work to do, so just point the user and exit
+        # cleanly (informative, not a crash).
+        { $_ -in "--mcp-only", "-McpOnly" }    { Show-McpMovedNotice; exit 0 }
         { $_ -in "--silent", "-Silent" }       { $script:Silent = $true; $i++ }
         { $_ -in "--tools", "-Tools" }         { $script:UserTools = $args[$i + 1]; $i += 2 }
         { $_ -in "--skills-profile", "-SkillsProfile" } { $script:SkillsProfile = $args[$i + 1]; $i += 2 }
@@ -391,6 +402,11 @@ while ($i -lt $args.Count) {
         }
         default { Write-Err "Unknown option: $($args[$i]) (use -h for help)"; $i++ }
     }
+}
+
+# Removed MCP env var — warn and continue with the normal (skills-only) install.
+if ($env:DEVKIT_INSTALL_MCP -in @("true", "1")) {
+    Show-McpMovedNotice
 }
 
 # ─── --uninstall ───────────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -1,7 +1,11 @@
 #
 # Databricks AI Dev Kit - Unified Installer (Windows)
 #
-# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+# Installs Databricks skills and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+#
+# The (deprecated, optional) MCP server has its own installer:
+#   databricks-mcp-server\mcp_install.ps1  (Windows)
+#   databricks-mcp-server/mcp_install.sh   (macOS/Linux)
 #
 # Usage: irm https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.ps1 -OutFile install.ps1
 #        .\install.ps1 [OPTIONS]
@@ -21,9 +25,6 @@
 #
 #   # Install for specific tools only
 #   .\install.ps1 -Tools cursor
-#
-#   # Skills only (skip MCP server)
-#   .\install.ps1 -SkillsOnly
 #
 #   # Install specific branch or tag
 #   $env:AIDEVKIT_BRANCH = '0.1.0'; .\install.ps1
@@ -52,17 +53,15 @@ if ($env:AIDEVKIT_BRANCH -or $env:DEVKIT_BRANCH) {
     }
 }
 
-$RepoUrl   = "https://github.com/$Owner/$Repo.git"
 $RawUrl    = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"
 $InstallDir = if ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $env:USERPROFILE ".ai-dev-kit" }
-$RepoDir   = Join-Path $InstallDir "repo"
+# $VenvPython is used by -Uninstall as a fallback Python interpreter for safely
+# editing leftover JSON config from older installs that included the MCP server.
 $VenvDir   = Join-Path $InstallDir ".venv"
 $VenvPython = Join-Path $VenvDir "Scripts\python.exe"
-$McpEntry  = Join-Path $RepoDir "databricks-mcp-server\run_server.py"
 
 # Minimum required versions
 $MinCliVersion = "0.278.0"
-# (MCP server SDK minimum is enforced by databricks-mcp-server/setup.ps1)
 # Agent skills are delegated to `databricks aitools`, which ships with CLI v1.0.0+
 $MinAitoolsCliVersion = "1.0.0"
 
@@ -71,16 +70,13 @@ $MinAitoolsCliVersion = "1.0.0"
 $script:Profile_     = if ($env:DEVKIT_PROFILE) { $env:DEVKIT_PROFILE } else { "DEFAULT" }
 $script:Scope        = if ($env:DEVKIT_SCOPE) { $env:DEVKIT_SCOPE } else { "project" }
 $script:ScopeExplicit = [bool]$env:DEVKIT_SCOPE  # Track if scope was explicitly set
-# The MCP server is deprecated/optional — skills work via the Databricks CLI, so
-# MCP defaults OFF and is opt-in (-Mcp / --mcp / DEVKIT_INSTALL_MCP=true). When
-# opted in, the venv build is delegated to databricks-mcp-server/setup.ps1.
+# This installer sets up skills only. The (deprecated, optional) MCP server has
+# moved to its own installer: databricks-mcp-server\mcp_install.ps1.
 $script:InstallSkills = $true
-$script:InstallMcp   = ($env:DEVKIT_INSTALL_MCP -in @("true", "1"))
 $script:Force        = ($env:DEVKIT_FORCE -in @("true", "1"))
 $script:Silent       = ($env:DEVKIT_SILENT -in @("true", "1"))
 $script:UserTools    = if ($env:DEVKIT_TOOLS) { $env:DEVKIT_TOOLS } else { "" }
 $script:Tools        = ""
-$script:UserMcpPath  = if ($env:DEVKIT_MCP_PATH) { $env:DEVKIT_MCP_PATH } else { "" }
 $script:ProfileProvided = [bool]$env:DEVKIT_PROFILE
 $script:SkillsProfile = if ($env:DEVKIT_SKILLS_PROFILE) { $env:DEVKIT_SKILLS_PROFILE } else { "" }
 $script:UserSkills   = if ($env:DEVKIT_SKILLS) { $env:DEVKIT_SKILLS } else { "" }
@@ -92,9 +88,6 @@ $script:AssumeYes    = $false
 # Pass --experimental false (or DEVKIT_EXPERIMENTAL=false) for stable only.
 # Explicit --skills requests are always honored as named.
 $script:InstallExperimental = ($env:DEVKIT_EXPERIMENTAL -notin @("false", "0"))
-
-# -McpPath / DEVKIT_MCP_PATH implies opting into the MCP server
-if ($script:UserMcpPath) { $script:InstallMcp = $true }
 
 # Raw-fetch ref override for MLflow skills (mlflow/skills is tagless -- main is intentional)
 $script:MlflowRef = if ($env:MLFLOW_REF) { $env:MLFLOW_REF } else { "main" }
@@ -323,10 +316,10 @@ while ($i -lt $args.Count) {
         { $_ -in "-b", "--branch", "-Branch" } { $Branch = $args[$i + 1]; $script:BranchExplicit = $true; $RawUrl = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"; $i += 2 }
         { $_ -in "-p", "--profile" }  { $script:Profile_ = $args[$i + 1]; $script:ProfileProvided = $true; $i += 2 }
         { $_ -in "-g", "--global", "-Global" }  { $script:Scope = "global"; $script:ScopeExplicit = $true; $i++ }
-        { $_ -in "--skills-only", "-SkillsOnly" } { $script:InstallMcp = $false; $i++ }
-        { $_ -in "--mcp", "-Mcp" }              { $script:InstallMcp = $true; $i++ }
-        { $_ -in "--mcp-only", "-McpOnly" }    { $script:InstallSkills = $false; $script:InstallMcp = $true; $i++ }
-        { $_ -in "--mcp-path", "-McpPath" }    { $script:UserMcpPath = $args[$i + 1]; $script:InstallMcp = $true; $i += 2 }
+        { $_ -in "--skills-only", "-SkillsOnly" } { $i++ }  # accepted for backward compat (skills-only is now the only mode)
+        { $_ -in "--mcp", "-Mcp", "--mcp-only", "-McpOnly", "--mcp-path", "-McpPath" } {
+            Write-Err "The MCP server has moved to its own installer. Run: .\databricks-mcp-server\mcp_install.ps1 (or mcp_install.sh on macOS/Linux)."
+        }
         { $_ -in "--silent", "-Silent" }       { $script:Silent = $true; $i++ }
         { $_ -in "--tools", "-Tools" }         { $script:UserTools = $args[$i + 1]; $i += 2 }
         { $_ -in "--skills-profile", "-SkillsProfile" } { $script:SkillsProfile = $args[$i + 1]; $i += 2 }
@@ -353,10 +346,6 @@ while ($i -lt $args.Count) {
             Write-Host "  -b, --branch NAME     Install a specific release/branch (runs that version's own installer)"
             Write-Host "  -p, --profile NAME    Databricks profile (default: DEFAULT)"
             Write-Host "  -g, --global          Install globally for all projects"
-            Write-Host "  --skills-only         Install skills only (default; MCP server is opt-in)"
-            Write-Host "  --mcp                 Install the deprecated MCP server (default: no)"
-            Write-Host "  --mcp-only            Install the MCP server only, skip skills"
-            Write-Host "  --mcp-path PATH       MCP server install path (implies --mcp)"
             Write-Host "  --silent              Silent mode (no output except errors)"
             Write-Host "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
             Write-Host "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
@@ -365,7 +354,7 @@ while ($i -lt $args.Count) {
             Write-Host "  --experimental BOOL   Include experimental agent skills (default: true; 'false' = stable only)"
             Write-Host "  --dry-run             Print what would be installed (resolved refs, aitools command) and exit"
             Write-Host "  -f, --force           Force reinstall"
-            Write-Host "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, MCP config, and Claude Code plugin"
+            Write-Host "  --uninstall           Remove AI Dev Kit: skills, Claude Code plugin, and any leftover MCP config from older installs"
             Write-Host "  --dry-run             With --uninstall: print what would be removed, change nothing"
             Write-Host "  -y, --yes             With --uninstall: skip the confirmation prompt"
             Write-Host "  -h, --help            Show this help"
@@ -373,8 +362,7 @@ while ($i -lt $args.Count) {
             Write-Host "Environment Variables:"
             Write-Host "  AIDEVKIT_BRANCH       Branch or tag to install (alias: DEVKIT_BRANCH; default: latest release)"
             Write-Host "  AIDEVKIT_HOME         Installation directory (default: ~/.ai-dev-kit)"
-            Write-Host "  DEVKIT_INSTALL_MCP    Set to 'true' to install the deprecated MCP server (default: false)"
-            Write-Host "  DEVKIT_PROFILE/SCOPE/TOOLS/SKILLS/SKILLS_PROFILE/MCP_PATH/FORCE/SILENT  (mirror the bash installer)"
+            Write-Host "  DEVKIT_PROFILE/SCOPE/TOOLS/SKILLS/SKILLS_PROFILE/FORCE/SILENT  (mirror the bash installer)"
             Write-Host "  DEVKIT_EXPERIMENTAL   'true' (default) or 'false' to skip experimental agent skills"
             Write-Host "  MLFLOW_REF            Ref for MLflow skills fetch (default: main)"
             Write-Host "  DRY_RUN               Set to '1' to print the install plan and exit"
@@ -382,7 +370,8 @@ while ($i -lt $args.Count) {
             Write-Host "Notes:"
             Write-Host "  Most Databricks skills are installed via 'databricks aitools' (Databricks CLI v1.0.0+)"
             Write-Host "  and are updated/uninstalled with 'databricks aitools update|uninstall', not this script."
-            Write-Host "  The MCP server is deprecated/optional — skills work without it. Opt in with --mcp."
+            Write-Host "  The MCP server is deprecated/optional and has its own installer:"
+            Write-Host "  .\databricks-mcp-server\mcp_install.ps1 (or mcp_install.sh on macOS/Linux)."
             Write-Host "  Renamed skills: databricks-bundles -> databricks-dabs,"
             Write-Host "  databricks-spark-declarative-pipelines -> databricks-pipelines."
             Write-Host "  Replaced skills: databricks-config -> databricks-core,"
@@ -494,7 +483,7 @@ function Get-ProjectLeftoversSummary {
 # Global/user-scope artifacts (what a --global uninstall removes).
 function Get-GlobalLeftoversSummary {
     $h = $env:USERPROFILE
-    $installDir = if ($script:UserMcpPath) { $script:UserMcpPath } elseif ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $h ".ai-dev-kit" }
+    $installDir = if ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $h ".ai-dev-kit" }
     $skillRoots = @(".claude\skills",".cursor\skills",".github\skills",".agents\skills",".gemini\skills",".gemini\antigravity\skills",".codeium\windsurf\skills",".config\opencode\skills",".kiro\skills") | ForEach-Object { Join-Path $h $_ }
     $mcpTargets = @(
         @{ Path=(Join-Path $h ".claude.json"); Kind="json"; Top="mcpServers" }, @{ Path=(Join-Path $h ".codex\config.toml"); Kind="toml" }, @{ Path=(Join-Path $h ".gemini\settings.json"); Kind="json"; Top="mcpServers" },
@@ -634,8 +623,7 @@ function Remove-ClaudeHook {
 function Invoke-Uninstall {
     $home_ = $env:USERPROFILE
     if ($script:Scope -eq "global") { $baseDir = $home_ } else { $baseDir = (Get-Location).Path }
-    $installDir = if ($script:UserMcpPath) { $script:UserMcpPath }
-                  elseif ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME }
+    $installDir = if ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME }
                   else { Join-Path $home_ ".ai-dev-kit" }
     if ($script:Scope -eq "global") { $stateDir = $installDir } else { $stateDir = Join-Path $baseDir ".ai-dev-kit" }
 
@@ -694,7 +682,7 @@ function Invoke-Uninstall {
     foreach ($h in $hookTargets) {
         if ((Test-Path $h) -and (Select-String -Path $h -Pattern 'check_update' -Quiet)) { $planHooks += $h }
     }
-    if ($script:Scope -eq "global" -or $script:UserMcpPath) {
+    if ($script:Scope -eq "global") {
         if (Test-Path $installDir) { $planRuntime += $installDir }
     }
     # On a global uninstall $stateDir IS the runtime dir; when that dir is already in
@@ -1212,31 +1200,6 @@ function Invoke-PromptProfile {
     }
 }
 
-# ─── MCP path selection (deprecated/optional MCP server) ───────
-# Skills work via the Databricks CLI, so the MCP server is opt-in only -- there is
-# no interactive opt-in prompt. This runs solely when the user passed -Mcp /
-# -McpOnly / -McpPath / DEVKIT_INSTALL_MCP to choose where the runtime lands.
-function Invoke-PromptMcpPath {
-    if (-not [string]::IsNullOrWhiteSpace($script:UserMcpPath)) {
-        $script:InstallDir = $script:UserMcpPath
-    } elseif (-not $script:Silent) {
-        Write-Host ""
-        Write-Host "  MCP server location" -ForegroundColor White
-        Write-Host "  The MCP server runtime (Python venv + source) will be installed here." -ForegroundColor DarkGray
-        Write-Host "  Shared across all your projects -- only the config files are per-project." -ForegroundColor DarkGray
-        Write-Host ""
-
-        $selected = Read-Prompt -PromptText "Install path" -Default $InstallDir
-        $script:InstallDir = $selected
-    }
-
-    # Update derived paths
-    $script:RepoDir    = Join-Path $script:InstallDir "repo"
-    $script:VenvDir    = Join-Path $script:InstallDir ".venv"
-    $script:VenvPython = Join-Path $script:VenvDir "Scripts\python.exe"
-    $script:McpEntry   = Join-Path $script:RepoDir "databricks-mcp-server\run_server.py"
-}
-
 # ─── Check prerequisites ─────────────────────────────────────
 function Test-Dependencies {
     # Git
@@ -1268,8 +1231,8 @@ function Test-Dependencies {
         Write-Msg "You can still install, but authentication will require the CLI later."
     }
 
-    # The MCP server's Python environment (and its uv/pip requirement) is built
-    # by databricks-mcp-server/setup.ps1 when the user opts in — not here.
+    # The (deprecated, optional) MCP server has its own installer
+    # (databricks-mcp-server\mcp_install.ps1); this installer sets up skills only.
 }
 
 # ─── Check version ───────────────────────────────────────────
@@ -1310,59 +1273,6 @@ function Test-Version {
             exit 0
         }
     }
-}
-
-# ─── Clone repo sources ──────────────────────────────────────
-# Needed for bundled skills and the MCP server setup script. Idempotent.
-function Get-RepoSources {
-    $prevEAP = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
-
-    if (Test-Path (Join-Path $script:RepoDir ".git")) {
-        & git -C $script:RepoDir fetch -q --depth 1 origin $Branch 2>&1 | Out-Null
-        & git -C $script:RepoDir reset --hard FETCH_HEAD 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Remove-Item -Recurse -Force $script:RepoDir -ErrorAction SilentlyContinue
-            & git -c advice.detachedHead=false clone -q --depth 1 --branch $Branch $RepoUrl $script:RepoDir 2>&1 | Out-Null
-        }
-    } else {
-        if (-not (Test-Path $script:InstallDir)) {
-            New-Item -ItemType Directory -Path $script:InstallDir -Force | Out-Null
-        }
-        & git -c advice.detachedHead=false clone -q --depth 1 --branch $Branch $RepoUrl $script:RepoDir 2>&1 | Out-Null
-    }
-    if ($LASTEXITCODE -ne 0) {
-        $ErrorActionPreference = $prevEAP
-        Write-Err "Failed to clone repository"
-    }
-    $ErrorActionPreference = $prevEAP
-    Write-Ok "Repository cloned ($Branch)"
-}
-
-# ─── Setup MCP server (deprecated, opt-in) ───────────────────
-# Delegates the venv build to databricks-mcp-server/setup.ps1 — the single
-# source of truth for the Python environment — so the installer doesn't
-# duplicate venv/pip logic here.
-function Install-McpServer {
-    Write-Step "Setting up MCP server"
-    Get-RepoSources
-
-    $setupScript = Join-Path $script:RepoDir "databricks-mcp-server\setup.ps1"
-    if (-not (Test-Path $setupScript)) {
-        Write-Err "MCP setup script not found at $setupScript"
-    }
-
-    Write-Msg "Building MCP server environment (databricks-mcp-server/setup.ps1)..."
-    $setupArgs = @("-VenvDir", $script:VenvDir)
-    if ($script:Silent) { $setupArgs += "-Quiet" }
-
-    $prevEAP = $ErrorActionPreference
-    $ErrorActionPreference = "Continue"
-    & $setupScript @setupArgs
-    $setupOk = ($LASTEXITCODE -eq 0)
-    $ErrorActionPreference = $prevEAP
-    if (-not $setupOk) { Write-Err "MCP server setup failed" }
-    Write-Ok "MCP server ready"
 }
 
 # ─── Skill profile selection ──────────────────────────────────
@@ -2615,151 +2525,6 @@ function Install-Skills {
     }
 }
 
-# ─── Write MCP configs ───────────────────────────────────────
-# Write/merge an MCP server entry into a JSON config.
-#   -Path     target config file
-#   -RootKey  top-level key: "mcpServers" (Claude/Cursor/Gemini/Windsurf/Kiro)
-#             or "servers" (Copilot)
-#   -Defer    include Claude's defer_loading hint
-# Replaces the old Write-McpJson / Write-CopilotMcpJson / Write-GeminiMcpJson
-# trio, which differed only in those two parameters. Merging is decoupled from
-# whether the venv exists yet, so an existing config is never clobbered.
-function Write-McpJsonConfig {
-    param([string]$Path, [string]$RootKey, [bool]$Defer)
-
-    $dir = Split-Path $Path -Parent
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    # Backup existing
-    if (Test-Path $Path) {
-        Copy-Item $Path "$Path.bak" -Force
-        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
-    }
-
-    # Try to merge with existing config (independent of whether the venv exists)
-    $existing = $null
-    if (Test-Path $Path) {
-        try { $existing = Get-Content $Path -Raw | ConvertFrom-Json } catch { $existing = $null }
-    }
-
-    # Use forward slashes for cross-platform JSON compatibility
-    $pythonPath = $script:VenvPython -replace '\\', '/'
-    $entryPath  = $script:McpEntry -replace '\\', '/'
-
-    if ($existing) {
-        if (-not $existing.$RootKey) {
-            $existing | Add-Member -NotePropertyName $RootKey -NotePropertyValue ([PSCustomObject]@{}) -Force
-        }
-        $dbProps = [ordered]@{ command = $pythonPath; args = @($entryPath) }
-        if ($Defer) { $dbProps.defer_loading = $true }
-        $dbProps.env = [PSCustomObject]@{ DATABRICKS_CONFIG_PROFILE = $script:Profile_ }
-        $existing.$RootKey | Add-Member -NotePropertyName "databricks" -NotePropertyValue ([PSCustomObject]$dbProps) -Force
-        $existing | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
-    } else {
-        $deferLine = if ($Defer) { "`n      `"defer_loading`": true," } else { "" }
-        $json = @"
-{
-  "$RootKey": {
-    "databricks": {
-      "command": "$pythonPath",
-      "args": ["$entryPath"],$deferLine
-      "env": {"DATABRICKS_CONFIG_PROFILE": "$($script:Profile_)"}
-    }
-  }
-}
-"@
-        Set-Content -Path $Path -Value $json -Encoding UTF8
-    }
-}
-
-function Write-McpToml {
-    param([string]$Path)
-
-    $dir = Split-Path $Path -Parent
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    # Check if already configured
-    if (Test-Path $Path) {
-        $content = Get-Content $Path -Raw
-        if ($content -match 'mcp_servers\.databricks') { return }
-        Copy-Item $Path "$Path.bak" -Force
-        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
-    }
-
-    $pythonPath = $script:VenvPython -replace '\\', '/'
-    $entryPath  = $script:McpEntry -replace '\\', '/'
-    $tomlBlock = @"
-
-[mcp_servers.databricks]
-command = "$pythonPath"
-args = ["$entryPath"]
-"@
-    Add-Content -Path $Path -Value $tomlBlock -Encoding UTF8
-}
-
-function Write-OpenCodeJson {
-    param([string]$Path)
-
-    $dir = Split-Path $Path -Parent
-    if (-not (Test-Path $dir)) {
-        New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    }
-
-    # Backup existing
-    if (Test-Path $Path) {
-        Copy-Item $Path "$Path.bak" -Force
-        Write-Msg "Backed up $(Split-Path $Path -Leaf) -> $(Split-Path $Path -Leaf).bak"
-    }
-
-    # Try to merge with existing config
-    $existing = $null
-    if ((Test-Path $Path) -and (Test-Path $script:VenvPython)) {
-        try {
-            $existing = Get-Content $Path -Raw | ConvertFrom-Json
-        } catch {
-            $existing = $null
-        }
-    }
-
-    if ($existing) {
-        if (-not $existing.'$schema') {
-            $existing | Add-Member -NotePropertyName '$schema' -NotePropertyValue 'https://opencode.ai/config.json' -Force
-        }
-        if (-not $existing.mcp) {
-            $existing | Add-Member -NotePropertyName "mcp" -NotePropertyValue ([PSCustomObject]@{}) -Force
-        }
-        $dbEntry = [PSCustomObject]@{
-            type        = "local"
-            command     = @($script:VenvPython -replace '\\', '/', $script:McpEntry -replace '\\', '/')
-            environment = [PSCustomObject]@{ DATABRICKS_CONFIG_PROFILE = $script:Profile_ }
-            enabled     = $true
-        }
-        $existing.mcp | Add-Member -NotePropertyName "databricks" -NotePropertyValue $dbEntry -Force
-        $existing | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
-    } else {
-        $pythonPath = $script:VenvPython -replace '\\', '/'
-        $entryPath  = $script:McpEntry -replace '\\', '/'
-        $json = @"
-{
-  "`$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "databricks": {
-      "type": "local",
-      "command": ["$pythonPath", "$entryPath"],
-      "environment": {"DATABRICKS_CONFIG_PROFILE": "$($script:Profile_)"},
-      "enabled": true
-    }
-  }
-}
-"@
-        Set-Content -Path $Path -Value $json -Encoding UTF8
-    }
-}
-
 function Write-GeminiMd {
     param([string]$Path)
 
@@ -2768,17 +2533,7 @@ function Write-GeminiMd {
     $content = @"
 # Databricks AI Dev Kit
 
-You have access to Databricks skills and MCP tools installed by the Databricks AI Dev Kit.
-
-## Available MCP Tools
-
-The ``databricks`` MCP server provides 50+ tools for interacting with Databricks, including:
-- SQL execution and warehouse management
-- Unity Catalog operations (tables, volumes, schemas)
-- Jobs and workflow management
-- Model serving endpoints
-- Genie spaces and AI/BI dashboards
-- Databricks Apps deployment
+You have access to Databricks skills installed by the Databricks AI Dev Kit.
 
 ## Available Skills
 
@@ -2790,161 +2545,9 @@ Skills are installed in ``.gemini/skills/`` and provide patterns and best practi
 - Model Serving, Vector Search
 - Databricks Apps
 - And more
-
-## Getting Started
-
-Try asking: "List my SQL warehouses" or "Show my Unity Catalog schemas"
 "@
     Set-Content -Path $Path -Value $content -Encoding UTF8
     Write-Ok "GEMINI.md"
-}
-
-# Merge a SessionStart version-check hook into a Claude settings.json (parity
-# with the bash installer's write_claude_hook). The command runs check_update.sh
-# via bash; forward slashes keep it working under Git Bash on Windows.
-function Write-ClaudeHook {
-    param([string]$Path, [string]$Script)
-
-    $dir = Split-Path $Path -Parent
-    if (-not (Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-
-    $cmd = "bash " + ($Script -replace '\\', '/')
-
-    $cfg = $null
-    if (Test-Path $Path) {
-        try { $cfg = Get-Content $Path -Raw | ConvertFrom-Json } catch { $cfg = $null }
-    }
-    if (-not $cfg) { $cfg = [PSCustomObject]@{} }
-
-    if (-not $cfg.hooks) {
-        $cfg | Add-Member -NotePropertyName "hooks" -NotePropertyValue ([PSCustomObject]@{}) -Force
-    }
-    if (-not $cfg.hooks.SessionStart) {
-        $cfg.hooks | Add-Member -NotePropertyName "SessionStart" -NotePropertyValue @() -Force
-    }
-
-    # Already configured? (look for an existing check_update.sh hook)
-    foreach ($group in @($cfg.hooks.SessionStart)) {
-        foreach ($h in @($group.hooks)) {
-            if ($h.command -and ($h.command -match 'check_update\.sh')) { return }
-        }
-    }
-
-    $hookEntry = [PSCustomObject]@{ type = "command"; command = $cmd; timeout = 5 }
-    $cfg.hooks.SessionStart = @($cfg.hooks.SessionStart) + [PSCustomObject]@{ hooks = @($hookEntry) }
-    $cfg | ConvertTo-Json -Depth 10 | Set-Content $Path -Encoding UTF8
-}
-
-function Write-McpConfigs {
-    param([string]$BaseDir)
-
-    Write-Step "Configuring MCP"
-
-    foreach ($tool in ($script:Tools -split ' ')) {
-        switch ($tool) {
-            "claude" {
-                # Global config lives in ~/.claude.json (the file Claude Code reads),
-                # matching the bash installer.
-                if ($script:Scope -eq "global") {
-                    Write-McpJsonConfig (Join-Path $env:USERPROFILE ".claude.json") "mcpServers" $true
-                } else {
-                    Write-McpJsonConfig (Join-Path $BaseDir ".mcp.json") "mcpServers" $true
-                }
-                Write-Ok "Claude MCP config"
-                # Add the version-check SessionStart hook (parity with bash)
-                $checkScript = Join-Path $script:RepoDir ".claude-plugin\check_update.sh"
-                if ($script:Scope -eq "global") {
-                    Write-ClaudeHook (Join-Path $env:USERPROFILE ".claude\settings.json") $checkScript
-                } else {
-                    Write-ClaudeHook (Join-Path $BaseDir ".claude\settings.json") $checkScript
-                }
-                Write-Ok "Claude update check hook"
-            }
-            "cursor" {
-                if ($script:Scope -eq "global") {
-                    Write-Warn "Cursor global: manual MCP configuration required"
-                    Write-Msg "  1. Open Cursor -> Settings -> Cursor Settings -> Tools & MCP"
-                    Write-Msg "  2. Click New MCP Server"
-                    Write-Msg "  3. Add the following JSON config:"
-                    Write-Msg "     {"
-                    Write-Msg "       `"mcpServers`": {"
-                    Write-Msg "         `"databricks`": {"
-                    Write-Msg "           `"command`": `"$($script:VenvPython)`","
-                    Write-Msg "           `"args`": [`"$($script:McpEntry)`"],"
-                    Write-Msg "           `"env`": {`"DATABRICKS_CONFIG_PROFILE`": `"$($script:Profile_)`"}"
-                    Write-Msg "         }"
-                    Write-Msg "       }"
-                    Write-Msg "     }"
-                } else {
-                    Write-McpJsonConfig (Join-Path $BaseDir ".cursor\mcp.json") "mcpServers" $true
-                    Write-Ok "Cursor MCP config"
-                }
-                Write-Warn "Cursor: MCP servers are disabled by default."
-                Write-Msg "  Enable in: Cursor -> Settings -> Cursor Settings -> Tools & MCP -> Toggle 'databricks'"
-            }
-            "copilot" {
-                if ($script:Scope -eq "global") {
-                    Write-Warn "Copilot global: configure MCP in VS Code settings (Ctrl+Shift+P -> 'MCP: Open User Configuration')"
-                    Write-Msg "  Command: $($script:VenvPython) | Args: $($script:McpEntry)"
-                } else {
-                    Write-McpJsonConfig (Join-Path $BaseDir ".vscode\mcp.json") "servers" $false
-                    Write-Ok "Copilot MCP config (.vscode/mcp.json)"
-                }
-                Write-Warn "Copilot: MCP servers must be enabled manually."
-                Write-Msg "  In Copilot Chat, click 'Configure Tools' (tool icon, bottom-right) and enable 'databricks'"
-            }
-            "codex" {
-                if ($script:Scope -eq "global") {
-                    Write-McpToml (Join-Path $env:USERPROFILE ".codex\config.toml")
-                } else {
-                    Write-McpToml (Join-Path $BaseDir ".codex\config.toml")
-                }
-                Write-Ok "Codex MCP config"
-            }
-            "gemini" {
-                if ($script:Scope -eq "global") {
-                    Write-McpJsonConfig (Join-Path $env:USERPROFILE ".gemini\settings.json") "mcpServers" $false
-                } else {
-                    Write-McpJsonConfig (Join-Path $BaseDir ".gemini\settings.json") "mcpServers" $false
-                }
-                Write-Ok "Gemini CLI MCP config"
-            }
-            "antigravity" {
-                if ($script:Scope -eq "project") {
-                    Write-Warn "Antigravity only supports global MCP configuration."
-                    Write-Msg "  Config written to ~/.gemini/antigravity/mcp_config.json"
-                }
-                Write-McpJsonConfig (Join-Path $env:USERPROFILE ".gemini\antigravity\mcp_config.json") "mcpServers" $false
-                Write-Ok "Antigravity MCP config"
-            }
-            "windsurf" {
-                if ($script:Scope -eq "project") {
-                    Write-Warn "Windsurf only supports global MCP configuration."
-                    Write-Msg "  Config written to ~/.codeium/windsurf/mcp_config.json"
-                }
-                Write-McpJsonConfig (Join-Path $env:USERPROFILE ".codeium\windsurf\mcp_config.json") "mcpServers" $true
-                Write-Ok "Windsurf MCP config"
-            }
-            "opencode" {
-                if ($script:Scope -eq "global") {
-                    Write-OpenCodeJson (Join-Path $env:USERPROFILE ".config\opencode\opencode.json")
-                } else {
-                    Write-OpenCodeJson (Join-Path $BaseDir "opencode.json")
-                }
-                Write-Ok "OpenCode MCP config"
-            }
-            "kiro" {
-                if ($script:Scope -eq "global") {
-                    $kiroSettings = Join-Path $env:USERPROFILE ".kiro\settings"
-                } else {
-                    $kiroSettings = Join-Path $BaseDir ".kiro\settings"
-                }
-                if (-not (Test-Path $kiroSettings)) { New-Item -ItemType Directory -Path $kiroSettings -Force | Out-Null }
-                Write-McpJsonConfig (Join-Path $kiroSettings "mcp.json") "mcpServers" $true
-                Write-Ok "Kiro MCP config"
-            }
-        }
-    }
 }
 
 # ─── Save version ────────────────────────────────────────────
@@ -2956,8 +2559,7 @@ function Save-Version {
     }
     if ($ver -match '(404|Not Found|error)') { $ver = "dev" }
 
-    # $script:InstallDir is only created during MCP setup; a skills-only run never
-    # clones, so ensure it exists before writing the version file.
+    # Ensure the install dir exists before writing the version file.
     if (-not (Test-Path $script:InstallDir)) {
         New-Item -ItemType Directory -Path $script:InstallDir -Force | Out-Null
     }
@@ -2988,15 +2590,7 @@ function Show-Summary {
     Write-Host ""
     Write-Msg "Next steps:"
     $step = 1
-    if ($script:InstallMcp -and ($script:Tools -match 'cursor')) {
-        Write-Msg "$step. Enable MCP in Cursor: Cursor -> Settings -> Cursor Settings -> Tools & MCP -> Toggle 'databricks'"
-        $step++
-    }
     if ($script:Tools -match 'copilot') {
-        if ($script:InstallMcp) {
-            Write-Msg "$step. In Copilot Chat, click 'Configure Tools' (tool icon, bottom-right) and enable 'databricks'"
-            $step++
-        }
         Write-Msg "$step. Use Copilot in Agent mode to access Databricks skills"
         $step++
     }
@@ -3005,11 +2599,7 @@ function Show-Summary {
         $step++
     }
     if ($script:Tools -match 'antigravity') {
-        Write-Msg "$step. Open your project in Antigravity to use Databricks skills and MCP tools"
-        $step++
-    }
-    if ($script:InstallMcp -and ($script:Tools -match 'windsurf')) {
-        Write-Msg "$step. Restart Windsurf to pick up the databricks MCP server (Windsurf -> Settings -> Windsurf Settings -> MCP)"
+        Write-Msg "$step. Open your project in Antigravity to use Databricks skills"
         $step++
     }
     if ($script:Tools -match 'opencode') {
@@ -3017,7 +2607,7 @@ function Show-Summary {
         $step++
     }
     if ($script:Tools -match 'kiro') {
-        Write-Msg "$step. Open your project in Kiro to use Databricks skills and MCP tools"
+        Write-Msg "$step. Open your project in Kiro to use Databricks skills"
         $step++
     }
     Write-Msg "$step. Open your project in your tool of choice"
@@ -3290,14 +2880,6 @@ function Invoke-Main {
         }
     }
 
-    # MCP path (only when explicitly opted in via -Mcp/-McpOnly/-McpPath/DEVKIT_INSTALL_MCP).
-    # The interactive MCP opt-in prompt was removed -- the MCP server is a
-    # deprecated/optional component (see the end-of-install note).
-    if ($script:InstallMcp) {
-        Invoke-PromptMcpPath
-        Write-Ok "MCP path: $($script:InstallDir)"
-    }
-
     # Confirmation summary
     if (-not $script:Silent) {
         Write-Host ""
@@ -3306,9 +2888,6 @@ function Invoke-Main {
         Write-Host "  Tools:       " -NoNewline; Write-Host "$(($script:Tools -split ' ') -join ', ')" -ForegroundColor Green
         Write-Host "  Profile:     " -NoNewline; Write-Host $script:Profile_ -ForegroundColor Green
         Write-Host "  Scope:       " -NoNewline; Write-Host $script:Scope -ForegroundColor Green
-        if ($script:InstallMcp) {
-            Write-Host "  MCP server:  " -NoNewline; Write-Host $script:InstallDir -ForegroundColor Green
-        }
         if ($script:InstallSkills) {
             $skTotal = $script:SelectedMlflowSkills.Count + $script:SelectedAgentBSkills.Count
             if (-not [string]::IsNullOrWhiteSpace($script:UserSkills)) {
@@ -3331,9 +2910,6 @@ function Invoke-Main {
                 Write-Host "excluded" -ForegroundColor Yellow -NoNewline
                 Write-Host " (--experimental false)" -ForegroundColor DarkGray
             }
-        }
-        if ($script:InstallMcp) {
-            Write-Host "  MCP config:  " -NoNewline; Write-Host "yes" -ForegroundColor Green
         }
         Write-Host ""
     }
@@ -3363,11 +2939,6 @@ function Invoke-Main {
         $baseDir = (Get-Location).Path
     }
 
-    # Setup MCP server (opt-in). The repo is only needed for the MCP server now.
-    if ($script:InstallMcp) {
-        Install-McpServer
-    }
-
     # Install skills managed by this installer (MLflow)
     if ($script:InstallSkills) {
         Install-Skills -BaseDir $baseDir
@@ -3386,11 +2957,6 @@ function Invoke-Main {
         } else {
             Write-GeminiMd (Join-Path $baseDir "GEMINI.md")
         }
-    }
-
-    # Write MCP configs
-    if ($script:InstallMcp) {
-        Write-McpConfigs -BaseDir $baseDir
     }
 
     # Save version

--- a/install.sh
+++ b/install.sh
@@ -169,6 +169,12 @@ warn() { [ "$SILENT" = true ] || echo -e "  ${Y}!${N} $*"; }
 die()  { echo -e "  ${R}✗${N} $*" >&2; exit 1; }  # Always show errors
 step() { [ "$SILENT" = true ] || echo -e "\n${B}$*${N}"; }
 
+# Deprecation notice for the removed MCP flags/env. Always printed to stderr
+# (even in silent mode) since the user explicitly passed a now-removed option.
+mcp_moved_notice() {
+    echo -e "  ${Y}!${N} MCP setup has moved out of this installer. Run databricks-mcp-server/mcp_install.sh (or mcp_install.ps1 on Windows) to install and register the Databricks MCP server." >&2
+}
+
 # Deprecation notice — shown on every install/upgrade while skills still ship
 # from this repo. The next major release installs skills via the Databricks CLI
 # from the official databricks/databricks-agent-skills set.
@@ -191,8 +197,14 @@ while [ $# -gt 0 ]; do
         -g|--global)      SCOPE="global"; SCOPE_EXPLICIT=true; shift ;;
         -b|--branch)      BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
         --skills-only)    shift ;;  # accepted for backward compat (skills-only is now the only mode)
-        --mcp|--mcp-only|--mcp-path)
-            die "The MCP server has moved to its own installer. Run: bash databricks-mcp-server/mcp_install.sh (or mcp_install.ps1 on Windows)." ;;
+        # Removed MCP flags — handled gracefully. --mcp warns and continues with
+        # the normal (skills-only) install; --mcp-path also consumes its value so
+        # arg-parsing doesn't choke on the now-unknown argument.
+        --mcp)            mcp_moved_notice; shift ;;
+        --mcp-path)       mcp_moved_notice; shift; [ $# -gt 0 ] && shift || true ;;
+        # --mcp-only had no non-MCP work to do, so just point the user and exit
+        # cleanly (informative, not a crash).
+        --mcp-only)       mcp_moved_notice; exit 0 ;;
         --skills-profile) SKILLS_PROFILE="$2"; shift 2 ;;
         --skills)         USER_SKILLS="$2"; shift 2 ;;
         --list-skills)    LIST_SKILLS=true; shift ;;
@@ -262,6 +274,11 @@ while [ $# -gt 0 ]; do
         *) die "Unknown option: $1 (use -h for help)" ;;
     esac
 done
+
+# Removed MCP env var — warn and continue with the normal (skills-only) install.
+if [ "${DEVKIT_INSTALL_MCP:-}" = "true" ] || [ "${DEVKIT_INSTALL_MCP:-}" = "1" ]; then
+    mcp_moved_notice
+fi
 
 # ─── --list-skills handler ─────────────────────────────────────
 # (function — needs fetch_agent_b_inventory; invoked after function definitions below)

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,11 @@
 #
 # Databricks AI Dev Kit - Unified Installer
 #
-# Installs skills, MCP server, and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+# Installs Databricks skills and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.
+#
+# The (deprecated, optional) MCP server has its own installer:
+#   databricks-mcp-server/mcp_install.sh   (macOS/Linux)
+#   databricks-mcp-server/mcp_install.ps1  (Windows)
 #
 # Usage: bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) [OPTIONS]
 #
@@ -18,9 +22,6 @@
 #
 #   # Install for specific tools only
 #   bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --tools cursor,codex,copilot,gemini
-#
-#   # Skills only (skip MCP server)
-#   bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --skills-only
 #
 #   # Install skills for a specific profile
 #   bash <(curl -sL https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/main/install.sh) --skills-profile data-engineer
@@ -53,7 +54,6 @@ ASSUME_YES=false
 SILENT="${DEVKIT_SILENT:-false}"
 TOOLS="${DEVKIT_TOOLS:-}"
 USER_TOOLS=""
-USER_MCP_PATH="${DEVKIT_MCP_PATH:-}"
 SKILLS_PROFILE="${DEVKIT_SKILLS_PROFILE:-}"
 USER_SKILLS="${DEVKIT_SKILLS:-}"
 DRY_RUN="${DRY_RUN:-false}"
@@ -97,17 +97,14 @@ else
   [ -z "$BRANCH" ] && BRANCH="main"
 fi
 
-# Installation mode defaults. The MCP server is deprecated/optional — skills
-# now work directly via the Databricks CLI, so MCP defaults OFF and is opt-in
-# (--mcp / --mcp-path / DEVKIT_INSTALL_MCP=true). When opted in, the venv build
-# is delegated to databricks-mcp-server/setup.sh.
+# Installation mode. This installer sets up skills only. The (deprecated,
+# optional) MCP server has moved to its own installer:
+#   databricks-mcp-server/mcp_install.sh   (macOS/Linux)
+#   databricks-mcp-server/mcp_install.ps1  (Windows)
 INSTALL_SKILLS=true
-INSTALL_MCP="${DEVKIT_INSTALL_MCP:-false}"
-[ "$INSTALL_MCP" = "true" ] || [ "$INSTALL_MCP" = "1" ] && INSTALL_MCP=true || INSTALL_MCP=false
 
 # Minimum required versions
 MIN_CLI_VERSION="0.278.0"
-# (MCP server SDK minimum is enforced by databricks-mcp-server/setup.sh)
 # Agent skills are delegated to `databricks aitools`, which ships with CLI v1.0.0+
 MIN_AITOOLS_CLI_VERSION="1.0.0"
 
@@ -193,10 +190,9 @@ while [ $# -gt 0 ]; do
         -p|--profile)     PROFILE="$2"; shift 2 ;;
         -g|--global)      SCOPE="global"; SCOPE_EXPLICIT=true; shift ;;
         -b|--branch)      BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
-        --skills-only)    INSTALL_MCP=false; shift ;;
-        --mcp-only)       INSTALL_SKILLS=false; INSTALL_MCP=true; shift ;;
-        --mcp)            INSTALL_MCP=true; shift ;;
-        --mcp-path)       USER_MCP_PATH="$2"; INSTALL_MCP=true; shift 2 ;;
+        --skills-only)    shift ;;  # accepted for backward compat (skills-only is now the only mode)
+        --mcp|--mcp-only|--mcp-path)
+            die "The MCP server has moved to its own installer. Run: bash databricks-mcp-server/mcp_install.sh (or mcp_install.ps1 on Windows)." ;;
         --skills-profile) SKILLS_PROFILE="$2"; shift 2 ;;
         --skills)         USER_SKILLS="$2"; shift 2 ;;
         --list-skills)    LIST_SKILLS=true; shift ;;
@@ -221,10 +217,6 @@ while [ $# -gt 0 ]; do
             echo "  -p, --profile NAME    Databricks profile (default: DEFAULT)"
             echo "  -b, --branch NAME     Install a specific release/branch (runs that version's own installer)"
             echo "  -g, --global          Install globally for all projects"
-            echo "  --skills-only         Install skills only (default; MCP server is opt-in)"
-            echo "  --mcp                 Install the deprecated MCP server (default: no)"
-            echo "  --mcp-only            Install the MCP server only, skip skills"
-            echo "  --mcp-path PATH       MCP server install path (implies --mcp; default: ~/.ai-dev-kit)"
             echo "  --silent              Silent mode (no output except errors)"
             echo "  --tools LIST          Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
             echo "  --skills-profile LIST Comma-separated profiles: all,data-engineer,analyst,ai-ml-engineer,app-developer"
@@ -233,7 +225,7 @@ while [ $# -gt 0 ]; do
             echo "  --experimental BOOL   Include experimental agent skills (default: true; 'false' = stable only)"
             echo "  --dry-run             Print what would be installed (resolved refs, aitools command) and exit"
             echo "  -f, --force           Force reinstall"
-            echo "  --uninstall           Remove AI Dev Kit: skills, MCP server runtime, MCP config, and Claude Code plugin"
+            echo "  --uninstall           Remove AI Dev Kit: skills, Claude Code plugin, and any leftover MCP config from older installs"
             echo "  --dry-run             With --uninstall: print what would be removed, change nothing"
             echo "  -y, --yes             With --uninstall: skip the confirmation prompt"
             echo "  -h, --help            Show this help"
@@ -241,11 +233,9 @@ while [ $# -gt 0 ]; do
             echo "Environment Variables (alternative to flags):"
             echo "  DEVKIT_PROFILE        Databricks config profile"
             echo "  DEVKIT_BRANCH         Git branch/tag to install (alias: AIDEVKIT_BRANCH; default: latest release)"
-            echo "  DEVKIT_INSTALL_MCP    Set to 'true' to install the deprecated MCP server (default: false)"
             echo "  DEVKIT_SCOPE          'project' or 'global'"
             echo "  DEVKIT_TOOLS          Comma-separated list of tools"
             echo "  DEVKIT_FORCE          Set to 'true' to force reinstall"
-            echo "  DEVKIT_MCP_PATH       Path to MCP server installation"
             echo "  DEVKIT_SKILLS_PROFILE Comma-separated skill profiles"
             echo "  DEVKIT_SKILLS         Comma-separated skill names"
             echo "  DEVKIT_SILENT         Set to 'true' for silent mode"
@@ -257,7 +247,8 @@ while [ $# -gt 0 ]; do
             echo "Notes:"
             echo "  Most Databricks skills are installed via 'databricks aitools' (Databricks CLI v1.0.0+)"
             echo "  and are updated/uninstalled with 'databricks aitools update|uninstall', not this script."
-            echo "  The MCP server is deprecated/optional — skills work without it. Opt in with --mcp."
+            echo "  The MCP server is deprecated/optional and has its own installer:"
+            echo "  bash databricks-mcp-server/mcp_install.sh (or mcp_install.ps1 on Windows)."
             echo "  Renamed skills: databricks-bundles -> databricks-dabs,"
             echo "  databricks-spark-declarative-pipelines -> databricks-pipelines."
             echo "  Replaced skills: databricks-config -> databricks-core,"
@@ -655,7 +646,7 @@ run_uninstall() {
         # renders: "Remove from current directory ..." / "Remove from home directory ..."
     fi
     [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
-    install_dir="${USER_MCP_PATH:-${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}}"
+    install_dir="${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}"
     [ "$SCOPE" = "global" ] && state_dir="$install_dir" || state_dir="$base_dir/.ai-dev-kit"
     VENV_PYTHON="$install_dir/.venv/bin/python"
 
@@ -719,10 +710,10 @@ run_uninstall() {
     for path in "${hook_targets[@]}"; do
         [ -f "$path" ] && grep -q 'check_update.sh' "$path" 2>/dev/null && plan_hooks+=("$path")
     done
-    # The shared MCP runtime (~/.ai-dev-kit) is global; only remove it on a global
-    # uninstall, or when the user explicitly points --mcp-path at it. A project
-    # uninstall leaves it so other projects/global keep working.
-    if [ "$SCOPE" = "global" ] || [ -n "$USER_MCP_PATH" ]; then
+    # The shared MCP runtime (~/.ai-dev-kit) left by older installs is global; only
+    # remove it on a global uninstall. A project uninstall leaves it so other
+    # projects/global keep working.
+    if [ "$SCOPE" = "global" ]; then
         [ -d "$install_dir" ] && plan_runtime+=("$install_dir")
     fi
     # On a global uninstall state_dir IS the runtime dir; when that dir is already in
@@ -819,13 +810,12 @@ run_uninstall() {
 }
 
 # Set configuration URLs after parsing branch argument
-REPO_URL="https://github.com/databricks-solutions/ai-dev-kit.git"
 RAW_URL="https://raw.githubusercontent.com/databricks-solutions/ai-dev-kit/${BRANCH}"
 INSTALL_DIR="${AIDEVKIT_HOME:-$HOME/.ai-dev-kit}"
-REPO_DIR="$INSTALL_DIR/repo"
+# VENV_PYTHON is used by --uninstall as a fallback Python interpreter for safely
+# editing leftover JSON config from older installs that included the MCP server.
 VENV_DIR="$INSTALL_DIR/.venv"
 VENV_PYTHON="$VENV_DIR/bin/python"
-MCP_ENTRY="$REPO_DIR/databricks-mcp-server/run_server.py"
 
 # ─── Interactive helpers ────────────────────────────────────────
 # Reads from /dev/tty so prompts work even when piped via curl | bash
@@ -1241,35 +1231,6 @@ prompt_profile() {
         selected=$(prompt "Profile name" "DEFAULT")
         PROFILE="$selected"
     fi
-}
-
-# ─── MCP path selection (deprecated/optional MCP server) ───────
-# Skills work via the Databricks CLI, so the MCP server is opt-in only — there is
-# no interactive opt-in prompt. This runs solely when the user passed --mcp /
-# --mcp-only / --mcp-path / DEVKIT_INSTALL_MCP to choose where the runtime lands.
-prompt_mcp_path() {
-    # If provided via --mcp-path flag, skip prompt
-    if [ -n "$USER_MCP_PATH" ]; then
-        INSTALL_DIR="$USER_MCP_PATH"
-    elif [ "$SILENT" = false ] && is_interactive; then
-        [ "$SILENT" = false ] && echo ""
-        [ "$SILENT" = false ] && echo -e "  ${B}MCP server location${N}"
-        [ "$SILENT" = false ] && echo -e "  ${D}The MCP server runtime (Python venv + source) will be installed here.${N}"
-        [ "$SILENT" = false ] && echo -e "  ${D}Shared across all your projects — only the config files are per-project.${N}"
-        [ "$SILENT" = false ] && echo ""
-
-        local selected
-        selected=$(prompt "Install path" "$INSTALL_DIR")
-
-        # Expand ~ to $HOME
-        INSTALL_DIR="${selected/#\~/$HOME}"
-    fi
-
-    # Update derived paths
-    REPO_DIR="$INSTALL_DIR/repo"
-    VENV_DIR="$INSTALL_DIR/.venv"
-    VENV_PYTHON="$VENV_DIR/bin/python"
-    MCP_ENTRY="$REPO_DIR/databricks-mcp-server/run_server.py"
 }
 
 # ─── Skill profile selection ──────────────────────────────────
@@ -2292,17 +2253,6 @@ check_deps() {
         warn "Databricks CLI not found. Install: ${B}curl -fsSL https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh | sh${N}"
         msg "${D}You can still install, but authentication will require the CLI later.${N}"
     fi
-
-    if [ "$INSTALL_MCP" = true ]; then
-        if command -v uv >/dev/null 2>&1; then
-            PKG="uv"
-            ok "$PKG ($(uv --version 2>/dev/null || echo 'unknown version'))"
-        else
-            die "uv is required but not found on your PATH.
-   Install it with: ${B}curl -LsSf https://astral.sh/uv/install.sh | sh${N}
-   Then re-run this installer."
-        fi
-    fi
 }
 
 # Check if update needed
@@ -2338,41 +2288,6 @@ check_version() {
             exit 0
         fi
     fi
-}
-
-# Clone or update the repo sources into $REPO_DIR (needed for bundled skills
-# and the MCP server setup script). Idempotent.
-clone_repo() {
-    if [ -d "$REPO_DIR/.git" ]; then
-        git -C "$REPO_DIR" fetch -q --depth 1 origin "$BRANCH" 2>/dev/null || true
-        git -C "$REPO_DIR" reset --hard FETCH_HEAD 2>/dev/null || {
-            rm -rf "$REPO_DIR"
-            git -c advice.detachedHead=false clone -q --depth 1 --branch "$BRANCH" "$REPO_URL" "$REPO_DIR" \
-                || die "Could not clone branch '$BRANCH' from $REPO_URL — check your network and that the branch exists."
-        }
-    else
-        mkdir -p "$INSTALL_DIR"
-        git -c advice.detachedHead=false clone -q --depth 1 --branch "$BRANCH" "$REPO_URL" "$REPO_DIR" \
-            || die "Could not clone branch '$BRANCH' from $REPO_URL — check your network and that the branch exists."
-    fi
-    ok "Repository cloned ($BRANCH)"
-}
-
-# Setup the (deprecated, opt-in) MCP server by delegating the venv build to
-# databricks-mcp-server/setup.sh — that script is the single source of truth for
-# the Python environment, so the installer doesn't duplicate venv/pip logic here.
-setup_mcp() {
-    step "Setting up MCP server"
-    clone_repo
-
-    local setup_script="$REPO_DIR/databricks-mcp-server/setup.sh"
-    [ -f "$setup_script" ] || die "MCP setup script not found at $setup_script"
-
-    msg "Building MCP server environment (databricks-mcp-server/setup.sh)..."
-    local quiet_flag=""
-    [ "$SILENT" = true ] && quiet_flag="--quiet"
-    bash "$setup_script" --venv-dir "$VENV_DIR" $quiet_flag || die "MCP server setup failed"
-    ok "MCP server ready"
 }
 
 # Install skills
@@ -2499,143 +2414,13 @@ install_skills() {
     fi
 }
 
-# Write MCP configs
-# Write/merge an MCP server entry into a JSON config.
-#   $1 path        target config file
-#   $2 root_key    top-level key: "mcpServers" (Claude/Cursor/Gemini/Windsurf/Kiro)
-#                  or "servers" (Copilot)
-#   $3 defer       "true" to include Claude's defer_loading hint, else "false"
-# Replaces the old write_mcp_json / write_copilot_mcp_json / write_gemini_mcp_json
-# trio, which differed only in those two parameters.
-write_mcp_json_config() {
-    local path=$1 root_key=$2 defer=$3
-    mkdir -p "$(dirname "$path")"
-
-    # Backup existing file before any modifications
-    if [ -f "$path" ]; then
-        cp "$path" "${path}.bak"
-        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
-    fi
-
-    local defer_py="" defer_json=""
-    if [ "$defer" = "true" ]; then
-        defer_py="'defer_loading': True, "
-        defer_json='
-      "defer_loading": true,'
-    fi
-
-    if [ -f "$VENV_PYTHON" ]; then
-        "$VENV_PYTHON" -c "
-import json
-try:
-    with open('$path') as f: cfg = json.load(f)
-except: cfg = {}
-cfg.setdefault('$root_key', {})['databricks'] = {'command': '$VENV_PYTHON', 'args': ['$MCP_ENTRY'], ${defer_py}'env': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'}}
-with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
-" 2>/dev/null && return
-    fi
-
-    # Fallback: only safe for new files — refuse to overwrite existing files
-    # that may contain other settings (e.g. ~/.claude.json)
-    if [ -f "$path" ]; then
-        warn "Cannot merge MCP config into $path without Python. Add manually."
-        return
-    fi
-
-    cat > "$path" << EOF
-{
-  "$root_key": {
-    "databricks": {
-      "command": "$VENV_PYTHON",
-      "args": ["$MCP_ENTRY"],${defer_json}
-      "env": {"DATABRICKS_CONFIG_PROFILE": "$PROFILE"}
-    }
-  }
-}
-EOF
-}
-
-write_mcp_toml() {
-    local path=$1
-    mkdir -p "$(dirname "$path")"
-    grep -q "mcp_servers.databricks" "$path" 2>/dev/null && return
-    if [ -f "$path" ]; then
-        cp "$path" "${path}.bak"
-        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
-    fi
-    cat >> "$path" << EOF
-
-[mcp_servers.databricks]
-command = "$VENV_PYTHON"
-args = ["$MCP_ENTRY"]
-EOF
-}
-
-write_opencode_json() {
-    local path=$1
-    mkdir -p "$(dirname "$path")"
-
-    # Backup existing file before any modifications
-    if [ -f "$path" ]; then
-        cp "$path" "${path}.bak"
-        msg "${D}Backed up ${path##*/} → ${path##*/}.bak${N}"
-    fi
-
-    if [ -f "$VENV_PYTHON" ]; then
-        "$VENV_PYTHON" -c "
-import json
-try:
-    with open('$path') as f: cfg = json.load(f)
-except: cfg = {}
-cfg.setdefault('\$schema', 'https://opencode.ai/config.json')
-cfg.setdefault('mcp', {})['databricks'] = {
-    'type': 'local',
-    'command': ['$VENV_PYTHON', '$MCP_ENTRY'],
-    'environment': {'DATABRICKS_CONFIG_PROFILE': '$PROFILE'},
-    'enabled': True
-}
-with open('$path', 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
-" 2>/dev/null && return
-    fi
-
-    # Fallback: only safe for new files
-    if [ -f "$path" ]; then
-        warn "Cannot merge MCP config into $path without Python. Add manually."
-        return
-    fi
-
-    cat > "$path" << EOF
-{
-  "\$schema": "https://opencode.ai/config.json",
-  "mcp": {
-    "databricks": {
-      "type": "local",
-      "command": ["$VENV_PYTHON", "$MCP_ENTRY"],
-      "environment": {"DATABRICKS_CONFIG_PROFILE": "$PROFILE"},
-      "enabled": true
-    }
-  }
-}
-EOF
-}
-
 write_gemini_md() {
     local path=$1
     [ -f "$path" ] && return  # Don't overwrite existing file
     cat > "$path" << 'GEMINIEOF'
 # Databricks AI Dev Kit
 
-You have access to Databricks skills and MCP tools installed by the Databricks AI Dev Kit.
-
-## Available MCP Tools
-
-The `databricks` MCP server provides 50+ tools for interacting with Databricks, including:
-- SQL execution and warehouse management
-- Unity Catalog operations (tables, volumes, schemas)
-- Jobs and workflow management
-- Model serving endpoints
-- Genie spaces and AI/BI dashboards
-- Databricks Apps deployment
+You have access to Databricks skills installed by the Databricks AI Dev Kit.
 
 ## Available Skills
 
@@ -2655,164 +2440,13 @@ GEMINIEOF
     ok "GEMINI.md"
 }
 
-write_claude_hook() {
-    local path=$1
-    local script=$2
-    mkdir -p "$(dirname "$path")"
-
-    # Merge into existing settings.json if present, using Python for safe JSON handling
-    if [ -f "$path" ] && [ -f "$VENV_PYTHON" ]; then
-        "$VENV_PYTHON" -c "
-import json
-path = '$path'
-script = '$script'
-hook_entry = {'type': 'command', 'command': 'bash ' + script, 'timeout': 5}
-try:
-    with open(path) as f: cfg = json.load(f)
-except: cfg = {}
-hooks = cfg.setdefault('hooks', {})
-session_hooks = hooks.setdefault('SessionStart', [])
-# Check if hook already exists
-for group in session_hooks:
-    for h in group.get('hooks', []):
-        if 'check_update.sh' in h.get('command', ''):
-            exit(0)  # Already configured
-# Append new hook group
-session_hooks.append({'hooks': [hook_entry]})
-with open(path, 'w') as f: json.dump(cfg, f, indent=2); f.write('\n')
-" 2>/dev/null && return
-    fi
-
-    # Fallback: write new file (only if no existing file)
-    [ -f "$path" ] && return  # Don't overwrite existing settings without Python
-    cat > "$path" << EOF
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash $script",
-            "timeout": 5
-          }
-        ]
-      }
-    ]
-  }
-}
-EOF
-}
-
-write_mcp_configs() {
-    step "Configuring MCP"
-    
-    local base_dir=$1
-    for tool in $TOOLS; do
-        case $tool in
-            claude)
-                [ "$SCOPE" = "global" ] && write_mcp_json_config "$HOME/.claude.json" mcpServers true || write_mcp_json_config "$base_dir/.mcp.json" mcpServers true
-                ok "Claude MCP config"
-                # Add version check hook to Claude settings
-                local check_script="$REPO_DIR/.claude-plugin/check_update.sh"
-                if [ "$SCOPE" = "global" ]; then
-                    write_claude_hook "$HOME/.claude/settings.json" "$check_script"
-                else
-                    write_claude_hook "$base_dir/.claude/settings.json" "$check_script"
-                fi
-                ok "Claude update check hook"
-                ;;
-            cursor)
-                if [ "$SCOPE" = "global" ]; then
-                    warn "Cursor global: manual MCP configuration required"
-                    msg "  1. Open ${B}Cursor → Settings → Cursor Settings → Tools & MCP${N}"
-                    msg "  2. Click ${B}New MCP Server${N}"
-                    msg "  3. Add the following JSON config:"
-                    msg "     {"
-                    msg "       \"mcpServers\": {"
-                    msg "         \"databricks\": {"
-                    msg "           \"command\": \"$VENV_PYTHON\","
-                    msg "           \"args\": [\"$MCP_ENTRY\"],"
-                    msg "           \"env\": {\"DATABRICKS_CONFIG_PROFILE\": \"$PROFILE\"}"
-                    msg "         }"
-                    msg "       }"
-                    msg "     }"
-                else
-                    write_mcp_json_config "$base_dir/.cursor/mcp.json" mcpServers true
-                    ok "Cursor MCP config"
-                fi
-                warn "Cursor: MCP servers are disabled by default."
-                msg "  Enable in: ${B}Cursor → Settings → Cursor Settings → Tools & MCP → Toggle 'databricks'${N}"
-                ;;
-            copilot)
-                if [ "$SCOPE" = "global" ]; then
-                    warn "Copilot global: configure MCP in VS Code settings (Ctrl+Shift+P → 'MCP: Open User Configuration')"
-                    msg "  Command: $VENV_PYTHON | Args: $MCP_ENTRY"
-                else
-                    write_mcp_json_config "$base_dir/.vscode/mcp.json" servers false
-                    ok "Copilot MCP config (.vscode/mcp.json)"
-                fi
-                warn "Copilot: MCP servers must be enabled manually."
-                msg "  In Copilot Chat, click ${B}Configure Tools${N} (tool icon, bottom-right) and enable ${B}databricks${N}"
-                ;;
-            codex)
-                [ "$SCOPE" = "global" ] && write_mcp_toml "$HOME/.codex/config.toml" || write_mcp_toml "$base_dir/.codex/config.toml"
-                ok "Codex MCP config"
-                ;;
-            gemini)
-                if [ "$SCOPE" = "global" ]; then
-                    write_mcp_json_config "$HOME/.gemini/settings.json" mcpServers false
-                else
-                    write_mcp_json_config "$base_dir/.gemini/settings.json" mcpServers false
-                fi
-                ok "Gemini CLI MCP config"
-                ;;
-            antigravity)
-                if [ "$SCOPE" = "project" ]; then
-                    warn "Antigravity only supports global MCP configuration."
-                    msg "  Config written to ${B}~/.gemini/antigravity/mcp_config.json${N}"
-                fi
-                write_mcp_json_config "$HOME/.gemini/antigravity/mcp_config.json" mcpServers false
-                ok "Antigravity MCP config"
-                ;;
-            windsurf)
-                if [ "$SCOPE" = "project" ]; then
-                    warn "Windsurf only supports global MCP configuration."
-                    msg "  Config written to ${B}~/.codeium/windsurf/mcp_config.json${N}"
-                fi
-                write_mcp_json_config "$HOME/.codeium/windsurf/mcp_config.json" mcpServers true
-                ok "Windsurf MCP config"
-                ;;
-            opencode)
-                if [ "$SCOPE" = "global" ]; then
-                    write_opencode_json "$HOME/.config/opencode/opencode.json"
-                else
-                    write_opencode_json "$base_dir/opencode.json"
-                fi
-                ok "OpenCode MCP config"
-                ;;
-            kiro)
-                if [ "$SCOPE" = "global" ]; then
-                    mkdir -p "$HOME/.kiro/settings"
-                    write_mcp_json_config "$HOME/.kiro/settings/mcp.json" mcpServers true
-                else
-                    mkdir -p "$base_dir/.kiro/settings"
-                    write_mcp_json_config "$base_dir/.kiro/settings/mcp.json" mcpServers true
-                fi
-                ok "Kiro MCP config"
-                ;;
-        esac
-    done
-}
-
 # Save version
 save_version() {
     # Use -f to fail on HTTP errors (like 404)
     local ver=$(curl -fsSL "$RAW_URL/VERSION" 2>/dev/null || echo "dev")
     # Validate version format
     [[ "$ver" =~ (404|Not Found|error) ]] && ver="dev"
-    # $INSTALL_DIR is only created during MCP setup (clone_repo); a skills-only
-    # run never clones, so ensure it exists before writing the version file.
+    # Ensure the state dir exists before writing the version file.
     mkdir -p "$INSTALL_DIR"
     echo "$ver" > "$INSTALL_DIR/version"
     if [ "$SCOPE" = "project" ]; then
@@ -2836,15 +2470,7 @@ summary() {
         echo ""
         msg "${B}Next steps:${N}"
         local step=1
-        if [ "$INSTALL_MCP" = true ] && echo "$TOOLS" | grep -q cursor; then
-            msg "${R}${step}. Enable MCP in Cursor: ${B}Cursor → Settings → Cursor Settings → Tools & MCP → Toggle 'databricks'${N}"
-            step=$((step + 1))
-        fi
         if echo "$TOOLS" | grep -q copilot; then
-            if [ "$INSTALL_MCP" = true ]; then
-                msg "${step}. In Copilot Chat, click ${B}Configure Tools${N} (tool icon, bottom-right) and enable ${B}databricks${N}"
-                step=$((step + 1))
-            fi
             msg "${step}. Use Copilot in ${B}Agent mode${N} to access Databricks skills"
             step=$((step + 1))
         fi
@@ -2853,11 +2479,7 @@ summary() {
             step=$((step + 1))
         fi
         if echo "$TOOLS" | grep -q antigravity; then
-            msg "${step}. Open your project in Antigravity to use Databricks skills and MCP tools"
-            step=$((step + 1))
-        fi
-        if [ "$INSTALL_MCP" = true ] && echo "$TOOLS" | grep -q windsurf; then
-            msg "${step}. Restart Windsurf to pick up the ${B}databricks${N} MCP server (Windsurf → Settings → Windsurf Settings → MCP)"
+            msg "${step}. Open your project in Antigravity to use Databricks skills"
             step=$((step + 1))
         fi
         if echo "$TOOLS" | grep -q opencode; then
@@ -2865,7 +2487,7 @@ summary() {
             step=$((step + 1))
         fi
         if echo "$TOOLS" | grep -q kiro; then
-            msg "${step}. Open your project in Kiro to use Databricks skills and MCP tools"
+            msg "${step}. Open your project in Kiro to use Databricks skills"
             step=$((step + 1))
         fi
         msg "${step}. Open your project in your tool of choice"
@@ -3146,15 +2768,7 @@ main() {
         fi
     fi
 
-    # ── Step 5: MCP path (only when explicitly opted in via --mcp/--mcp-only/
-    # --mcp-path/DEVKIT_INSTALL_MCP). The interactive MCP opt-in prompt was removed —
-    # the MCP server is a deprecated/optional component (see the end-of-install note). ──
-    if [ "$INSTALL_MCP" = true ]; then
-        prompt_mcp_path
-        ok "MCP path: $INSTALL_DIR"
-    fi
-
-    # ── Step 6: Confirm before proceeding ──
+    # ── Step 5: Confirm before proceeding ──
     if [ "$SILENT" = false ]; then
         echo ""
         echo -e "  ${B}Summary${N}"
@@ -3162,7 +2776,6 @@ main() {
         echo -e "  Tools:       ${G}$(echo "$TOOLS" | tr ' ' ', ')${N}"
         echo -e "  Profile:     ${G}${PROFILE}${N}"
         echo -e "  Scope:       ${G}${SCOPE}${N}"
-        [ "$INSTALL_MCP" = true ]    && echo -e "  MCP server:  ${G}${INSTALL_DIR}${N}"
         if [ "$INSTALL_SKILLS" = true ]; then
             if [ -n "$USER_SKILLS" ]; then
                 echo -e "  Skills:      ${G}custom selection${N} ${Y}(will be overwritten, backup your changes first)${N}"
@@ -3174,7 +2787,6 @@ main() {
             [ -n "$SELECTED_AGENT_B_SKILLS" ] && echo -e "  Agent skills: ${G}via databricks aitools${N} ${D}(requires Databricks CLI v${MIN_AITOOLS_CLI_VERSION}+)${N}"
             [ "$INSTALL_EXPERIMENTAL" = false ] && echo -e "  Experimental: ${Y}excluded${N} ${D}(--experimental false)${N}"
         fi
-        [ "$INSTALL_MCP" = true ]    && echo -e "  MCP config:  ${G}yes${N}"
         echo ""
     fi
 
@@ -3194,17 +2806,12 @@ main() {
         fi
     fi
 
-    # ── Step 7: Version check (may exit early if up to date) ──
+    # ── Step 6: Version check (may exit early if up to date) ──
     check_version
-    
+
     # Determine base directory
     local base_dir
     [ "$SCOPE" = "global" ] && base_dir="$HOME" || base_dir="$(pwd)"
-    
-    # Setup MCP server (opt-in). The repo is only needed for the MCP server now.
-    if [ "$INSTALL_MCP" = true ]; then
-        setup_mcp
-    fi
 
     # Install skills managed by this installer (MLflow)
     [ "$INSTALL_SKILLS" = true ] && install_skills "$base_dir"
@@ -3224,9 +2831,6 @@ main() {
         fi
     fi
 
-    # Write MCP configs
-    [ "$INSTALL_MCP" = true ] && write_mcp_configs "$base_dir"
-    
     # Save version
     save_version
     


### PR DESCRIPTION
## Summary

Splits the MCP server installation out of the unified `install.sh` / `install.ps1` into dedicated, self-contained installers, leaving the top-level installers to handle **skills only**.

### New: `databricks-mcp-server/mcp_install.sh` and `mcp_install.ps1`
- Full MCP-client registration ported from the old `install.sh`/`install.ps1` MCP path.
- **Delegate the venv build** to `setup.sh` / `setup.ps1` (via `--venv-dir` / `-VenvDir`) — those files are the single source of truth for the runtime and are **unchanged**.
- Register with all **9 clients**, each preserving its exact config shape / root key / format:
  - Claude Code — `.mcp.json` (project) / `~/.claude.json` (global), root `mcpServers`
  - Cursor — `.cursor/mcp.json`, root `mcpServers`
  - GitHub Copilot — `.vscode/mcp.json`, root `servers`
  - OpenAI Codex — `.codex/config.toml`, `[mcp_servers.databricks]`
  - Gemini CLI — `.gemini/settings.json`, root `mcpServers`
  - Antigravity — `~/.gemini/antigravity/mcp_config.json`, root `mcpServers`
  - Windsurf — `~/.codeium/windsurf/mcp_config.json`, root `mcpServers`
  - OpenCode — `opencode.json` / `~/.config/opencode/opencode.json`, root `mcp`
  - Kiro — `.kiro/settings/mcp.json`, root `mcpServers`
- Every client — **including Codex** (fixing the old `install.sh`, which omitted it) — gets `"env": {"DATABRICKS_CONFIG_PROFILE": "<profile>"}`. **No host or token is ever written.**
- Prompt for scope + client selection + Databricks profile; absolute paths computed from `SCRIPT_DIR`.
- Safe merge with `.bak` backup, idempotent, symmetric `--uninstall` / `-Uninstall`, and the client post-hints (Cursor enable, Copilot Configure Tools, Windsurf restart).

### Changed: `install.sh` / `install.ps1` — MCP removed
- Dropped `--mcp` / `--mcp-only` / `--mcp-path` flags, `DEVKIT_INSTALL_MCP` / `DEVKIT_MCP_PATH` env, `INSTALL_MCP` gating, and all MCP-only helpers (`setup_mcp`, `clone_repo`, the `write_mcp_*` / `Write-Mcp*` config writers, `Write-ClaudeHook`).
- Help / summary / next-steps text cleaned; a pointer to `databricks-mcp-server/mcp_install.sh` (`.ps1`) added.
- **Uninstall keeps its MCP cleanup** so registrations from older `install.sh --mcp` runs can still be removed.

### Docs
- `databricks-mcp-server/README.md` Step 3 now recommends `mcp_install.sh`/`.ps1` and keeps the manual snippet as a fallback, with the `DATABRICKS_CONFIG_PROFILE` env block added.

## Gates
- `bash -n install.sh` ✅ and `bash -n databricks-mcp-server/mcp_install.sh` ✅
- `shellcheck -S warning`: install.sh warning count unchanged vs HEAD (11 → 11, all pre-existing/shared code); `mcp_install.sh` clean.
- `git diff HEAD -- databricks-mcp-server/setup.sh setup.ps1` → **empty** (unchanged).
- **pwsh not available locally** — PowerShell parse gate could not be run; `install.ps1` / `mcp_install.ps1` verified by inspection and grep sweep (zero dangling `$script:InstallMcp` / `Invoke-PromptMcpPath` / `Install-McpServer` / `Write-McpConfigs` / `$RepoUrl` / `$McpEntry` references).

## Notes / decisions
- The `check_update.sh` SessionStart hook was transitively MCP-only (it lived under the cloned repo dir populated only by `setup_mcp`), so `write_claude_hook` / `Write-ClaudeHook` were removed from the skills-only path.
- Uninstall MCP cleanup deliberately retained — flagged above.

This pull request and its description were written by Isaac.