### PR TITLE
fix(install): suggest a valid claude plugin scope when plugin verification fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1907,9 +1907,14 @@ verify_claude_plugin() {
     [ -z "$found" ] && found=$(claude plugin list 2>/dev/null | grep -F "$id" || true) || true
 
     if [ -z "$found" ]; then
+        # The `claude` CLI only accepts user|project|local scopes — not the installer's
+        # own "global". Translate the same way remove_claude_plugin() does so the
+        # command we hand the user actually runs: global → user, project → project.
+        local claude_scope
+        [ "$SCOPE" = "project" ] && claude_scope="project" || claude_scope="user"
         die_plugin_setup \
             "installing the Claude plugin (${id})" \
-            "claude plugin install ${id} --scope ${SCOPE}" \
+            "claude plugin install ${id} --scope ${claude_scope}" \
             "databricks aitools reported success but the plugin is not registered — run that command yourself and confirm it succeeds (it needs a working 'claude' CLI)."
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1907,9 +1907,7 @@ verify_claude_plugin() {
     [ -z "$found" ] && found=$(claude plugin list 2>/dev/null | grep -F "$id" || true) || true
 
     if [ -z "$found" ]; then
-        # The `claude` CLI only accepts user|project|local scopes — not the installer's
-        # own "global". Translate the same way remove_claude_plugin() does so the
-        # command we hand the user actually runs: global → user, project → project.
+        # The `claude` CLI only accepts user|project|local scopes
         local claude_scope
         [ "$SCOPE" = "project" ] && claude_scope="project" || claude_scope="user"
         die_plugin_setup \


### PR DESCRIPTION
## What

When `verify_claude_plugin()` can't find the `databricks@claude-plugins-official` plugin after `databricks aitools install`, it aborts and prints a copy-paste command for the user to run manually. That command interpolated the installer's own `$SCOPE` value:

```
claude plugin install databricks@claude-plugins-official --scope global
```

But the `claude` CLI only accepts `user`, `project`, or `local` as scopes — `global` is invalid, so the suggested command fails for anyone who did a global install.

## Fix

Translate the installer's scope to a valid `claude` scope before building the message, matching what `remove_claude_plugin()` already does elsewhere in this script:

- `global` → `user`
- `project` → `project`

## Notes

- This only changes the **guidance text** printed on the failure path. The actual `claude plugin install --scope global` invocation that some users hit is emitted internally by `databricks aitools install --scope global` (a separate binary), so that passthrough would need a fix in the Databricks CLI itself — out of scope for this repo.
- `bash -n install.sh` passes.

This pull request and its description were written by Isaac but it was lovingly and carefully reviewed by me (because it's a 4 line change)