### PR TITLE
Remove dead code from install.sh and install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -55,10 +55,6 @@ if ($env:AIDEVKIT_BRANCH -or $env:DEVKIT_BRANCH) {
 
 $RawUrl    = "https://raw.githubusercontent.com/$Owner/$Repo/$Branch"
 $InstallDir = if ($env:AIDEVKIT_HOME) { $env:AIDEVKIT_HOME } else { Join-Path $env:USERPROFILE ".ai-dev-kit" }
-# $VenvPython is used by -Uninstall as a fallback Python interpreter for safely
-# editing leftover JSON config from older installs that included the MCP server.
-$VenvDir   = Join-Path $InstallDir ".venv"
-$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
 
 # Minimum required versions
 $MinCliVersion = "0.278.0"
@@ -300,22 +296,6 @@ function Show-McpMovedNotice {
     [Console]::Error.WriteLine("  ! MCP setup has moved out of this installer. Run databricks-mcp-server\mcp_install.ps1 (or mcp_install.sh on macOS/Linux) to install and register the Databricks MCP server.")
 }
 
-# Deprecation notice - shown on every install/upgrade while skills still ship
-# from this repo. The next major release installs skills via the Databricks CLI
-# from the official databricks/databricks-agent-skills set.
-function Show-DeprecationNotice {
-    if ($script:Silent) { return }
-    $bar = "  ------------------------------------------------------------"
-    Write-Host ""
-    Write-Host $bar -ForegroundColor Yellow
-    Write-Host "  !  Heads up: skills are moving" -ForegroundColor Yellow
-    Write-Host "  In the next release, the skills for AI Dev Kit will be" -ForegroundColor DarkGray
-    Write-Host "  promoted to a shared, engineering-supported repository." -ForegroundColor DarkGray
-    Write-Host "  In future releases, this installer will set up skills" -ForegroundColor DarkGray
-    Write-Host "  using the Databricks CLI." -ForegroundColor DarkGray
-    Write-Host $bar -ForegroundColor Yellow
-}
-
 # ─── Parse arguments ─────────────────────────────────────────
 $i = 0
 while ($i -lt $args.Count) {
@@ -401,7 +381,7 @@ while ($i -lt $args.Count) {
             Write-Host "  .\install.ps1 -Profile DEFAULT -Force"
             return
         }
-        default { Write-Err "Unknown option: $($args[$i]) (use -h for help)"; $i++ }
+        default { Write-Err "Unknown option: $($args[$i]) (use -h for help)" }
     }
 }
 
@@ -879,7 +859,6 @@ function Select-Checkbox {
     $drawCheckbox = {
         [Console]::SetCursorPosition(0, [Math]::Max(0, [Console]::CursorTop - $totalRows))
         for ($j = 0; $j -lt $count; $j++) {
-            $line = "  "
             if ($j -eq $cursor) {
                 Write-Host "  " -NoNewline
                 Write-Host ">" -ForegroundColor Blue -NoNewline

--- a/install.sh
+++ b/install.sh
@@ -175,21 +175,6 @@ mcp_moved_notice() {
     echo -e "  ${Y}!${N} MCP setup has moved out of this installer. Run databricks-mcp-server/mcp_install.sh (or mcp_install.ps1 on Windows) to install and register the Databricks MCP server." >&2
 }
 
-# Deprecation notice — shown on every install/upgrade while skills still ship
-# from this repo. The next major release installs skills via the Databricks CLI
-# from the official databricks/databricks-agent-skills set.
-deprecation_notice() {
-    [ "$SILENT" = true ] && return
-    echo ""
-    echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
-    echo -e "  ${Y}${B}⚠  Heads up: skills are moving${N}"
-    echo -e "  ${D}In the next release, the skills for AI Dev Kit will be${N}"
-    echo -e "  ${D}promoted to a shared, engineering-supported repository.${N}"
-    echo -e "  ${D}In future releases, this installer will set up skills${N}"
-    echo -e "  ${D}using the Databricks CLI.${N}"
-    echo -e "  ${Y}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${N}"
-}
-
 # Parse arguments
 while [ $# -gt 0 ]; do
     case $1 in


### PR DESCRIPTION
Pure cleanup of confirmed dead/unreachable/vestigial code in the two top-level installer scripts. No behavior change — every deletion was verified to have zero reachable call sites or reads.

## Deleted

| File | Symbol | Why it's dead |
|---|---|---|
| `install.sh` | `deprecation_notice()` | Zero call sites. The "skills are moving" announcement has already shipped and is being retired, so the call was not restored. |
| `install.ps1` | `Show-DeprecationNotice` | Zero call sites, same reason. |
| `install.ps1` | `$VenvDir` / `$VenvPython` block | Never read. The venv now lives in `databricks-mcp-server/mcp_install.ps1`, and `Invoke-Uninstall` edits JSON via `ConvertFrom-Json`/`ConvertTo-Json` rather than shelling out to a Python interpreter. |
| `install.ps1` | `$line = "  "` in `$drawCheckbox` | Assigned, never read. |
| `install.ps1` | `$i++` after `Write-Err` in the arg-parse `default` arm | Unreachable — `Write-Err` ends in `exit 1`. |

The bash `VENV_PYTHON` is genuinely live (read at three call sites) and was deliberately left in place — only the PowerShell counterpart was dead.

## Explicitly left untouched

- All MCP deprecation shims: `Show-McpMovedNotice` / `mcp_moved_notice` and the `--mcp` / `-Mcp`, `--mcp-path` / `-McpPath`, `--mcp-only` / `-McpOnly`, and `DEVKIT_INSTALL_MCP` arms — reachable, they warn and point at `mcp_install`.
- The `--skills-only` / `-SkillsOnly` arm despite its empty body — load-bearing, since removing it would make the flag fall through to the error/exit path.
- The `$AgentBExcluded` / `AGENT_B_EXCLUDED` empty-array knob and its no-op loops — a documented deliberate knob.
- The uninstall MCP-cleanup helpers (`Test-McpJsonHasDatabricks`, `Remove-McpJsonKey`, `Remove-McpTomlBlock`) and their `mcpTargets`/`planMcp` plumbing.
- `$script:InstallSkills` always-true const — cosmetic, out of scope.

## Gates

- `bash -n install.sh` — passes.
- `shellcheck install.sh` — 49 findings before, 49 after, and the normalized finding set is byte-identical (`diff` clean). No new warnings.
- `install.ps1` parse check — **not run: no PowerShell binary is installed on the machine used for this change** (`pwsh`, `powershell`, and the usual `/usr/local/microsoft/powershell` install paths are all absent). The PowerShell edits are localized deletions of whole function definitions, a variable-assignment block, and two single statements, but the parse gate is genuinely unverified and should be confirmed on a host with `pwsh`.
- Post-deletion re-grep: `deprecation_notice`, `Show-DeprecationNotice`, `VenvPython`, `VenvDir`, and `$line = "  "` all have zero occurrences; all KEEP-list symbols are still present at their expected sites.

Co-authored-by: omnigent <noreply@omnigent.ai>

This pull request and its description were written by Isaac.