### PR TITLE
Move MCP server venv default to repo root

### DIFF
--- a/databricks-mcp-server/mcp_install.ps1
+++ b/databricks-mcp-server/mcp_install.ps1
@@ -16,7 +16,7 @@
 #   -Profile NAME     Databricks config profile to inject (default: DEFAULT)
 #   -Global           Register globally (home dir) instead of per-project
 #   -Tools LIST       Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro
-#   -VenvDir DIR      Virtual environment location (default: <this dir>\.venv)
+#   -VenvDir DIR      Virtual environment location (default: <repo root>\.venv)
 #   -SkipVenv         Skip the setup.ps1 venv build (assume it already exists)
 #   -Silent           Silent mode (no output except errors)
 #   -Uninstall        Remove only the 'databricks' MCP entry from each client config
@@ -51,6 +51,7 @@ $ErrorActionPreference = "Stop"
 # unified installer's clone-to-~\.ai-dev-kit flow — paths derive from here, the
 # same way setup.ps1 does.
 $script:ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$script:ParentDir = Split-Path -Parent $script:ScriptDir
 $script:McpEntry  = Join-Path $script:ScriptDir "run_server.py"
 
 # ─── Defaults (env vars mirror the bash installer) ──────────────
@@ -72,7 +73,7 @@ else                 { $script:UserTools = "" }
 $script:Tools = ""
 
 if ($VenvDir)        { $script:VenvDir = $VenvDir }
-else                 { $script:VenvDir = Join-Path $script:ScriptDir ".venv" }
+else                 { $script:VenvDir = Join-Path $script:ParentDir ".venv" }
 
 $script:SkipVenv   = [bool]$SkipVenv
 $script:Uninstall  = [bool]$Uninstall
