### PR TITLE
Fix deploy status check: successful deploys fell into the failure branch

### DIFF
--- a/databricks-builder-app/scripts/deploy.sh
+++ b/databricks-builder-app/scripts/deploy.sh
@@ -392,17 +392,46 @@ echo ""
 # Step 8: Deploy the app
 # ─────────────────────────────────────────────────────────────────────────────
 echo -e "${YELLOW}[8/${TOTAL_STEPS}] Deploying app...${NC}"
-DEPLOY_OUTPUT=$(databricks apps deploy "$APP_NAME" --source-code-path "$WORKSPACE_PATH" $CLI_ARGS 2>&1)
+# Capture stdout (JSON) only; progress/spinner output stays on stderr so it does
+# not pollute the JSON we parse below.
+DEPLOY_RC=0
+DEPLOY_OUTPUT=$(databricks apps deploy "$APP_NAME" --source-code-path "$WORKSPACE_PATH" $CLI_ARGS --output json) || DEPLOY_RC=$?
 echo "$DEPLOY_OUTPUT"
 
-DEPLOY_STATE=$(echo "$DEPLOY_OUTPUT" | python3 -c "
+DEPLOY_STATE=""
+DEPLOY_PARSE_ERROR=""
+if [ -n "$DEPLOY_OUTPUT" ]; then
+  DEPLOY_STATE=$(printf '%s' "$DEPLOY_OUTPUT" | python3 -c '
 import sys, json
+raw = sys.stdin.read()
 try:
-    data = json.load(sys.stdin)
-    print(data.get('status', {}).get('state', ''))
-except Exception:
-    print('')
-" 2>/dev/null || echo "")
+    data = json.loads(raw)
+except ValueError as exc:
+    sys.stderr.write("deploy output is not valid JSON: %s\n" % exc)
+    sys.exit(1)
+if not isinstance(data, dict):
+    sys.stderr.write("deploy output is not a JSON object\n")
+    sys.exit(1)
+print(data.get("status", {}).get("state", ""))
+' 2>&1) || { DEPLOY_PARSE_ERROR="$DEPLOY_STATE"; DEPLOY_STATE=""; }
+fi
+
+if [ "$DEPLOY_RC" -ne 0 ]; then
+  echo ""
+  echo -e "${RED}Deployment failed: 'databricks apps deploy' exited with status ${DEPLOY_RC}.${NC}"
+  echo -e "  Deploy output: ${DEPLOY_OUTPUT:-<empty>}"
+  echo -e "  Check logs with: databricks apps logs ${APP_NAME} ${CLI_ARGS}"
+  exit 1
+elif [ -z "$DEPLOY_STATE" ]; then
+  # The CLI reported success but we could not read a state — do not claim success,
+  # and do not hide why the state could not be determined.
+  echo ""
+  echo -e "${YELLOW}⚠${NC} Deploy command succeeded but the deployment state could not be determined."
+  [ -n "$DEPLOY_PARSE_ERROR" ] && echo -e "  Reason: ${DEPLOY_PARSE_ERROR}"
+  echo -e "  Deploy output: ${DEPLOY_OUTPUT:-<empty>}"
+  echo -e "  Verify with: databricks apps get ${APP_NAME} ${CLI_ARGS} --output json"
+  exit 1
+fi
 
 if [ "$DEPLOY_STATE" = "SUCCEEDED" ]; then
   echo ""
@@ -444,7 +473,8 @@ for obj in objects:
   echo ""
 else
   echo ""
-  echo -e "${RED}Deployment may have issues. Check the output above.${NC}"
+  echo -e "${RED}Deployment did not succeed (state: ${DEPLOY_STATE}).${NC}"
+  echo -e "  Deploy output: ${DEPLOY_OUTPUT:-<empty>}"
   echo -e "  Check logs with: databricks apps logs ${APP_NAME} ${CLI_ARGS}"
   exit 1
 fi


### PR DESCRIPTION
Addresses the blocking cross-review finding on #576.

## Bug

In `databricks-builder-app/scripts/deploy.sh` (step 8, the deploy status check), the output of `databricks apps deploy` was parsed with python3 `json.load()`, but the command never passed `--output json`. The CLI (v1.9.0) defaults to `text` output, so `json.load()` raised on every run, the bare `except` printed `''`, and `DEPLOY_STATE` never equalled `SUCCEEDED`.

Result: **a successful deploy fell into the failure branch** — the success banner never printed, the old-deployment cleanup never ran, and the script exited 1.

Two problems compounded it:

- `2>&1` merged progress/spinner output into the captured stream, so even valid JSON would have been polluted.
- The parse error was swallowed twice (`except: print('')` plus `2>/dev/null || echo ""`), making a real deploy failure indistinguishable from a parse failure.

## Fix

- Pass `--output json` to `databricks apps deploy`, mirroring the existing `databricks apps get ... --output json` call further down in the same script.
- Capture **stdout only** (no `2>&1`), so stderr progress output goes to the terminal instead of into the JSON being parsed.
- Surface errors instead of hiding them. Three distinct outcomes now report clearly and include the actual deploy output:
  - non-zero CLI exit -> `Deployment failed: ... exited with status N`
  - output present but state unreadable -> `state could not be determined` plus the parse reason
  - state present but not `SUCCEEDED` -> `Deployment did not succeed (state: X)`
- A genuine `SUCCEEDED` deploy now reaches the success path (banner + old-deployment cleanup).

Change is scoped to the status-check block; no unrelated refactoring.

## Verification

- `bash -n databricks-builder-app/scripts/deploy.sh` — syntax OK.
- `shellcheck databricks-builder-app/scripts/deploy.sh` — 17 findings before and after, identical; no new warnings introduced. The one note on a changed line (SC2086, unquoted `$CLI_ARGS`) is pre-existing and matches the script-wide pattern.
- Exercised the extracted parse/branch logic against: `SUCCEEDED` JSON (-> success path, exit 0), `FAILED` JSON, plain-text output (the old bug scenario), non-zero CLI exit, a JSON array, and JSON missing `status` — every failure case exits non-zero with a specific message.

This pull request and its description were written by Isaac.