### PR TITLE
fix: remove unnecessary whitespace from script headers

### DIFF
--- a/databricks-mcp-server/mcp_install.ps1
+++ b/databricks-mcp-server/mcp_install.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Databricks MCP Server - Client Registration Installer (Windows)
 #
 # Builds the MCP server runtime (by delegating to setup.ps1) and registers the

--- a/databricks-mcp-server/setup.ps1
+++ b/databricks-mcp-server/setup.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Setup script for databricks-mcp-server (Windows).
 #
 # Creates the Python virtual environment and installs the MCP server (plus its

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Databricks AI Dev Kit - Unified Installer (Windows)
 #
 # Installs Databricks skills and configuration for Claude Code, Cursor, OpenAI Codex, GitHub Copilot, Gemini CLI, Antigravity, Windsurf, OpenCode, and Kiro.


### PR DESCRIPTION
I added three bytes: EF BB BF — the UTF-8 byte order mark — at the very start of the files. Those three bytes are a marker, not content. They tell Windows PowerShell 5.1 "this file is UTF-8," which stops it from falling back to Windows-1252 and mangling every multi-byte character in the script.

 #598 try to install mcp server using powershell