@@ -91,7 +92,7 @@ if ($Help) {
     Write-Host "  -Profile NAME     Databricks config profile to inject (default: DEFAULT)"
     Write-Host "  -Global           Register globally (home dir) instead of per-project"
     Write-Host "  -Tools LIST       Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
-    Write-Host "  -VenvDir DIR      Virtual environment location (default: <this dir>\.venv)"
+    Write-Host "  -VenvDir DIR      Virtual environment location (default: <repo root>\.venv)"
     Write-Host "  -SkipVenv         Skip the setup.ps1 venv build (assume it already exists)"
     Write-Host "  -Silent           Silent mode (no output except errors)"
     Write-Host "  -Uninstall        Remove only the 'databricks' MCP entry from each client config"

--- a/databricks-mcp-server/mcp_install.sh
+++ b/databricks-mcp-server/mcp_install.sh
@@ -17,7 +17,7 @@
 #   -p, --profile NAME   Databricks config profile to inject (default: DEFAULT)
 #   -g, --global         Register globally (home dir) instead of per-project
 #   --tools LIST         Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro
-#   --venv-dir DIR       Virtual environment location (default: <this dir>/.venv)
+#   --venv-dir DIR       Virtual environment location (default: <repo root>/.venv)
 #   --skip-venv          Skip the setup.sh venv build (assume it already exists)
 #   --silent             Silent mode (no output except errors)
 #   --uninstall          Remove only the 'databricks' MCP entry from each client config
@@ -39,6 +39,7 @@ set -e
 # unified installer's clone-to-~/.ai-dev-kit flow — paths derive from here, the
 # same way setup.sh does.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 MCP_ENTRY="$SCRIPT_DIR/run_server.py"
 
 # Defaults (can be overridden by environment variables or command-line arguments)
@@ -48,7 +49,7 @@ SCOPE_EXPLICIT=false
 SILENT="${DEVKIT_SILENT:-false}"
 TOOLS="${DEVKIT_TOOLS:-}"
 USER_TOOLS=""
-VENV_DIR="$SCRIPT_DIR/.venv"
+VENV_DIR="$PARENT_DIR/.venv"
 SKIP_VENV=false
 UNINSTALL=false
 DRY_RUN=false
@@ -91,7 +92,7 @@ while [ $# -gt 0 ]; do
             echo "  -p, --profile NAME   Databricks config profile to inject (default: DEFAULT)"
             echo "  -g, --global         Register globally (home dir) instead of per-project"
             echo "  --tools LIST         Comma-separated: claude,cursor,copilot,codex,gemini,antigravity,windsurf,opencode,kiro"
-            echo "  --venv-dir DIR       Virtual environment location (default: <this dir>/.venv)"
+            echo "  --venv-dir DIR       Virtual environment location (default: <repo root>/.venv)"
             echo "  --skip-venv          Skip the setup.sh venv build (assume it already exists)"
             echo "  --silent             Silent mode (no output except errors)"
             echo "  --uninstall          Remove only the 'databricks' MCP entry from each client config"

--- a/databricks-mcp-server/setup.ps1
+++ b/databricks-mcp-server/setup.ps1
@@ -13,7 +13,7 @@
 #   .\databricks-mcp-server\setup.ps1 [OPTIONS]
 #
 # Options:
-#   -VenvDir DIR   Location for the virtual environment (default: <this dir>\.venv)
+#   -VenvDir DIR   Location for the virtual environment (default: <repo root>\.venv)
 #   -Python VER    Python version to request from uv (default: 3.11)
 #   -Quiet         Suppress progress output (errors still print)
 #   -Help          Show this help
@@ -26,7 +26,9 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ParentDir = Split-Path -Parent $ScriptDir
 $ToolsCoreDir = Join-Path $ParentDir "databricks-tools-core"
 
-$VenvDir = Join-Path $ScriptDir ".venv"
+# The venv lives at the repo root (the parent of this directory), matching the
+# paths the README documents. -VenvDir overrides this.
+$VenvDir = Join-Path $ParentDir ".venv"
 $PythonVersion = "3.11"
 $Quiet = $false
 
@@ -41,7 +43,7 @@ while ($i -lt $args.Count) {
             Write-Host ""
             Write-Host "Usage: .\databricks-mcp-server\setup.ps1 [OPTIONS]"
             Write-Host ""
-            Write-Host "  -VenvDir DIR   Virtual environment location (default: <script dir>\.venv)"
+            Write-Host "  -VenvDir DIR   Virtual environment location (default: <repo root>\.venv)"
             Write-Host "  -Python VER    Python version for uv (default: 3.11)"
             Write-Host "  -Quiet         Suppress progress output"
             Write-Host "  -Help          Show this help"

--- a/databricks-mcp-server/setup.sh
+++ b/databricks-mcp-server/setup.sh
@@ -15,7 +15,7 @@
 #   bash databricks-mcp-server/setup.sh [OPTIONS]
 #
 # Options:
-#   --venv-dir DIR   Location for the virtual environment (default: <this dir>/.venv)
+#   --venv-dir DIR   Location for the virtual environment (default: <repo root>/.venv)
 #   --python VER     Python version to request from uv (default: 3.11)
 #   --quiet          Suppress progress output (errors still print)
 #   -h, --help       Show this help
@@ -28,7 +28,9 @@ PARENT_DIR="$(dirname "${SCRIPT_DIR}")"
 TOOLS_CORE_DIR="${PARENT_DIR}/databricks-tools-core"
 
 # Defaults
-VENV_DIR="${SCRIPT_DIR}/.venv"
+# The venv lives at the repo root (the parent of this directory), matching the
+# paths the README documents. --venv-dir overrides this.
+VENV_DIR="${PARENT_DIR}/.venv"
 PYTHON_VERSION="3.11"
 QUIET=false
 
@@ -45,7 +47,7 @@ while [ $# -gt 0 ]; do
             echo ""
             echo "Usage: bash databricks-mcp-server/setup.sh [OPTIONS]"
             echo ""
-            echo "  --venv-dir DIR   Virtual environment location (default: <script dir>/.venv)"
+            echo "  --venv-dir DIR   Virtual environment location (default: <repo root>/.venv)"
             echo "  --python VER     Python version for uv (default: 3.11)"
             echo "  --quiet          Suppress progress output"
             echo "  -h, --help       Show this help"


### PR DESCRIPTION
## Summary
- Default MCP server venv paths to the repo root `.venv` instead of `databricks-mcp-server/.venv`.
- Preserve explicit `--venv-dir` / `-VenvDir` overrides and mcp_install-to-setup pass-through.
- Keep MCP entry paths derived from script locations, not the current working directory.

## Validation
- `bash -n databricks-mcp-server/setup.sh` PASS
- `bash -n databricks-mcp-server/mcp_install.sh` PASS
- `shellcheck -S warning databricks-mcp-server/setup.sh databricks-mcp-server/mcp_install.sh` PASS
- `shellcheck databricks-mcp-server/setup.sh databricks-mcp-server/mcp_install.sh` reports baseline style/info findings in `mcp_install.sh` also present on `install-from-databricks-agent-skills`
- `pwsh` parse SKIPPED: `pwsh` not installed
- grep for stale script-dir venv defaults PASS
- `git diff --check` PASS
